### PR TITLE
add default 0 value for batch_dims in v1::Gather reference

### DIFF
--- a/modules/arm_plugin/src/arm_converter/arm_converter_gather.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter_gather.cpp
@@ -17,7 +17,8 @@ template <> Converter::Conversion::Ptr Converter::Convert(const ngraph::op::v1::
                                     node.get_input_shape(0),
                                     node.get_input_shape(1),
                                     node.get_output_shape(0),
-                                    static_cast<size_t>(node.get_axis()));
+                                    static_cast<size_t>(node.get_axis()),
+                                    0);
     };
 
     return CallSwitch(

--- a/modules/arm_plugin/src/arm_converter/arm_converter_gather.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter_gather.cpp
@@ -18,7 +18,7 @@ template <> Converter::Conversion::Ptr Converter::Convert(const ngraph::op::v1::
                                     node.get_input_shape(1),
                                     node.get_output_shape(0),
                                     static_cast<size_t>(node.get_axis()),
-                                    0);
+                                    static_cast<size_t>(0));
     };
 
     return CallSwitch(

--- a/modules/arm_plugin/src/arm_converter/arm_converter_gather.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter_gather.cpp
@@ -17,8 +17,8 @@ template <> Converter::Conversion::Ptr Converter::Convert(const ngraph::op::v1::
                                     node.get_input_shape(0),
                                     node.get_input_shape(1),
                                     node.get_output_shape(0),
-                                    static_cast<int64_t>(node.get_axis()),
-                                    static_cast<int64_t>(0));
+                                    static_cast<size_t>(node.get_axis()),
+                                    static_cast<size_t>(0));
     };
 
     return CallSwitch(

--- a/modules/arm_plugin/src/arm_converter/arm_converter_gather.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter_gather.cpp
@@ -17,8 +17,8 @@ template <> Converter::Conversion::Ptr Converter::Convert(const ngraph::op::v1::
                                     node.get_input_shape(0),
                                     node.get_input_shape(1),
                                     node.get_output_shape(0),
-                                    static_cast<size_t>(node.get_axis()),
-                                    static_cast<size_t>(0));
+                                    static_cast<int64_t>(node.get_axis()),
+                                    static_cast<int64_t>(0));
     };
 
     return CallSwitch(


### PR DESCRIPTION
Changed reference implementation for evaluate: introduced optional argument `batch_dims` for `v7::Gather` (in https://github.com/openvinotoolkit/openvino/pull/5088).  But for `v1::Gather` `batch_dims` is always 0.