### PR TITLE
[ARM CPU plugin] Skip deviceID tests

### DIFF
--- a/modules/arm_plugin/tests/functional/shared_tests_instances/skip_tests_config.cpp
+++ b/modules/arm_plugin/tests/functional/shared_tests_instances/skip_tests_config.cpp
@@ -45,6 +45,12 @@ std::vector<std::string> disabledTestPatterns() {
         ".*OVInferenceChaining.*Dynamic.*", // Dynamic shape is not supported
         ".*ReturnResultNotReadyFromWaitInAsyncModeForTooSmallTimeout.*", // Unsupported topology
         ".*NmsLayerTest.*CompareWithRefs.*numBatches=3.*numBoxes=100.*numClasses=5.*paramsPrec=FP32.*maxBoxPrec=I32.*thrPrec=FP32.*",
+        ".*OVClassNetworkTestP.*QueryNetworkMultiThrows.*",
+        ".*OVClassNetworkTestP.*LoadNetworkMultiWithoutSettingDevicePrioritiesThrows.*",
+        R"(.*OVClassQueryNetworkTest.*DeviceID.*)",
+        R"(.*OVClassLoadNetworkTest.*DeviceID.*)",
+        R"(.*OVClassLoadNetworkTest.*(MULTIwithHETERO|HETEROwithMULTI|MULTIwithAUTO)NoThrow.*)",
+        R"(.*OVClassLoadNetworkTest.*QueryNetwork(MULTIWithHETERO|HETEROWithMULTI)NoThrow_V10.*)",
 #ifdef __arm__
         // Sporadic hanges on linux-debian_9_arm runner (armv7l) 72140
         ".*canStartSeveralAsyncInsideCompletionCallbackWithSafeDtor.*AUTO.*",


### PR DESCRIPTION
OV tests updates (https://github.com/openvinotoolkit/openvino/commit/e075785486c0404551a73537d1d5c663a020a1cd) stop skipping some tests internally, so they need to be skipped explicitly by plugins.