### PR TITLE
Skip Broadcast_748166 test

### DIFF
--- a/modules/arm_plugin/tests/functional/conformance/skip_configs/skip_config_arm.lst
+++ b/modules/arm_plugin/tests/functional/conformance/skip_configs/skip_config_arm.lst
@@ -8,3 +8,5 @@
 .*MaxPool_334685.*
 .*VariadicSplit_629649.*
 .*VariadicSplit_642662.*
+# Skip the test below because it takes ~5 hrs. to pass it
+.*Broadcast_748166.*


### PR DESCRIPTION
The test Broadcast_748166 is going to be temporarily skipped until the team is found the cause of its 5 hrs execution time.