### PR TITLE
Fixed deprecation warnings

### DIFF
--- a/modules/arm_plugin/src/arm_converter/arm_converter_nms.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter_nms.cpp
@@ -159,7 +159,7 @@ template<> Converter::Conversion::Ptr Converter::Convert(const opset::NonMaxSupp
                                     node.get_output_partial_shape(0).get_max_shape(),
                                     node.get_sort_result_descending(),
                                     node.output(0).get_element_type(),
-                                    hosts,
+                                    HostTensors{hosts, &node},
                                     selected_scores_type,
                                     node.get_box_encoding());
     };


### PR DESCRIPTION
NMS conversion do not use deprecated `ngraph::Tensor::get_name`