### PR TITLE
[Java] Add method release() for InferRequest for better resources management

### DIFF
--- a/modules/java_api/cpp/infer_request.cpp
+++ b/modules/java_api/cpp/infer_request.cpp
@@ -51,8 +51,13 @@ JNIEXPORT jlong JNICALL Java_org_intel_openvino_InferRequest_GetTensor(JNIEnv *e
     return 0;
 }
 
-JNIEXPORT void JNICALL Java_org_intel_openvino_InferRequest_delete(JNIEnv *, jobject, jlong addr)
+JNIEXPORT void JNICALL Java_org_intel_openvino_InferRequest_delete(JNIEnv *env, jobject obj, jlong addr)
 {
-    InferRequest *req = (InferRequest *)addr;
-    delete req;
+    jclass cls = env->GetObjectClass(obj);
+    jfieldID field = env->GetFieldID(cls, "isReleased", "Z");
+    jboolean isReleased = env->GetBooleanField(obj, field);
+    if (!isReleased) {
+      InferRequest *req = (InferRequest *)addr;
+      delete req;
+    }
 }

--- a/modules/java_api/org/intel/openvino/InferRequest.java
+++ b/modules/java_api/org/intel/openvino/InferRequest.java
@@ -4,6 +4,8 @@
 package org.intel.openvino;
 
 public class InferRequest extends Wrapper {
+    private boolean isReleased = false;
+
     protected InferRequest(long addr) {
         super(addr);
     }
@@ -22,6 +24,11 @@ public class InferRequest extends Wrapper {
 
     public Tensor get_tensor(String tensorName) {
         return new Tensor(GetTensor(nativeObj, tensorName));
+    }
+
+    public void release() {
+        delete(nativeObj);
+        isReleased = true;
     }
 
     /*----------------------------------- native methods -----------------------------------*/


### PR DESCRIPTION
I've faced a bug with ARM plugin when InferRequest produces correct output just once. Subsequent `infer()` calls return same output for different inputs. So I have recreate InferRequest for every new data. Method `release()` helps free memory before garbage collector.