### PR TITLE
[openvino-optimum] Fix BERT accuracy issue and other updates

### DIFF
--- a/.github/workflows/test_optimum.yml
+++ b/.github/workflows/test_optimum.yml
@@ -71,7 +71,7 @@ jobs:
     - name: Test OpenVINO backend
       working-directory: modules/optimum/tests/openvino
       run: |
-        python -m unittest -v
+        python -m unittest discover
 
   test_examples:
     name: "Examples"

--- a/modules/optimum/optimum/intel/nncf/patches/trainer_4.11.0.patch
+++ b/modules/optimum/optimum/intel/nncf/patches/trainer_4.11.0.patch
@@ -207,7 +207,7 @@ index 070f200..fe35a08 100644
 +        input_names = self.tokenizer.model_input_names
 +        if input_names[0] == "input_ids":
 +            input_names = ["input_ids", "attention_mask", "token_type_ids"]
-+        self.compression_ctrl.export_model(path_to_onnx, input_names=input_names)
++        self.compression_ctrl.export_model(path_to_onnx, input_names=input_names, save_format="onnx_12")
 +
 +        import subprocess
 +

--- a/modules/optimum/optimum/intel/nncf/patches/trainer_4.9.1.patch
+++ b/modules/optimum/optimum/intel/nncf/patches/trainer_4.9.1.patch
@@ -206,7 +206,7 @@ index d6e0d51..0ede165 100644
 +        input_names = self.tokenizer.model_input_names
 +        if input_names[0] == "input_ids":
 +            input_names = ["input_ids", "attention_mask", "token_type_ids"]
-+        self.compression_ctrl.export_model(path_to_onnx, input_names=input_names)
++        self.compression_ctrl.export_model(path_to_onnx, input_names=input_names, save_format="onnx_12")
 +
 +        import subprocess
 +

--- a/modules/optimum/setup.py
+++ b/modules/optimum/setup.py
@@ -23,6 +23,7 @@ nncf_deps = [
     "openvino-dev[onnx]",
     "nncf",
     "transformers<4.16.0",
+    "datasets",
 ]
 
 # Add patches as data

--- a/modules/optimum/tests/openvino/test_modeling_ov_auto.py
+++ b/modules/optimum/tests/openvino/test_modeling_ov_auto.py
@@ -3,19 +3,19 @@
 
 import os
 import unittest
-from packaging import version
 
-import numpy as np
-
-import transformers
-from transformers import AutoTokenizer
 import datasets
+import numpy as np
+import transformers
 from datasets import DatasetDict, load_dataset
+from packaging import version
+from transformers import AutoConfig, AutoTokenizer
+
 
 try:
     from transformers.testing_utils import require_tf, require_torch
 except ImportError:
-    from transformers.file_utils import is_torch_available, is_tf_available
+    from transformers.file_utils import is_tf_available, is_torch_available
 
     def require_torch(test_case):
         if not is_torch_available():
@@ -40,16 +40,16 @@ except ImportError:
 
 from optimum.intel.openvino import (
     OVAutoModel,
+    OVAutoModelForAudioClassification,
     OVAutoModelForMaskedLM,
     OVAutoModelForQuestionAnswering,
     OVAutoModelWithLMHead,
-    OVAutoModelForAudioClassification,
     OVMBartForConditionalGeneration,
 )
 
 
 class OVBertForQuestionAnsweringTest(unittest.TestCase):
