### PR TITLE
More precise arch for apple m1

### DIFF
--- a/modules/arm_plugin/cmake/features.cmake
+++ b/modules/arm_plugin/cmake/features.cmake
@@ -12,7 +12,7 @@ if(ARM)
 elseif(AARCH64)
     if(APPLE)
         # Apple M1 is assumed
-        set(ARM_COMPUTE_TARGET_ARCH_DEFAULT arm64-v8.2-a)
+        set(ARM_COMPUTE_TARGET_ARCH_DEFAULT armv8.6-a)
     else()
         set(ARM_COMPUTE_TARGET_ARCH_DEFAULT arm64-v8a)
     endif()

--- a/modules/arm_plugin/src/arm_converter/arm_converter_activation.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter_activation.cpp
@@ -129,7 +129,7 @@ template<> Converter::Conversion::Ptr Converter::Convert(const opset::HardSigmoi
             auto beta  = beta_node->cast_vector<float>()[0];
             return make(ngraph::runtime::reference::hard_sigmoid<float>, alpha, beta);
         }
-        default: THROW_IE_EXCEPTION << "Unsupported Type: " << node.get_input_element_type(0); return {};
+        default: IE_THROW() << "Unsupported Type: " << node.get_input_element_type(0); return {};
     }
 }
 

--- a/modules/arm_plugin/src/arm_converter/arm_converter_cumsum.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter_cumsum.cpp
@@ -58,7 +58,7 @@ template<> Converter::Conversion::Ptr Converter::Convert(const opset::CumSum& no
                 case ngraph::element::Type_t::i16 : return make(ngraph::runtime::reference::cumsum<ngraph::float16, std::int16_t>);
                 case ngraph::element::Type_t::u16 : return make(ngraph::runtime::reference::cumsum<ngraph::float16, std::uint16_t>);
                 case ngraph::element::Type_t::i32 : return make(ngraph::runtime::reference::cumsum<ngraph::float16, int32_t>);
-                default: THROW_IE_EXCEPTION << "Unsupported Type: " << node.get_input_element_type(1); return {};
+                default: IE_THROW() << "Unsupported Type: " << node.get_input_element_type(1); return {};
             }
         case ngraph::element::Type_t::f32 :
             switch (node.get_input_element_type(1)) {

--- a/modules/arm_plugin/src/arm_converter/arm_converter_detection_output.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter_detection_output.cpp
@@ -18,7 +18,7 @@ void detection_output(const T* _location,
                       const ngraph::Shape& locShape,
                       const ngraph::Shape& priorsShape,
                       const ngraph::Shape& outShape) {
-    THROW_IE_EXCEPTION << "Not implemented";
+    IE_THROW(NotImplemented) << "Not implemented";
 }
 
 template<> void detection_output<ngraph::float16>(const ngraph::float16* _location,

--- a/modules/arm_plugin/thirdparty/CMakeLists.txt
+++ b/modules/arm_plugin/thirdparty/CMakeLists.txt
@@ -63,6 +63,7 @@ else()
         embed_kernels=0
         examples=0
         internal_only=0
+        data_layout_support=nchw
         build_dir=${CMAKE_CURRENT_BINARY_DIR}
         arch=${ARM_COMPUTE_TARGET_ARCH}
         -j8


### PR DESCRIPTION
- More precise arch for apple m1
- Fixed deprecation warnings
- Disabled NHWC kernels which are not used by ARM plugin