### PR TITLE
Fix model-optimizer path in mo_pytorch setup.py

### DIFF
--- a/modules/mo_pytorch/setup.py
+++ b/modules/mo_pytorch/setup.py
@@ -42,6 +42,6 @@ setup(name='openvino-mo-pytorch',
         "Operating System :: OS Independent",
       ],
       install_requires=[
-        'openvino-mo @ git+https://github.com/openvinotoolkit/openvino.git#subdirectory=model-optimizer'
+        'openvino-mo @ git+https://github.com/openvinotoolkit/openvino.git#subdirectory=tools/mo'
       ],
 )


### PR DESCRIPTION
Recently model-optimizer in OpenVINO repohas been moved to another directory, see: https://github.com/openvinotoolkit/openvino/pull/7708