### PR TITLE
Fix the skip pattern for hanging ARM test

### DIFF
--- a/modules/arm_plugin/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/modules/arm_plugin/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -45,7 +45,7 @@ std::vector<std::string> disabledTestPatterns() {
         ".*ReturnResultNotReadyFromWaitInAsyncModeForTooSmallTimeout.*", // Unsupported topology
 #ifdef __arm__
         // Sporadic hanges on linux-debian_9_arm runner (armv7l) 72140
-        ".*canStartSeveralAsyncInsideCompletionCallbackWithSafeDtor.*CPU_THROUGHPUT_STREAMS_CPU_THROUGHPUT_AUTO_",
+        ".*canStartSeveralAsyncInsideCompletionCallbackWithSafeDtor.*CPU_THROUGHPUT_STREAMS_CPU_THROUGHPUT_AUTO.*",
 #endif
     };
 }


### PR DESCRIPTION
Looks like the issue described in 72140 still reproduces on the same test case, but without '_' postfix