### PR TITLE
[PyTorch] Ignore global sys.argv when convert a model

### DIFF
--- a/modules/mo_pytorch/mo_pytorch.py
+++ b/modules/mo_pytorch/mo_pytorch.py
@@ -119,6 +119,10 @@ def convert(model, **args):
     for arg, value in args.items():
         parser.set_defaults(**{arg: str(value)})
 
+    # Replace original parser to ignore global sys.argv
+    origin_parse = parser.parse_args
+    parser.parse_args = lambda: origin_parse([])
+
     err = None
     try:
         err = main(parser, None, 'pytorch')


### PR DESCRIPTION
Ignore mo_pytorch user code command line arguments