### PR TITLE
get back with fake_quantize original call after cleanup in OV

### DIFF
--- a/modules/arm_plugin/src/arm_converter/arm_converter_fake_quantize.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter_fake_quantize.cpp
@@ -20,8 +20,8 @@ template<> Converter::Conversion::Ptr Converter::Convert(const opset::FakeQuanti
                                     node.get_auto_broadcast());
     };
     switch (node.input(0).get_element_type()) {
-        case ngraph::element::Type_t::f16 : return make(ngraph::runtime::reference::v0::fake_quantize<ngraph::float16>);
-        case ngraph::element::Type_t::f32 : return make(ngraph::runtime::reference::v0::fake_quantize<float>);
+        case ngraph::element::Type_t::f16 : return make(ngraph::runtime::reference::fake_quantize<ngraph::float16>);
+        case ngraph::element::Type_t::f32 : return make(ngraph::runtime::reference::fake_quantize<float>);
         default: IE_THROW() << "Arm Plugin: Unsupported Type: " << node.get_element_type();
     }
 }


### PR DESCRIPTION
### Description
- drop `v0` namespace after OV cleanup

### Ticket
 - *60603*

### Related
 - https://github.com/openvinotoolkit/openvino/pull/6810
 - https://github.com/openvinotoolkit/openvino_contrib/pull/178
