### PR TITLE
Disable Azure Pipelines CI for openvino-optimum

### DIFF
--- a/.ci/azure/android_arm64.yml
+++ b/.ci/azure/android_arm64.yml
@@ -1,3 +1,21 @@
+trigger:
+  branches:
+    include:
+    - master
+    - releases/*
+  paths:
+    exclude:
+    - modules/optimum
+
+pr:
+  branches:
+    include:
+    - master
+    - releases/*
+  paths:
+    exclude:
+    - modules/optimum
+
 resources:
   repositories:
   - repository: openvino

--- a/.ci/azure/linux_arm64.yml
+++ b/.ci/azure/linux_arm64.yml
@@ -1,3 +1,21 @@
+trigger:
+  branches:
+    include:
+    - master
+    - releases/*
+  paths:
+    exclude:
+    - modules/optimum
+
+pr:
+  branches:
+    include:
+    - master
+    - releases/*
+  paths:
+    exclude:
+    - modules/optimum
+
 resources:
   repositories:
   - repository: openvino

--- a/.ci/azure/linux_coverity_arm64.yml
+++ b/.ci/azure/linux_coverity_arm64.yml
@@ -1,3 +1,21 @@
+trigger:
+  branches:
+    include:
+    - master
+    - releases/*
+  paths:
+    exclude:
+    - modules/optimum
+
+pr:
+  branches:
+    include:
+    - master
+    - releases/*
+  paths:
+    exclude:
+    - modules/optimum
+
 resources:
   repositories:
   - repository: openvino

--- a/.ci/azure/mac.yml
+++ b/.ci/azure/mac.yml
@@ -1,3 +1,21 @@
+trigger:
+  branches:
+    include:
+    - master
+    - releases/*
+  paths:
+    exclude:
+    - modules/optimum
+
+pr:
+  branches:
+    include:
+    - master
+    - releases/*
+  paths:
+    exclude:
+    - modules/optimum
+
 resources:
   repositories:
   - repository: openvino

--- a/.ci/azure/windows.yml
+++ b/.ci/azure/windows.yml
@@ -1,3 +1,21 @@
+trigger:
+  branches:
+    include:
+    - master
+    - releases/*
+  paths:
+    exclude:
+    - modules/optimum
+
+pr:
+  branches:
+    include:
+    - master
+    - releases/*
+  paths:
+    exclude:
+    - modules/optimum
+
 resources:
   repositories:
   - repository: openvino


### PR DESCRIPTION
Optimum code is not covered by this CI so it is not useful to run it on changes to modules/optimum.
Tested with Linux CI (already merged: https://github.com/openvinotoolkit/openvino_contrib/pull/387). Confirmed that that works with this PR: https://github.com/openvinotoolkit/openvino_contrib/pull/388 where we now see "this check was skipped" for that test.

![image](https://user-images.githubusercontent.com/77325899/176659972-d59b9685-4ac1-40db-b150-203ee607be6f.png)
