### PR TITLE
Update openvino-optimum requirements in setup.py

### DIFF
--- a/modules/optimum/setup.py
+++ b/modules/optimum/setup.py
@@ -15,8 +15,10 @@ except Exception as error:
 
 
 install_requires = [
-    "transformers",
+    "transformers<4.16.0",
     "openvino",
+    "protobuf==3.20.*",
+    "sentencepiece"
 ]
 
 nncf_deps = [


### PR DESCRIPTION
Limit transformers version (to same upper version as .[nncf] install already has), add protobuf and sentencepiece to requirements to enable more models by default.