### PR TITLE
[nvidia] Avoid implicit inclusions

### DIFF
--- a/modules/nvidia_plugin/src/transformer/bidirectional_lstm_sequence_composition.cpp
+++ b/modules/nvidia_plugin/src/transformer/bidirectional_lstm_sequence_composition.cpp
@@ -8,11 +8,13 @@
 #include <gsl/gsl_assert>
 #include <gsl/span_ext>
 #include <ngraph/pass/constant_folding.hpp>
+#include <ngraph/pass/manager.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
 #include <ngraph/variant.hpp>
 #include <openvino/op/concat.hpp>
 #include <openvino/op/lstm_sequence.hpp>
+#include <openvino/op/reshape.hpp>
 #include <openvino/op/transpose.hpp>
 #include <transformations/common_optimizations/common_optimizations.hpp>
 #include <transformations/common_optimizations/nop_elimination.hpp>


### PR DESCRIPTION
It's needed to unlock CI of https://github.com/openvinotoolkit/openvino/pull/13469. Problem occurred once _implicit_ inclusions where removed from some other header file (which didn't need that).