### PR TITLE
[ARM plugin]: build/android - workaround ANDROID_TOOLCHAIN_PREFIX

### DIFF
--- a/modules/arm_plugin/thirdparty/CMakeLists.txt
+++ b/modules/arm_plugin/thirdparty/CMakeLists.txt
@@ -118,8 +118,15 @@ else()
                                 "Please, speficy -DANDROID_PLATFORM=android-18 at least")
         endif()
 
+        if(ANDROID_NDK_REVISION LESS "23.0")
+            list(APPEND ARM_COMPUTE_OPTIONS toolchain_prefix="${ANDROID_TOOLCHAIN_PREFIX}")
+        else()
+            string(REGEX REPLACE "/bin/[^/]+-" "/bin/llvm-" ANDROID_TOOLCHAIN_PREFIX_FIXED "${ANDROID_TOOLCHAIN_PREFIX}")
+            message(STATUS "SCONS: using ANDROID_TOOLCHAIN_PREFIX=${ANDROID_TOOLCHAIN_PREFIX_FIXED}")
+            list(APPEND ARM_COMPUTE_OPTIONS toolchain_prefix="${ANDROID_TOOLCHAIN_PREFIX_FIXED}")
+        endif()
+
         list(APPEND ARM_COMPUTE_OPTIONS
-            toolchain_prefix="${ANDROID_TOOLCHAIN_PREFIX}"
             compiler_prefix="${ANDROID_TOOLCHAIN_ROOT}/bin/")
 
         set(extra_flags "${extra_flags} --target=${ANDROID_LLVM_TRIPLE}")


### PR DESCRIPTION
Build error message:

```
Using compilers:
CC  /opt/android/android-sdk.studio/ndk/25.1.8937393/toolchains/llvm/prebuilt/linux-x86_64/bin/clang
CXX  /opt/android/android-sdk.studio/ndk/25.1.8937393/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++
sh: line 1: /opt/android/android-sdk.studio/ndk/25.1.8937393/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android-ar: No such file or directory
```

Details: https://github.com/android/ndk/issues/1802