### PR TITLE
[Java] libov_runtime.dylib renamed to libopenvino.dylib on Mac

### DIFF
--- a/modules/java_api/org/intel/openvino/IECore.java
+++ b/modules/java_api/org/intel/openvino/IECore.java
@@ -41,7 +41,7 @@ public class IECore extends IEWrapper {
     // plugins.xml and *.mvcmd in case of the JAR package os OpenVINO.
     public static void loadNativeLibs() {
         // A set of required libraries which are listed in dependency order.
-        final String[] nativeLibs = {"tbb", "tbbmalloc", "ov_runtime", "inference_engine_java_api"};
+        final String[] nativeLibs = {"tbb", "tbbmalloc", "openvino", "inference_engine_java_api"};
 
         InputStream resources_list = null;
         try {


### PR DESCRIPTION
https://dev.azure.com/openvinoci/dldt/_build/results?buildId=284701&view=logs&j=a82d9e72-1de4-5bd6-c188-90296135479e&t=79340282-cc49-53b9-a234-48d22cf6b121:

```
/Users/runner/work/1/_w/install_pkg/runtime/lib/intel64:
total 208936
drwxr-xr-x  18 runner  staff       576 Feb 18 13:07 .
drwxr-xr-x   3 runner  staff        96 Feb 18 13:07 ..
-rwxr-xr-x   1 runner  staff    231312 Feb 18 13:07 libinference_engine_java_api.dylib
-rwxr-xr-x   1 runner  staff  20606672 Feb 18 13:07 libopenvino.dylib
-rwxr-xr-x   1 runner  staff    466976 Feb 18 13:07 libopenvino_auto_batch_plugin.so
-rwxr-xr-x   1 runner  staff    609136 Feb 18 13:07 libopenvino_auto_plugin.so
-rwxr-xr-x   1 runner  staff    272000 Feb 18 13:07 libopenvino_c.dylib
-rwxr-xr-x   1 runner  staff   2153496 Feb 18 13:07 libopenvino_gapi_preproc.so
-rwxr-xr-x   1 runner  staff    574264 Feb 18 13:07 libopenvino_hetero_plugin.so
-rwxr-xr-x   1 runner  staff  55451992 Feb 18 13:07 libopenvino_intel_cpu_plugin.so
-rwxr-xr-x   1 runner  staff  10413344 Feb 18 13:07 libopenvino_intel_myriad_plugin.so
-rwxr-xr-x   1 runner  staff    507600 Feb 18 13:07 libopenvino_ir_frontend.dylib
-rwxr-xr-x   1 runner  staff   5462216 Feb 18 13:07 libopenvino_onnx_frontend.dylib
-rwxr-xr-x   1 runner  staff   1378256 Feb 18 13:07 libopenvino_paddle_frontend.dylib
-rw-r--r--   1 runner  staff   4415336 Feb 18 12:51 libopenvino_tensorflow_fe.dylib
-rw-r--r--   1 runner  staff   2099248 Nov  1 20:37 pcie-ma2x8x.mvcmd
-rw-r--r--   1 runner  staff       696 Feb 18 12:46 plugins.xml
-rw-r--r--   1 runner  staff   2298632 Nov  1 20:34 usb-ma2x8x.mvcmd
```