### PR TITLE
Skip conformance tests

### DIFF
--- a/modules/arm_plugin/tests/functional/conformance/skip_configs/skip_config_arm.lst
+++ b/modules/arm_plugin/tests/functional/conformance/skip_configs/skip_config_arm.lst
@@ -8,5 +8,7 @@
 .*MaxPool_334685.*
 .*VariadicSplit_629649.*
 .*VariadicSplit_642662.*
-# Skip the test below because it takes ~5 hrs. to pass it
+# Skip the tests below because it takes too long to complete them
 .*Broadcast_748166.*
+.*Convolution_80631.*
+.*ConvolutionBackpropData_1046455.*


### PR DESCRIPTION
Disable 2 more tests which take ~ 3 hrs to execute.