### PR TITLE
[openvino-optimum] Initialize Trainer.compression_ctrl

### DIFF
--- a/modules/optimum/optimum/intel/nncf/patches/trainer_4.11.0.patch
+++ b/modules/optimum/optimum/intel/nncf/patches/trainer_4.11.0.patch
@@ -33,6 +33,8 @@ index 070f200..fe35a08 100644
              args = TrainingArguments(output_dir=output_dir)
          self.args = args
 +
++        self.compression_ctrl = None
++
 +        if nncf_config is not None:
 +            nncf_config.auto_register_extra_structs(args, train_dataset, data_collator)
 +            # TODO: restore compression state

--- a/modules/optimum/optimum/intel/nncf/patches/trainer_4.9.1.patch
+++ b/modules/optimum/optimum/intel/nncf/patches/trainer_4.9.1.patch
@@ -33,6 +33,8 @@ index d6e0d51..0ede165 100644
              args = TrainingArguments(output_dir=output_dir)
          self.args = args
 +
++        self.compression_ctrl = None
++
 +        if nncf_config is not None:
 +            nncf_config.auto_register_extra_structs(args, train_dataset, data_collator)
 +            # TODO: restore compression state


### PR DESCRIPTION
Fix error that occured when training without nncf_config:
![8011dd2d0497ce16a5dcc8c055f5368e](https://user-images.githubusercontent.com/77325899/166442007-43bdf837-e016-4c2c-af16-602d3efbcf77.png)
