### PR TITLE
[CI] Install setuptools for Python wheel

### DIFF
--- a/.ci/azure/linux.yml
+++ b/.ci/azure/linux.yml
@@ -80,6 +80,7 @@ jobs:
       unzip gradle-$(GRADLE_VER)-bin.zip
       # For opencv-python: python3-setuptools and pip upgrade
       python3 -m pip install --upgrade pip
+      python3 -m pip install -U setuptools
       python3 -m pip install -r $(OPENVINO_REPO_DIR)/src/bindings/python/requirements.txt
       python3 -m pip install -r $(OPENVINO_REPO_DIR)/src/bindings/python/requirements_test.txt
       python3 -m pip install -r $(OPENVINO_REPO_DIR)/src/bindings/python/src/compatibility/openvino/requirements-dev.txt


### PR DESCRIPTION
resolves recent error https://dev.azure.com/openvinoci/dldt/_build/results?buildId=321733&view=logs&j=9df09860-c2bf-529a-b3cd-66c2937309a0&t=a9460859-4d28-593e-b30d-60f45632dad3&l=867 

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'wheel.vendored'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'wheel.vendored'
CMake Error at src/bindings/python/wheel/CMakeLists.txt:38 (string):
  string sub-command STRIP requires two arguments.
```