### PR TITLE
[ARM plugin]: add 'Slice' implementation

### DIFF
--- a/modules/arm_plugin/src/arm_converter/arm_converter.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter.cpp
@@ -71,6 +71,7 @@ Converter::Converter(const std::shared_ptr<const ov::Model> model, const Configu
     Register<opset::Minimum>();
     Register<opset::Maximum>();
     Register<opset::ArmStridedSlice>();
+    Register<opset::ArmSlice>();
     Register<opset::Negative>();
     Register<opset::Floor>();
     Register<opset::Exp>();
@@ -183,6 +184,7 @@ Converter::Converter(const std::shared_ptr<const ov::Model> model, const Configu
         Register<ngraph::op::v8::I420toBGR>();
         Register<ngraph::op::v8::I420toRGB>();
         Register<ngraph::op::v8::MaxPool>();
+        Register<ngraph::op::v8::Slice>();
     }
     Register<opset::Result>();
     for (auto&& node : model->get_ordered_ops()) {

--- a/modules/arm_plugin/src/arm_converter/arm_converter_interpolate.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter_interpolate.cpp
@@ -32,9 +32,18 @@ static void pad_input_data(const uint8_t* data_ptr,
     }
 }
 
+void get_default_axes(std::vector<int64_t>& axes_vec,
+                      const ngraph::PartialShape& input_partial_shape) {
+    const auto input_rank = input_partial_shape.rank().get_length();
+    axes_vec.resize(input_rank);
+    std::iota(axes_vec.begin(), axes_vec.end(), 0);
+    return;
+}
+
 template <typename T, typename V, typename U>
 void wrap_interpolate(const T* input_data,
                       const ngraph::Shape& input_shape,
+                      const ngraph::PartialShape& input_partial_shape,
                       const V* scales,
                       const ngraph::Shape& scales_shape,
                       const U* axes,
@@ -56,33 +65,41 @@ void wrap_interpolate(const T* input_data,
 
     pad_input_data(data_ptr, padded_data_ptr, type_size, input_shape, padded_shape, pads_begin);
 
+    std::vector<int64_t> axes_vec;
+    if (axes != nullptr) {
+        auto axes_size = ngraph::shape_size(axes_shape);
+        axes_vec.assign(axes, axes + axes_size);
+    } else {
+        get_default_axes(axes_vec, input_partial_shape);
+    }
+
     auto scales_size = ngraph::shape_size(scales_shape);
     std::vector<float> scales_vec;
     if (attrs.shape_calculation_mode == ngraph::op::v4::Interpolate::ShapeCalcMode::SIZES) {
         for (size_t i = 0; i < scales_size; i++) {
-            auto axis = axes[i];
+            size_t axis = axes_vec[i];
             scales_vec.push_back(static_cast<float>(out_shape[axis]) / padded_shape[axis]);
         }
     } else {
         scales_vec = std::vector<float>(scales, scales + scales_size);
     }
 
-    auto axes_size = ngraph::shape_size(axes_shape);
-    std::vector<int64_t> axes_vec(axes, axes + axes_size);
     ngraph::runtime::reference::interpolate<T>(reinterpret_cast<T*>(padded_data_ptr),
-                                                padded_shape,
-                                                scales_vec,
-                                                axes_vec,
-                                                out,
-                                                out_shape,
-                                                attrs);
+                                               padded_shape,
+                                               scales_vec,
+                                               axes_vec,
+                                               out,
+                                               out_shape,
+                                               attrs);
 }
 
 template<> Converter::Conversion::Ptr Converter::Convert(const opset::Interpolate& node) {
     auto make = [&] (auto refFunction) {
+    if (node.get_input_size() == 4) {
         return this->MakeConversion(refFunction,
                                     node.input(0),
                                     node.get_input_shape(0),
+                                    node.get_input_partial_shape(0),
                                     node.input(2),
                                     node.get_input_shape(2),
                                     node.input(3),
@@ -90,12 +107,25 @@ template<> Converter::Conversion::Ptr Converter::Convert(const opset::Interpolat
                                     node.output(0),
                                     node.get_output_shape(0),
                                     node.get_attrs());
+    }
+    return this->MakeConversion(refFunction,
+                                node.input(0),
+                                node.get_input_shape(0),
+                                node.get_input_partial_shape(0),
+                                node.input(2),
+                                node.get_input_shape(2),
+                                nullptr,
+                                ngraph::Shape{},
+                                node.output(0),
+                                node.get_output_shape(0),
+                                node.get_attrs());
     };
     return CallSwitch(
         AP_WRAP(make, wrap_interpolate),
         node.get_input_element_type(0), allTypes,
         node.get_input_element_type(2), floatTypes,
-        node.get_input_element_type(1), indexTypes);
+        node.get_input_size() == 4 ? node.get_input_element_type(3) : ngraph::element::i64,
+        indexTypes);
 }
 
 template<> Converter::Conversion::Ptr Converter::Convert(const opset::ArmInterpolate& node) {

--- a/modules/arm_plugin/src/arm_converter/arm_converter_slice.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter_slice.cpp
@@ -1,0 +1,92 @@
+// Copyright (C) 2020-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+
+
+#include <arm_compute/runtime/NEON/functions/NESlice.h>
+#include <ngraph/runtime/reference/slice.hpp>
+#include "ngraph/slice_plan.hpp"
+#include "arm_converter/arm_converter.hpp"
+
+namespace ArmPlugin {
+
+template <typename T, typename U>
+void wrap_slice(const T* arg,
+                        const U* begin,
+                        const U* steps,
+                        const U* axes,
+                        T* out,
+                        const ngraph::Shape& arg_shape,
+                        const ngraph::Shape& out_shape,
+                        const ngraph::Shape& begin_shape,
+                        const ngraph::Shape& step_shape,
+                        const ngraph::Shape& axes_shape,
+                        size_t elem_size) {
+    std::vector<int64_t> begin_const(begin, begin + ngraph::shape_size(begin_shape));
+    std::vector<int64_t> step_const(steps, steps + ngraph::shape_size(step_shape));
+    std::vector<int64_t> axes_const(axes, axes + ngraph::shape_size(axes_shape));
+
+    ngraph::runtime::reference::slice(reinterpret_cast<const char*>(arg),
+                                      arg_shape,
+                                      reinterpret_cast<char*>(out),
+                                      out_shape,
+                                      elem_size,
+                                      begin_const,
+                                      step_const,
+                                      axes_const);
+}
+
+template <> Converter::Conversion::Ptr Converter::Convert(const ngraph::op::v8::Slice& node) {
+    auto make = [&] (auto refFunction) {
+        return this->MakeConversion(refFunction,
+                                    node.input(0),
+                                    node.input(1),
+                                    node.input(3),
+                                    node.input(4),
+                                    node.output(0),
+                                    node.get_input_shape(0),
+                                    node.get_output_shape(0),
+                                    node.get_input_shape(1),
+                                    node.get_input_shape(3),
+                                    node.get_input_shape(4),
+                                    node.get_element_type().size());
+    };
+
+    return CallSwitch(
+        AP_WRAP(make, wrap_slice),
+        node.input(0), allTypes,
+        node.input(1), indexTypes);
+}
+
+template <> Converter::Conversion::Ptr Converter::Convert(const opset::ArmSlice& node) {
+    auto begin  = safe_cast<ngraph::op::Constant>(
+                        node.input_value(1).get_node_shared_ptr())->cast_vector<int>();
+    auto end    = safe_cast<ngraph::op::Constant>(
+                        node.input_value(2).get_node_shared_ptr())->cast_vector<int>();
+    auto axes = safe_cast<ngraph::op::Constant>(
+                        node.input_value(4).get_node_shared_ptr())->cast_vector<int>();
+    auto shape  = node.get_input_shape(0);
+    const auto rank = shape.size();
+
+    arm_compute::Coordinates starts, finishes;
+    starts.set_num_dimensions(rank);
+    finishes.set_num_dimensions(rank);
+    for (size_t i = 0; i < rank; ++i) {
+        const auto axis = AxisCast(i, rank);
+        starts.set(axis, 0);
+        finishes.set(axis, shape[i]);
+    }
+
+    for (size_t i = 0; i < begin.size(); ++i) {
+        const auto axis = AxisCast(
+            axes[i] >= 0 ?
+            axes[i] : axes[i] + rank, rank);
+
+        starts.set(axis, begin[i]);
+        finishes.set(axis, end[i] >= 0 ?
+            end[i] : shape[axes[i]] + end[i]);
+    }
+
+    return MakeConversion<arm_compute::NESlice>(node.input(0), node.output(0), starts, finishes);
+}
+}  //  namespace ArmPlugin

--- a/modules/arm_plugin/src/opset/opset.hpp
+++ b/modules/arm_plugin/src/opset/opset.hpp
@@ -15,6 +15,7 @@
 #include "mvn_arm.hpp"
 #include "normalizel2_arm.hpp"
 #include "strided_slice_arm.hpp"
+#include "slice_arm.hpp"
 #include "transpose_arm.hpp"
 #include "fft_arm.hpp"
 #include "quantize.hpp"

--- a/modules/arm_plugin/src/opset/slice_arm.cpp
+++ b/modules/arm_plugin/src/opset/slice_arm.cpp
@@ -1,0 +1,33 @@
+// Copyright (C) 2020-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "slice_arm.hpp"
+#include "ngraph/validation_util.hpp"
+
+using namespace ngraph;
+using namespace ArmPlugin;
+
+opset::ArmSlice::~ArmSlice() {}
+
+opset::ArmSlice::ArmSlice(const ngraph::Output<ngraph::Node>& data,
+                                        const ngraph::Output<ngraph::Node>& begin,
+                                        const ngraph::Output<ngraph::Node>& end,
+                                        const ngraph::Output<ngraph::Node>& step,
+                                        const ngraph::Output<ngraph::Node>& axes)
+    : ngraph::op::v8::Slice{data, begin, end, step, axes } {
+    constructor_validate_and_infer_types();
+}
+
+std::shared_ptr<ngraph::Node> ArmPlugin::opset::ArmSlice::clone_with_new_inputs(const ngraph::OutputVector& new_args) const {
+    auto num_args = new_args.size();
+    if (num_args == 4) {
+        return std::make_shared<ArmSlice>(new_args.at(0),
+                                          new_args.at(1),
+                                          new_args.at(2),
+                                          new_args.at(3),
+                                          new_args.at(4));
+    } else {
+        throw ngraph_error("Unsupported number of arguments for ArmSlice operation");
+    }
+}

--- a/modules/arm_plugin/src/opset/slice_arm.hpp
+++ b/modules/arm_plugin/src/opset/slice_arm.hpp
@@ -1,0 +1,29 @@
+// Copyright (C) 2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "ngraph_opset.hpp"
+#include <ngraph/opsets/opset7.hpp>
+#include "utils.hpp"
+
+namespace ArmPlugin {
+namespace opset {
+
+class ArmSlice : public ngraph::op::v8::Slice {
+public:
+    OPENVINO_OP("ArmSlice", "arm_opset", ngraph::op::v8::Slice);
+
+    ~ArmSlice() override;
+
+    ArmSlice(const ngraph::Output<ngraph::Node>& data,
+                    const ngraph::Output<ngraph::Node>& begin,
+                    const ngraph::Output<ngraph::Node>& end,
+                    const ngraph::Output<ngraph::Node>& step,
+                    const ngraph::Output<ngraph::Node>& axes);
+
+    std::shared_ptr<ngraph::Node> clone_with_new_inputs(const ngraph::OutputVector& new_args) const override;
+};
+}  // namespace opset
+}  // namespace ArmPlugin

--- a/modules/arm_plugin/src/transformations/arm_optimizations.cpp
+++ b/modules/arm_plugin/src/transformations/arm_optimizations.cpp
@@ -44,6 +44,7 @@
 #include "convert_logical.hpp"
 #include "convert_strided_slice.hpp"
 #include "convert_strided_slice_arm.hpp"
+#include "convert_slice_arm.hpp"
 #include "convert_group_conv.hpp"
 #include "convert_conv1d_to_conv2d.hpp"
 #include "convert_grn_to_normalizel2.hpp"
@@ -276,6 +277,7 @@ bool ArmPlugin::pass::ArmOptimizations::run_on_model(const std::shared_ptr<ov::M
         manager.register_pass<ov::pass::GraphRewrite>()->add_matcher<pass::DecomposeVariadicSplit>();
         manager.register_pass<ov::pass::GraphRewrite>()->add_matcher<pass::ConvertStridedSliceToArm>();
         manager.register_pass<ov::pass::GraphRewrite>()->add_matcher<pass::ConvertStridedSlice>();
+        manager.register_pass<ov::pass::GraphRewrite>()->add_matcher<pass::ConvertSliceToArm>();
         manager.register_pass<ov::pass::GraphRewrite>()->add_matcher<pass::ConvertBatchNormInferenceV0toV5>();
         manager.register_pass<ov::pass::GraphRewrite>()->add_matcher<pass::ConvertBatchNormInference>();
         manager.register_pass<ov::pass::GraphRewrite>()->add_matcher<pass::ConvertShuffleChannels>();

--- a/modules/arm_plugin/src/transformations/convert_interpolate_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_interpolate_arm.cpp
@@ -106,11 +106,19 @@ ArmPlugin::pass::ConvertInterpolate::ConvertInterpolate() {
             return false;
         }
 
-        auto arm_interp = std::make_shared<opset::ArmInterpolate>(interp->input_value(0),
-                                                                  interp->input_value(1),
-                                                                  interp->input_value(2),
-                                                                  interp->input_value(3),
-                                                                  attrs);
+        std::shared_ptr<opset::ArmInterpolate> arm_interp = nullptr;
+        if (interp->get_input_size() == 4) {
+            arm_interp = std::make_shared<opset::ArmInterpolate>(interp->input_value(0),
+                                                                 interp->input_value(1),
+                                                                 interp->input_value(2),
+                                                                 interp->input_value(3),
+                                                                 attrs);
+        } else {
+            arm_interp = std::make_shared<opset::ArmInterpolate>(interp->input_value(0),
+                                                                 interp->input_value(1),
+                                                                 interp->input_value(2),
+                                                                 attrs);
+        }
         arm_interp->set_friendly_name(interp->get_friendly_name());
         ngraph::copy_runtime_info(interp, arm_interp);
         ngraph::replace_node(interp, arm_interp);

--- a/modules/arm_plugin/src/transformations/convert_slice_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_slice_arm.cpp
@@ -1,0 +1,50 @@
+// Copyright (C) 2020-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+
+#include "transformations/convert_slice_arm.hpp"
+#include "opset/opset.hpp"
+#include <ngraph/rt_info.hpp>
+#include <ngraph/pattern/op/wrap_type.hpp>
+#include "ngraph/validation_util.hpp"
+
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSliceToArm, "ConvertSliceToArm", 0);
+ArmPlugin::pass::ConvertSliceToArm::ConvertSliceToArm() {
+    auto slice = ngraph::pattern::wrap_type<ngraph::op::v8::Slice>();
+
+    ngraph::matcher_pass_callback callback = [](ngraph::pattern::Matcher& m) {
+        auto slice = std::dynamic_pointer_cast<ngraph::op::v8::Slice>(m.get_match_root());
+        if (!slice) {
+            return false;
+        }
+
+        if (slice->get_input_shape(0).size() > 4) {
+            return false;
+        }
+
+        auto&& begin_node  = std::dynamic_pointer_cast<ngraph::op::Constant>(slice->input_value(1).get_node_shared_ptr());
+        auto&& end_node    = std::dynamic_pointer_cast<ngraph::op::Constant>(slice->input_value(2).get_node_shared_ptr());
+        auto&& step_node = std::dynamic_pointer_cast<ngraph::op::Constant>(slice->input_value(3).get_node_shared_ptr());
+        if (!begin_node || !end_node || !step_node) {
+            return false;
+        }
+
+        const auto axes_const  = slice->get_input_size() > 4 ?
+            ngraph::get_constant_from_source(slice->input_value(4)) :
+            slice->get_default_const_axes(slice->input_value(1));
+
+        auto arm_slice = std::make_shared<opset::ArmSlice>(slice->input_value(0),
+                                                           slice->input_value(1),
+                                                           slice->input_value(2),
+                                                           slice->input_value(3),
+                                                           axes_const);
+
+        arm_slice->set_friendly_name(slice->get_friendly_name());
+        ngraph::copy_runtime_info(slice, arm_slice);
+        ngraph::replace_node(slice, arm_slice);
+        return true;
+    };
+
+    auto m = std::make_shared<ngraph::pattern::Matcher>(slice, "ConvertSliceToArm");
+    register_matcher(m, callback);
+}

--- a/modules/arm_plugin/src/transformations/convert_slice_arm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_slice_arm.hpp
@@ -1,0 +1,17 @@
+// Copyright (C) 2020-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <ngraph/pass/graph_rewrite.hpp>
+
+namespace ArmPlugin {
+namespace pass {
+
+class ConvertSliceToArm: public ngraph::pass::MatcherPass {
+public:
+    NGRAPH_RTTI_DECLARATION;
+    ConvertSliceToArm();
+};
+}  // namespace pass
+}  // namespace ArmPlugin


### PR DESCRIPTION
Add implementation of 'opset8::Slice' in ARM plugin through native 'NESlice'. Fixes #428

Signed-off-by: Dmitry Gurulev <dmitry.gurulev@gmail.com>