-    def check_model(self, model, tok):
+    def check_model(self, model, tok, expected_answer):
         context = """
         Soon her eye fell on a little glass box that
         was lying under the table: she opened it, and
@@ -78,7 +78,7 @@ class OVBertForQuestionAnsweringTest(unittest.TestCase):
         answer_ids = input_ids[0, start_pos:end_pos]
         answer = tok.convert_tokens_to_string(tok.convert_ids_to_tokens(answer_ids))
 
-        self.assertEqual(answer, "the garden")
+        self.assertEqual(answer, expected_answer)
 
     @require_torch
     @unittest.skipIf(is_openvino_api_2 and "GITHUB_ACTIONS" in os.environ, "Memory limit exceed")
@@ -87,7 +87,7 @@ class OVBertForQuestionAnsweringTest(unittest.TestCase):
         model = OVAutoModelForQuestionAnswering.from_pretrained(
             "bert-large-uncased-whole-word-masking-finetuned-squad", from_pt=True
         )
-        self.check_model(model, tok)
+        self.check_model(model, tok, "the garden")
 
     @unittest.skipIf(
         version.parse(transformers.__version__) < version.parse("4.0.0"),
@@ -98,7 +98,62 @@ class OVBertForQuestionAnsweringTest(unittest.TestCase):
         model = OVAutoModelForQuestionAnswering.from_pretrained(
             "dkurt/bert-large-uncased-whole-word-masking-squad-int8-0001"
         )
-        self.check_model(model, tok)
+        self.check_model(model, tok, "the garden")
+
+    @require_torch
+    def test_tinybert_from_pt(self):
+        model_name = "Intel/dynamic_tinybert"
+        tok = AutoTokenizer.from_pretrained(model_name)
+        model = OVAutoModelForQuestionAnswering.from_pretrained(model_name, from_pt=True)
+        self.check_model(model, tok, "if it makes me grow smaller, i can creep under the door")
+
+
+@require_torch
+class SameOutputTest(unittest.TestCase):
+    def check_same_ouput(self, model_name):
+        """
+        Sanity check that argmax and argmin output is the same for PyTorch and OpenVINO models
+        """
+        import torch
+        from transformers import AutoModelForMaskedLM, AutoModelForQuestionAnswering
+        from utils import generate_random_inputs
+
+        torch.set_grad_enabled(False)
+
+        arch = AutoConfig.from_pretrained(model_name).to_dict()["architectures"][0]
+        if arch.endswith("ForQuestionAnswering"):
+            ov_model = OVAutoModelForQuestionAnswering.from_pretrained(model_name, from_pt=True)
+            pt_model = AutoModelForQuestionAnswering.from_pretrained(model_name)
+        elif arch.endswith("ForMaskedLM"):
+            ov_model = OVAutoModelForMaskedLM.from_pretrained(model_name, from_pt=True)
+            pt_model = AutoModelForMaskedLM.from_pretrained(model_name)
+        else:
+            raise NotImplementedError("Only QA and MaskedLM models are currently supported for this test.")
+        tok = AutoTokenizer.from_pretrained(model_name)
+        input_datas = generate_random_inputs(
+            num_items=25, input_names=tok.model_input_names, seq_length=128, return_tensors="pt"
+        )
+
+        all_results = []
+        for input_data in input_datas:
+
+            ov_result = ov_model(**input_data, return_dict=True)
+            pt_result = pt_model(**input_data, return_dict=True)
+            ov_values = np.array(next(iter(ov_result.values()))).round(4)
+            pt_values = np.array(next(iter(pt_result.values()))).round(4)
+
+            same_result = np.argmax(ov_values) == np.argmax(pt_values) and np.argmin(ov_values) == np.argmin(pt_values)
+            all_results.append(same_result)
+        all_same = all(all_results)
+        self.assertTrue(all_same, f"Different output for PyTorch and OpenVINO on {model_name}: {all_results}")
+
+    def test_same_output_tinybert(self):
+        model_name = "Intel/dynamic_tinybert"
+        self.check_same_ouput(model_name)
+
+    def test_same_output_bert(self):
+        model_name = "csarron/bert-base-uncased-squad-v1"
+        self.check_same_ouput(model_name)
 
 
 @require_torch
@@ -346,3 +401,31 @@ class OVMBartForConditionalGenerationTest(unittest.TestCase):
     def test_from_ir(self):
         model = OVMBartForConditionalGeneration.from_pretrained("dkurt/mbart-large-50-many-to-many-mmt-int8")
         self.check_model(model, "Le chef de l’ONU affirme qu’aucune solution militaire n’existe dans la Syrie.")
+
+
+class QAModelMetricTest(unittest.TestCase):
+    def compare_metrics(self, model_name):
+        """
+        Compute F1 and Exact Match over small dataset subset. Compare OpenVINO
+        and PyTorch result: return True if metrics are the same, False if not.
+        """
+        from utils import QAModel
+
+        ov_model = QAModel(model_name, "ov", 128)
+        pt_model = QAModel(model_name, "pt", 128)
+
+        examples = load_dataset("squad", split="validation")
+        examples = examples.select(range(0, 50))
+        ov_f1, ov_em = ov_model.compute_metrics(examples)
+        pt_f1, pt_em = pt_model.compute_metrics(examples)
+        print(f"{model_name}, ov f1: {ov_f1}, pt f1: {pt_f1}")
+        print(f"{model_name}, ov em: {ov_em}, pt em: {pt_em}")
+        return ov_f1 == pt_f1 and ov_em == pt_em
+
+    @require_torch
+    @unittest.skipIf(
+        version.parse(transformers.__version__) < version.parse("4.15.0"), "Too old version for QA models"
+    )
+    def test_bert_metrics(self):
+        model_name = "csarron/bert-base-uncased-squad-v1"
+        self.assertTrue(self.compare_metrics(model_name))

--- a/modules/optimum/tests/openvino/test_modeling_ov_auto.py
+++ b/modules/optimum/tests/openvino/test_modeling_ov_auto.py
@@ -109,7 +109,7 @@ class OVBertForQuestionAnsweringTest(unittest.TestCase):
 
 
 @require_torch
-class SameOutputTest(unittest.TestCase):
+class MultiFrameworkSameOutputTest(unittest.TestCase):
     def check_same_ouput(self, model_name):
         """
         Sanity check that argmax and argmin output is the same for PyTorch and OpenVINO models

