### PR TITLE
[LPT] Introduce new granularity attribute instead of OperationPerTensorQuantizationRestriction

### DIFF
--- a/modules/arm_plugin/src/transformations/arm_optimizations.cpp
+++ b/modules/arm_plugin/src/transformations/arm_optimizations.cpp
@@ -80,8 +80,8 @@
 #include <ngraph/pass/constant_folding.hpp>
 
 #include <transformations/low_precision/disable_convert_constant_folding_on_const_path.hpp>
-#include <low_precision/common/operation_per_tensor_quantization_restriction.hpp>
-#include <low_precision/common/operation_precision_restriction.hpp>
+#include <low_precision/common/quantization_granularity_restriction.hpp>
+#include <low_precision/common/precisions_restriction.hpp>
 #include <low_precision/convolution.hpp>
 #include <low_precision/fake_quantize.hpp>
 #include <low_precision/fold_convert.hpp>
@@ -211,25 +211,25 @@ bool ArmPlugin::pass::ArmOptimizations::run_on_function(std::shared_ptr<ov::Mode
     using namespace ngraph::pass::low_precision;
     if (quantized) {
         Dump(m, "before_common");
-        auto supportedPrecisions = std::vector<OperationPrecisionRestriction>({
-            OperationPrecisionRestriction::create<ngraph::opset1::Convolution>({
+        auto supportedPrecisions = std::vector<PrecisionsRestriction>({
+            PrecisionsRestriction::create<ngraph::opset1::Convolution>({
                 {0, {ngraph::element::u8, ngraph::element::i8}},
                 {1, {ngraph::element::u8, ngraph::element::i8}},
             }),
-            OperationPrecisionRestriction::create<ngraph::opset1::ConvolutionBackpropData>({
+            PrecisionsRestriction::create<ngraph::opset1::ConvolutionBackpropData>({
                 {0, {ngraph::element::u8, ngraph::element::i8}},
                 {1, {ngraph::element::u8, ngraph::element::i8}}
             }),
-            OperationPrecisionRestriction::create<ngraph::opset1::GroupConvolution>({
+            PrecisionsRestriction::create<ngraph::opset1::GroupConvolution>({
                 {0, {ngraph::element::u8, ngraph::element::i8}},
                 {1, {ngraph::element::u8, ngraph::element::i8}}
             })
         });
 
-        auto perTensorQuantization = std::vector<OperationPerTensorQuantizationRestriction>({
-            OperationPerTensorQuantizationRestriction::create<ngraph::opset1::Convolution>({0}),
-            OperationPerTensorQuantizationRestriction::create<ngraph::opset1::ConvolutionBackpropData>({0}),
-            OperationPerTensorQuantizationRestriction::create<ngraph::opset1::GroupConvolution>({0})
+        auto perTensorQuantization = std::vector<QuantizationGranularityRestriction>({
+            QuantizationGranularityRestriction::create<ngraph::opset1::Convolution>({0}),
+            QuantizationGranularityRestriction::create<ngraph::opset1::ConvolutionBackpropData>({0}),
+            QuantizationGranularityRestriction::create<ngraph::opset1::GroupConvolution>({0})
         });
 
         ov::pass::Manager lptManager;


### PR DESCRIPTION
### Details:
 - *Introduce new granularity attribute instead of OperationPerTensorQuantizationRestriction*

### Tickets:
 - *73725*

OpenVINO PR: https://github.com/openvinotoolkit/openvino/pull/11330
product-config PR: https://github.com/intel-innersource/frameworks.ai.openvino.ci.product-configs/pull/1055