### PR TITLE
Java Gradle update

### DIFF
--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -31,7 +31,7 @@ jobs:
     BIN_DIR: $(OPENVINO_REPO_DIR)/bin/intel64/$(BUILD_TYPE)
     INSTALL_DIR: $(WORK_DIR)/install_pkg
     SETUPVARS: $(INSTALL_DIR)/setupvars.sh
-    GRADLE_VER: 6.5.1
+    GRADLE_VER: 7.1.1
 
   steps:
   - script: |
@@ -76,7 +76,6 @@ jobs:
       $(OPENVINO_REPO_DIR)/install_build_dependencies.sh
       # Move jdk into contrib install_build_dependencies.sh
       sudo apt --assume-yes install default-jdk
-      # Fix tests for running with gradle 7.1.1
       wget https://services.gradle.org/distributions/gradle-$(GRADLE_VER)-bin.zip
       unzip gradle-$(GRADLE_VER)-bin.zip
       # For opencv-python: python3-setuptools and pip upgrade

--- a/.ci/azure/windows.yml
+++ b/.ci/azure/windows.yml
@@ -107,7 +107,7 @@ jobs:
 
   - script: |
       call $(SETUPVARS)
-      set PATH=$(WORK_DIR)\gradle-$(GRADLE_VER)\bin;%PATH%
+      set PATH=$(WORK_DIR)\gradle-$(GRADLE_VER)-bin\gradle-$(GRADLE_VER)\bin;%PATH%
       gradle clean build --info
       gradle test -Prun_tests -DMODELS_PATH=$(MODELS_PATH) -Ddevice=CPU --info
     workingDirectory: $(REPO_DIR)\modules\java_api

--- a/.ci/azure/windows.yml
+++ b/.ci/azure/windows.yml
@@ -107,7 +107,8 @@ jobs:
 
   - script: |
       call $(SETUPVARS)
-      $(WORK_DIR)\gradle-$(GRADLE_VER)\bin\gradle clean build --info
-      $(WORK_DIR)\gradle-$(GRADLE_VER)\bin\gradle test -Prun_tests -DMODELS_PATH=$(MODELS_PATH) -Ddevice=CPU --info
+      set PATH=$(WORK_DIR)\gradle-$(GRADLE_VER)\bin;%PATH%
+      gradle clean build --info
+      gradle test -Prun_tests -DMODELS_PATH=$(MODELS_PATH) -Ddevice=CPU --info
     workingDirectory: $(REPO_DIR)\modules\java_api
     displayName: 'Java tests'

--- a/.ci/azure/windows.yml
+++ b/.ci/azure/windows.yml
@@ -107,7 +107,7 @@ jobs:
 
   - script: |
       call $(SETUPVARS)
-      $(WORK_DIR)/gradle-$(GRADLE_VER)/bin/gradle clean build --info
-      $(WORK_DIR)/gradle-$(GRADLE_VER)/bin/gradle test -Prun_tests -DMODELS_PATH=$(MODELS_PATH) -Ddevice=CPU --info
+      $(WORK_DIR)\gradle-$(GRADLE_VER)\bin\gradle clean build --info
+      $(WORK_DIR)\gradle-$(GRADLE_VER)\bin\gradle test -Prun_tests -DMODELS_PATH=$(MODELS_PATH) -Ddevice=CPU --info
     workingDirectory: $(REPO_DIR)\modules\java_api
     displayName: 'Java tests'

--- a/.ci/azure/windows.yml
+++ b/.ci/azure/windows.yml
@@ -33,6 +33,7 @@ jobs:
     MSVC_COMPILER_PATH: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.24.28314\bin\Hostx64\x64\cl.exe
     INSTALL_DIR: $(WORK_DIR)\install_pkg
     SETUPVARS: $(INSTALL_DIR)\setupvars.bat
+    GRADLE_VER: 7.1.1
 
   steps:
   - script: |
@@ -76,6 +77,8 @@ jobs:
       rem Speed up build
       powershell -command "Invoke-WebRequest https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-win.zip -OutFile ninja-win.zip"
       powershell -command "Expand-Archive -Force ninja-win.zip"
+      powershell -command "Invoke-WebRequest https://services.gradle.org/distributions/gradle-$(GRADLE_VER)-bin.zip -OutFile gradle-$(GRADLE_VER)-bin.zip"
+      powershell -command "Expand-Archive -Force gradle-$(GRADLE_VER)-bin.zip"
     workingDirectory: $(WORK_DIR)
     displayName: 'Install dependencies'
 
@@ -104,7 +107,7 @@ jobs:
 
   - script: |
       call $(SETUPVARS)
-      gradle clean build --info
-      gradle test -Prun_tests -DMODELS_PATH=$(MODELS_PATH) -Ddevice=CPU --info
+      $(WORK_DIR)/gradle-$(GRADLE_VER)/bin/gradle clean build --info
+      $(WORK_DIR)/gradle-$(GRADLE_VER)/bin/gradle test -Prun_tests -DMODELS_PATH=$(MODELS_PATH) -Ddevice=CPU --info
     workingDirectory: $(REPO_DIR)\modules\java_api
     displayName: 'Java tests'

--- a/.ci/azure/windows.yml
+++ b/.ci/azure/windows.yml
@@ -12,8 +12,7 @@ resources:
 
 jobs:
 - job: Win
-  # About 150% of total time
-  timeoutInMinutes: 60
+  timeoutInMinutes: 90
 
   pool:
     name: WIN_VMSS_VENV_F8S_WU2


### PR DESCRIPTION
Ticket 61954

https://dev.azure.com/openvinoci/dldt/_build/results?buildId=288052&view=logs&j=c66b862c-dbaa-5827-5973-496890707eb5&t=0f6a71b9-1318-5ab5-30ad-a6e7f3c41df2&l=448
```
Unexpected exception thrown.
org.gradle.internal.remote.internal.MessageIOException: Could not write '/127.0.0.1:51363'.
	at org.gradle.internal.remote.internal.inet.SocketConnection.flush(SocketConnection.java:140)
	at org.gradle.internal.remote.internal.hub.MessageHub$ConnectionDispatch.run(MessageHub.java:331)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
	at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:48)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:56)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.io.IOException: An existing connection was forcibly closed by the remote host
	at sun.nio.ch.SocketDispatcher.write0(Native Method)
	at sun.nio.ch.SocketDispatcher.write(SocketDispatcher.java:51)
	at sun.nio.ch.IOUtil.writeFromNativeBuffer(IOUtil.java:93)
	at sun.nio.ch.IOUtil.write(IOUtil.java:51)
	at sun.nio.ch.SocketChannelImpl.write(SocketChannelImpl.java:471)
	at org.gradle.internal.remote.internal.inet.SocketConnection$SocketOutputStream.writeWithNonBlockingRetry(SocketConnection.java:279)
	at org.gradle.internal.remote.internal.inet.SocketConnection$SocketOutputStream.writeBufferToChannel(SocketConnection.java:267)
	at org.gradle.internal.remote.internal.inet.SocketConnection$SocketOutputStream.flush(SocketConnection.java:261)
	at org.gradle.internal.remote.internal.inet.SocketConnection.flush(SocketConnection.java:138)
	... 7 more

> Task :test FAILED
```