### PR TITLE
Enabled quantized MobileNetV2

### DIFF
--- a/modules/arm_plugin/src/arm_converter/arm_converter_convert.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter_convert.cpp
@@ -115,6 +115,8 @@ template <> Converter::Conversion::Ptr Converter::Convert(const opset::Convert& 
             }
         case ngraph::element::Type_t::f32 :
             switch (dst) {
+                case ngraph::element::Type_t::i8 :
+                    return make(ngraph::runtime::reference::convert<float, std::int8_t>);
                 case ngraph::element::Type_t::u8 :
                     return make(ngraph::runtime::reference::convert<float, std::uint8_t>);
                 case ngraph::element::Type_t::i16 :

--- a/modules/arm_plugin/src/opset/quantize.cpp
+++ b/modules/arm_plugin/src/opset/quantize.cpp
@@ -11,48 +11,30 @@ using namespace ngraph;
 
 NGRAPH_RTTI_DEFINITION(opset::ArmQuantize, "ArmQuantize", 0);
 
-opset::ArmQuantize::ArmQuantize(const ngraph::Output<ngraph::Node>& data,
-                                const ngraph::Output<ngraph::Node>& input_low,
-                                const ngraph::Output<ngraph::Node>& input_high,
-                                const ngraph::Output<ngraph::Node>& output_low,
-                                const ngraph::Output<ngraph::Node>& output_high,
-                                std::size_t levels,
-                                const ngraph::op::AutoBroadcastSpec& auto_broadcast) :
-    FakeQuantize{data, input_low, input_high, output_low, output_high, levels, auto_broadcast} {}
+opset::ArmQuantize::ArmQuantize(const ngraph::Output<ngraph::Node>& data) : Op{{data}} {}
 
 opset::ArmQuantize::~ArmQuantize() {}
 
 std::shared_ptr<Node> opset::ArmQuantize::clone_with_new_inputs(const OutputVector& new_args) const {
     check_new_args_count(this, new_args);
-    return std::make_shared<ArmQuantize>(new_args.at(0), // X
-                                         new_args.at(1), // input_low
-                                         new_args.at(2), // input_high
-                                         new_args.at(3), // output_low
-                                         new_args.at(4), // output_high
-                                         get_levels(),
-                                         get_auto_broadcast());
+    return std::make_shared<ArmQuantize>(new_args.at(0));
+}
+
+void opset::ArmQuantize::validate_and_infer_types() {
+    set_output_type(0, get_input_element_type(0), get_input_partial_shape(0));
 }
 
 NGRAPH_RTTI_DEFINITION(opset::ArmDequantize, "ArmDequantize", 0);
 
-opset::ArmDequantize::ArmDequantize(const ngraph::Output<ngraph::Node>& data,
-                                    const ngraph::Output<ngraph::Node>& input_low,
-                                    const ngraph::Output<ngraph::Node>& input_high,
-                                    const ngraph::Output<ngraph::Node>& output_low,
-                                    const ngraph::Output<ngraph::Node>& output_high,
-                                    std::size_t levels,
-                                    const ngraph::op::AutoBroadcastSpec& auto_broadcast) :
-    FakeQuantize{data, input_low, input_high, output_low, output_high, levels, auto_broadcast} {}
+opset::ArmDequantize::ArmDequantize(const ngraph::Output<ngraph::Node>& data) : Op{{data}} {}
 
 opset::ArmDequantize::~ArmDequantize() {}
 
 std::shared_ptr<Node> opset::ArmDequantize::clone_with_new_inputs(const OutputVector& new_args) const {
     check_new_args_count(this, new_args);
-    return std::make_shared<ArmDequantize>(new_args.at(0), // X
-                                           new_args.at(1), // input_low
-                                           new_args.at(2), // input_high
-                                           new_args.at(3), // output_low
-                                           new_args.at(4), // output_high
-                                           get_levels(),
-                                           get_auto_broadcast());
+    return std::make_shared<ArmDequantize>(new_args.at(0));
+}
+
+void opset::ArmDequantize::validate_and_infer_types() {
+    set_output_type(0, get_input_element_type(0), get_input_partial_shape(0));
 }

--- a/modules/arm_plugin/src/opset/quantize.hpp
+++ b/modules/arm_plugin/src/opset/quantize.hpp
@@ -12,30 +12,20 @@
 namespace ArmPlugin {
 namespace opset {
 
-struct ArmQuantize : public FakeQuantize {
+struct ArmQuantize : public ngraph::op::Op {
     NGRAPH_RTTI_DECLARATION;
-    ArmQuantize(const ngraph::Output<ngraph::Node>& data,
-                const ngraph::Output<ngraph::Node>& input_low,
-                const ngraph::Output<ngraph::Node>& input_high,
-                const ngraph::Output<ngraph::Node>& output_low,
-                const ngraph::Output<ngraph::Node>& output_high,
-                std::size_t levels,
-                const ngraph::op::AutoBroadcastSpec& auto_broadcast = {ngraph::op::AutoBroadcastType::NUMPY});
+    ArmQuantize(const ngraph::Output<ngraph::Node>& data);
     ~ArmQuantize() override;
     std::shared_ptr<ngraph::Node> clone_with_new_inputs(const ngraph::OutputVector& new_args) const override;
+    void validate_and_infer_types() override;
 };
 
-struct ArmDequantize : public FakeQuantize {
+struct ArmDequantize : public ngraph::op::Op {
     NGRAPH_RTTI_DECLARATION;
-    ArmDequantize(const ngraph::Output<ngraph::Node>& data,
-                  const ngraph::Output<ngraph::Node>& input_low,
-                  const ngraph::Output<ngraph::Node>& input_high,
-                  const ngraph::Output<ngraph::Node>& output_low,
-                  const ngraph::Output<ngraph::Node>& output_high,
-                  std::size_t levels,
-                  const ngraph::op::AutoBroadcastSpec& auto_broadcast = {ngraph::op::AutoBroadcastType::NUMPY});
+    ArmDequantize(const ngraph::Output<ngraph::Node>& data);
     ~ArmDequantize() override;
     std::shared_ptr<ngraph::Node> clone_with_new_inputs(const ngraph::OutputVector& new_args) const override;
+    void validate_and_infer_types() override;
 };
 
 }  // namespace opset

--- a/modules/arm_plugin/src/opset/util.cpp
+++ b/modules/arm_plugin/src/opset/util.cpp
@@ -3,9 +3,18 @@
 //
 
 #include "transpose_arm.hpp"
+#include "arm_compute/core/Rounding.h"
 
 namespace ArmPlugin {
 namespace opset {
+
+float round(const float v) {
+#ifdef __aarch64__
+            return arm_compute::round(v, arm_compute::RoundingPolicy::TO_NEAREST_EVEN);
+#else  // __aarch64__
+            return arm_compute::round(v, arm_compute::RoundingPolicy::TO_ZERO);
+#endif // __aarch64__z
+}
 
 arm_compute::QuantizationInfo makeQuantizationInfo(
                 const ngraph::Output<ngraph::Node>& input_low_output,

--- a/modules/arm_plugin/src/opset/utils.hpp
+++ b/modules/arm_plugin/src/opset/utils.hpp
@@ -12,6 +12,8 @@
 
 namespace ArmPlugin {
 namespace opset {
+float round(const float v);
+
 arm_compute::QuantizationInfo makeQuantizationInfo(
                 const ngraph::Output<ngraph::Node>& input_low,
                 const ngraph::Output<ngraph::Node>& input_high,
@@ -19,6 +21,7 @@ arm_compute::QuantizationInfo makeQuantizationInfo(
                 const ngraph::Output<ngraph::Node>& output_high);
 
 arm_compute::ActivationLayerInfo makeActivationLayerInfo(ngraph::Node* node);
+
 
 }  // namespace opset
 }  // namespace ArmPlugin

--- a/modules/arm_plugin/src/transformations/quantize_fusion.hpp
+++ b/modules/arm_plugin/src/transformations/quantize_fusion.hpp
@@ -22,6 +22,10 @@ struct DequantizeNodeFusion : public ngraph::pass::FunctionPass{
     bool run_on_function(std::shared_ptr<ngraph::Function> f) override;
 };
 
+struct MovePerChenelQuantizationInfoToWeights : public ngraph::pass::MatcherPass {
+    MovePerChenelQuantizationInfoToWeights();
+};
+
 struct PropogateQuantizationInfo: public ngraph::pass::FunctionPass {
     bool run_on_function(std::shared_ptr<ngraph::Function> f) override;
 };

--- a/modules/arm_plugin/tests/functional/shared_tests_instances/low_precision_transformations/arm_convolution.cpp
+++ b/modules/arm_plugin/tests/functional/shared_tests_instances/low_precision_transformations/arm_convolution.cpp
@@ -173,6 +173,29 @@ const std::vector<LayerTestsDefinitions::ArmConvolutionTransformationParam> para
         "ArmConvolution",
         "I8"
     },
+    {
+        { 256ul, ngraph::Shape { 1, 3, 1, 1 }, { 0.f, 0.f, 0.f }, { 255.f, 255.f, 255.f }, { 0.f, 0.f, 0.f }, { 25.5f, 25.5f, 25.5f } },
+        true,
+        { 255ul, ngraph::Shape { 6, 1, 1, 1 }, { 0.f, 0.f, 0.f, 0.f, 0.f, 0.f }, { 254.f, 254.f, 254.f, 254.f, 254.f, 254.f },
+                                               { -12.7f, -12.7f*2, -12.7f*4, -12.7f, -12.7f/2, -12.7f/4 },
+                                               { 12.7f, 12.7f*2, 12.7f*4, 12.7f, 12.7f/2, 12.7f/4 } },
+        true,
+        { 256ul, ngraph::Shape { 1 }, { -128.f }, { 127.f }, { -12.8f }, { 12.7f }},
+        "ArmConvolution",
+        "I8"
+    },
+    {
+        { 256ul, ngraph::Shape { 1, 3, 1, 1 }, { 0.f, 0.f, 0.f }, { 255.f, 255.f/2, 255.f/4 }, { -1.27f }, { 1.28 } },
+        true,
+        { 255ul, ngraph::Shape { 6, 1, 1, 1 }, { 0.f, 0.f, 0.f, 0.f, 0.f, 0.f },
+                                               { 254.f, 254.f, 254.f, 254.f, 254.f, 254.f },
+                                               { -12.7f, -12.7f*2, -12.7f*4, -12.7f, -12.7f/2, -12.7f/4 },
+                                               { 12.7f, 12.7f*2, 12.7f*4, 12.7f, 12.7f/2, 12.7f/4 } },
+        true,
+        { 256ul, ngraph::Shape { 1 }, { -128.f }, { 127.f }, { -12.8f }, { 12.7f }},
+        "ArmConvolution",
+        "I8"
+    },
 };
 
 const std::vector<ngraph::Shape> shapes = {

--- a/modules/arm_plugin/tests/functional/shared_tests_instances/low_precision_transformations/arm_group_convolution.cpp
+++ b/modules/arm_plugin/tests/functional/shared_tests_instances/low_precision_transformations/arm_group_convolution.cpp
@@ -176,6 +176,29 @@ const std::vector<LayerTestsDefinitions::ArmGroupConvolutionTransformationParam>
         "ArmGroupConvolution",
         "I8"
     },
+    {
+        { 256ul, ngraph::Shape { 1, 3, 1, 1 }, { 0.f, 0.f, 0.f }, { 255.f, 255.f, 255.f }, { 0.f, 0.f, 0.f }, { 25.5f, 25.5f, 25.5f } },
+        true,
+        { 255ul, ngraph::Shape { 3, 1, 1, 1 }, { 0.f, 0.f, 0.f}, { 254.f, 254.f, 254.f },
+                                               { -12.7f, -12.7f*2, -12.7f*4 },
+                                               { 12.7f, 12.7f*2, 12.7f*4 } },
+        true,
+        { 256ul, ngraph::Shape { 1 }, { -128.f }, { 127.f }, { -12.8f }, { 12.7f }},
+        "ArmGroupConvolution",
+        "I8"
+    },
+    {
+        { 256ul, ngraph::Shape { 1, 3, 1, 1 }, { 0.f, 0.f, 0.f }, { 255.f, 255.f/2, 255.f/4 }, { -1.27f }, { 1.28 } },
+        true,
+        { 255ul, ngraph::Shape { 3, 1, 1, 1 }, { 0.f, 0.f, 0.f },
+                                               { 254.f, 254.f, 254.f },
+                                               { -12.7f, -12.7f*2, -12.7f*4 },
+                                               { 12.7f, 12.7f*2, 12.7f*4 } },
+        true,
+        { 256ul, ngraph::Shape { 1 }, { -128.f }, { 127.f }, { -12.8f }, { 12.7f }},
+        "ArmGroupConvolution",
+        "I8"
+    },
 };
 
 const std::vector<ngraph::Shape> shapes = {


### PR DESCRIPTION
* Arm Compute does not support per channel quantization on output tensors of convolution. So we have to move scales to weights quantization info and offset to biases.
* ArmQuantize is applied to separate channels in case of per-channel quantization
* Dequantiztion operations are not converted into ArmDequanitze in case of per-channel dequantization