### PR TITLE
Fix Java build on Mac

### DIFF
--- a/modules/java_api/build.gradle
+++ b/modules/java_api/build.gradle
@@ -19,6 +19,7 @@ allprojects {
 
 def native_resources = [
     System.getenv('INTEL_OPENVINO_DIR') + "/runtime/lib/intel64",  // UNIX
+    System.getenv('INTEL_OPENVINO_DIR') + "/runtime/lib/intel64/Release",  // Mac
     System.getenv('INTEL_OPENVINO_DIR') + "/runtime/bin/intel64/Release",  // Windows
     System.getenv('TBB_DIR') + "/../lib/",
 ]


### PR DESCRIPTION
see https://dev.azure.com/openvinoci/dldt/_build/results?buildId=296497&view=logs&j=a82d9e72-1de4-5bd6-c188-90296135479e&t=79340282-cc49-53b9-a234-48d22cf6b121:
```
/Users/runner/work/1/_w/install_pkg/runtime/lib/intel64/Release:
total 206560
drwxr-xr-x  18 runner  staff       576 Mar  9 07:34 .
drwxr-xr-x   3 runner  staff        96 Mar  9 07:34 ..
-rwxr-xr-x   1 runner  staff    295912 Mar  9 07:34 libinference_engine_java_api.dylib
-rwxr-xr-x   1 runner  staff  20648144 Mar  9 07:34 libopenvino.dylib
```

but on Linux:
```
/agent/_work/1/_w/install_pkg/runtime/lib/intel64:
total 118736
drwxr-xr-x 2 AzDevOps AzDevOps     4096 Mar  9 06:21 .
drwxr-xr-x 3 AzDevOps AzDevOps     4096 Mar  9 06:21 ..
-rw-r--r-- 1 AzDevOps AzDevOps  8871798 Mar  9 05:56 cache.json
-rw-r--r-- 1 AzDevOps AzDevOps  3120536 Jan 10 10:38 libgna.so
lrwxrwxrwx 1 AzDevOps AzDevOps        9 Mar  9 06:21 libgna.so.2 -> libgna.so
lrwxrwxrwx 1 AzDevOps AzDevOps       11 Mar  9 06:21 libgna.so.3.0.0.1455 -> libgna.so.2
-rw-r--r-- 1 AzDevOps AzDevOps   301208 Mar  9 06:20 libinference_engine_java_api.so
-rw-r--r-- 1 AzDevOps AzDevOps 17915416 Mar  9 06:15 libopenvino.so
```