### PR TITLE
[LPT] ARM convolution tests change

### DIFF
--- a/modules/arm_plugin/tests/functional/shared_tests_instances/low_precision_transformations/convolution_transformation.cpp
+++ b/modules/arm_plugin/tests/functional/shared_tests_instances/low_precision_transformations/convolution_transformation.cpp
@@ -50,13 +50,13 @@ const std::vector<LayerTestsDefinitions::ConvolutionTransformationParam> params 
     //     false,
     // },
     {
-        { 16ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
+        { 14ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 255.f }, { 0.f }, { 25.5f } },
         false,
-        { 16ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
+        { 14ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 254.f }, { -12.7f }, { 12.7f } },
         false,
     },
     {
-        { 16ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 25.5f }, { 0.f }, { 25.5f } },
+        { 14ul, ngraph::Shape { 1, 1, 1, 1 }, { 0.f }, { 25.5f }, { 0.f }, { 25.5f } },
         false,
         { 255ul, ngraph::Shape { 1, 1, 1, 1 }, { -12.7f }, { 12.7f }, { -12.7f }, { 12.7f } },
         false,


### PR DESCRIPTION
Change 16 levels to 14 levels in tests on incorrectness due to 16 levels support in LPT.