### PR TITLE
[Optimum] Fix MO command call

### DIFF
--- a/.github/workflows/test_optimum.yml
+++ b/.github/workflows/test_optimum.yml
@@ -6,8 +6,6 @@ on:
     paths:
       - "modules/optimum/**"
       - ".github/workflows/test_optimum.yml"
-  schedule:
-    - cron: "00 9 * * 6"  # Run every saturday on 9:00 UTC
 
 jobs:
   check_code_style:
@@ -45,8 +43,8 @@ jobs:
           "transformers[torch,tf-cpu] torch==1.9.1",
         ]
         openvino-version: [
-          "openvino-dev~=2021.4.2",
-          "openvino-dev~=2022.1.0.dev",
+          "openvino-dev==2021.4.2",
+          "openvino-dev==2022.1.0",
         ]
     steps:
     - uses: actions/checkout@v2

--- a/modules/optimum/optimum/intel/nncf/patches/trainer_4.11.0.patch
+++ b/modules/optimum/optimum/intel/nncf/patches/trainer_4.11.0.patch
@@ -206,7 +206,7 @@ index 070f200..fe35a08 100644
 +        import subprocess
 +
 +        subprocess.run(
-+            [sys.executable, "-m", "mo", "--input_model", path_to_onnx, "--output_dir", output_dir], check=True
++            ["mo", "--input_model", path_to_onnx, "--output_dir", output_dir], check=True
 +        )
 +
      def store_flos(self):

--- a/modules/optimum/optimum/intel/nncf/patches/trainer_4.9.1.patch
+++ b/modules/optimum/optimum/intel/nncf/patches/trainer_4.9.1.patch
@@ -205,7 +205,7 @@ index d6e0d51..0ede165 100644
 +        import subprocess
 +
 +        subprocess.run(
-+            [sys.executable, "-m", "mo", "--input_model", path_to_onnx, "--output_dir", output_dir], check=True
++            ["mo", "--input_model", path_to_onnx, "--output_dir", output_dir], check=True
 +        )
 +
      def store_flos(self):


### PR DESCRIPTION
failed run: https://github.com/openvinotoolkit/openvino_contrib/runs/5662183846?check_suite_focus=true

```
/opt/hostedtoolcache/Python/3.7.12/x64/bin/python: No module named mo
```

That's strange how it worked before because `python -m mo` has been replaced to just `mo` long time ago.

Also, updated test to stable version and removed a scheduled run.