### PR TITLE
Changed return value for ArmOptimizations run_on_function

### DIFF
--- a/modules/arm_plugin/src/transformations/arm_optimizations.cpp
+++ b/modules/arm_plugin/src/transformations/arm_optimizations.cpp
@@ -133,5 +133,5 @@ bool ArmPlugin::pass::ArmOptimizations::run_on_function(std::shared_ptr<ngraph::
     manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::f16, ngraph::element::f32);
 #endif
     manager.run_passes(f);
-    return true;
+    return false;
 }


### PR DESCRIPTION
Pass manager inside the `run_on_function` already changed the ngraph function and we don't have to return `true`