--- a/modules/optimum/tests/openvino/utils.py
+++ b/modules/optimum/tests/openvino/utils.py
@@ -33,7 +33,7 @@ class QAModel:
             add_special_tokens=True,
             max_length=512 if self.max_seq_length is None else min(self.max_seq_length, 512),
             padding="max_length" if self.max_seq_length is not None else "do_not_pad",
-            truncation="only_second",
+            truncation=True,
         )
         # Do inference
         result = self.model(**encoded_input, return_dict=True)

--- a/modules/optimum/tests/openvino/utils.py
+++ b/modules/optimum/tests/openvino/utils.py
@@ -1,0 +1,116 @@
+from typing import Optional, Sequence
+
+import numpy as np
+import torch
+from datasets import load_metric
+from optimum.intel.openvino import OVAutoModelForQuestionAnswering
+from transformers import AutoModelForQuestionAnswering, AutoTokenizer
+
+
+class QAModel:
+    def __init__(self, model_name, framework, max_seq_length=None):
+        """
+        Wrapper class for QuestionAnswering models
+
+        :param model_name: model name, e.g. "bert-base-uncased". Should refer to a PyTorch
+                           model on Hugging Face Model Hub
+        :param framework: "ov" or "pytorch"
+        :param max_seq_length: max sequence length for inference. e.g. 128
+        """
+        if framework == "ov":
+            self.model = OVAutoModelForQuestionAnswering.from_pretrained(model_name, from_pt=True)
+        else:
+            self.model = AutoModelForQuestionAnswering.from_pretrained(model_name)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.max_seq_length = max_seq_length
+
+    def ask(self, question, context):
+        torch.set_grad_enabled(False)
+        encoded_input = self.tokenizer.encode_plus(
+            question,
+            context,
+            return_tensors="pt",
+            add_special_tokens=True,
+            max_length=512 if self.max_seq_length is None else min(self.max_seq_length, 512),
+            padding="max_length" if self.max_seq_length is not None else "do_not_pad",
+            truncation="only_second",
+        )
+        # Do inference
+        result = self.model(**encoded_input, return_dict=True)
+
+        # Convert inference result to answer
+        answer_start_scores = np.array(result["start_logits"])
+        answer_end_scores = np.array(result["end_logits"])
+        answer_start = np.argmax(answer_start_scores)
+        answer_end = np.argmax(answer_end_scores) + 1
+        # Convert tokens to answer string
+        input_ids = encoded_input["input_ids"].tolist()[0]
+        answer = self.tokenizer.convert_tokens_to_string(
+            self.tokenizer.convert_ids_to_tokens(input_ids[answer_start:answer_end])
+        )
+        return answer
+
+    def compute_metrics(self, examples):
+        metric = load_metric("squad")
+        f1 = []
+        em = []
+        for item in examples:
+            answer = self.ask(item["question"], item["context"])
+            references = [{"id": item["id"], "answers": item["answers"]}]
+            predictions = [{"id": item["id"], "prediction_text": answer}]
+            metric_scores = metric.compute(references=references, predictions=predictions)
+            f1.append(metric_scores["f1"])
+            em.append(metric_scores["exact_match"])
+        return np.mean(f1), np.mean(em)
+
+
+def generate_random_inputs(
+    num_items: int,
+    input_names: Sequence,
+    seq_length: int,
+    std: Optional[int] = None,
+    seed: int = 141,
+    return_tensors="np",
+):
+    """
+    Return list of input data dictionaries with `num_items` items. Sequences have length `seq_length`. If
+    std is given, sequences of a random distribution around length will be returned, otherwise fixed length
+    sequences of seq_length will be returned.
+
+    :param num_items: number of input data dictionaries to return
+    :param input_names: model input names. Example ["input_ids", "attention_mask"]
+    :param seq_length: sequence length. Example: 128
+    :param std: standard deviation for sequence length. If given, return input_data with dynamic shapes with
+        mean `seq_length`. If None, return input_data with static shapes of `seq_length`
+    :param seed: random seed for reproducibility
+    :param return_tensors: "np" for Numpy tensors, "pt" for PyTorch tensors
+    :return: list with `num_items` dictionaries with input data,
+        where dictionaries have keys with `input_names`
+    """
+
+    if return_tensors == "pt":
+        import torch
+
+        random_func = torch.randint
+    else:
+        random_func = np.random.randint
+
+    assert len(input_names) >= 2
+    if std is not None:
+        np.random.seed(seed)
+        clip_length = 512  # hardcoded max model input shape
+        seq_lengths = np.random.normal(seq_length, std, num_items).clip(0, clip_length)
+        seq_lengths = (seq_lengths - seq_lengths.mean()) / seq_lengths.std()
+        seq_lengths = seq_lengths * std + seq_length
+        seq_lengths = seq_lengths.clip(0, clip_length).round().astype(np.uint16)
+    else:
+        seq_lengths = np.repeat(seq_length, num_items)
+
+    input_list = []
+    for generated_seq_length in seq_lengths:
+        input_data = {}
+        for input_name in input_names:
+            high = 10000 if input_name == "input_ids" else 1
+            input_data[input_name] = random_func(low=0, high=high, size=(1, generated_seq_length))
+        input_list.append(input_data)
+    return input_list


### PR DESCRIPTION
- Add token_type_ids for PyTorch models. This fixes an accuracy issue with some BERT models.
- Add accuracy check tests (would catch accuracy issue fixed by adding token_type_ids)
- Get output names for QA models from model instead of hardcoding (required for NNCF models unless users manually set the expected output names)
- Use ONNX opset_version 12
- Add datasets to [nncf] and [all] requirements

token_type_ids not added to TensorFlow models yet - that requires more testing and tests and should be fixed in a future PR. Added a #TODO comment to TF model loading for now.

requirements could be improved further to distinguish between nncf and all. You need datasets for NNCF examples though, and it's a simple library - it is good to have it installed by default with nncf too.