### PR TITLE
[NVIDIA] Fix Concat layer with negative axis

### DIFF
--- a/modules/nvidia_plugin/src/ops/concat.cpp
+++ b/modules/nvidia_plugin/src/ops/concat.cpp
@@ -29,7 +29,10 @@ ConcatOp::ConcatOp(const CreationContext& context,
     Expects(num_inputs_ == GetInputIds().size());
     Expects(GetOutputIds().size() == 1);
     const auto& outputShape = concatOp.get_output_shape(0);
-    const int64_t axis = concatOp.get_axis();
+    int64_t axis = concatOp.get_axis();
+    if (axis < 0) {
+        axis += static_cast<int64_t>(concatOp.get_input_partial_shape(0).rank().get_length());
+    }
     Expects(axis >= 0 && axis < outputShape.size());
     auto num_chunks =
         std::accumulate(outputShape.begin(), outputShape.begin() + axis + 1, 1, std::multiplies<size_t>());

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/concat.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/concat.cpp
@@ -13,7 +13,7 @@ using namespace LayerTestsDefinitions;
 
 namespace {
 
-std::vector<int> axes = {0, 1, 2, 3};
+std::vector<int> axes = {-3, -2, -1, 0, 1, 2, 3};
 std::vector<std::vector<std::vector<size_t>>> inShapes = {
     {{10, 10, 10, 10}},
     {{10, 10, 10, 10}, {10, 10, 10, 10}},


### PR DESCRIPTION
### Details:
 - *Fix Concat layer with negative axis (enables swin-tiny-patch4-window7-224 topology under PROXY plugin)*

### Tickets:
 - *ticket-id*

