### PR TITLE
Skip more canStartSeveralAsyncInsideCompletionCallbackWithSafeDtor cases

### DIFF
--- a/modules/arm_plugin/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/modules/arm_plugin/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -45,7 +45,7 @@ std::vector<std::string> disabledTestPatterns() {
         ".*ReturnResultNotReadyFromWaitInAsyncModeForTooSmallTimeout.*", // Unsupported topology
 #ifdef __arm__
         // Sporadic hanges on linux-debian_9_arm runner (armv7l) 72140
-        ".*canStartSeveralAsyncInsideCompletionCallbackWithSafeDtor.*CPU_THROUGHPUT_STREAMS_CPU_THROUGHPUT_AUTO.*",
+        ".*canStartSeveralAsyncInsideCompletionCallbackWithSafeDtor.*AUTO.*",
 #endif
     };
 }


### PR DESCRIPTION
The hang described in reproduces in issue 72140 also reproduces on smoke_BehaviorTests/OVInferRequestCallbackTests.canStartSeveralAsyncInsideCompletionCallbackWithSafeDtor/targetDevice=CPU_configItem=NUM_STREAMS_AUTO test case as well