### PR TITLE
[ARM plugin] Activation fixes

### DIFF
--- a/modules/arm_plugin/src/arm_converter/arm_converter_activation.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter_activation.cpp
@@ -122,7 +122,7 @@ template<> Converter::Conversion::Ptr Converter::Convert(const opset::Gelu& node
 
 template<> Converter::Conversion::Ptr Converter::Convert(const opset::Swish& node) {
     float beta = 1.0;
-    if (ov::get_constant_from_source(node.input_value(1)) != nullptr) {
+    if (node.get_input_size() > 1) {
         beta = ov::get_constant_from_source(node.input_value(1))->cast_vector<float>()[0];
     }
     arm_compute::ActivationLayerInfo info(arm_compute::ActivationLayerInfo::ActivationFunction::SWISH, beta);

--- a/modules/arm_plugin/src/arm_converter/arm_converter_activation.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter_activation.cpp
@@ -122,7 +122,7 @@ template<> Converter::Conversion::Ptr Converter::Convert(const opset::Gelu& node
 
 template<> Converter::Conversion::Ptr Converter::Convert(const opset::Swish& node) {
     float beta = 1.0;
-    if (node.get_input_size() > 1) {
+    if (node.get_input_size() > 1 && ov::get_constant_from_source(node.input_value(1)) != nullptr) {
         beta = ov::get_constant_from_source(node.input_value(1))->cast_vector<float>()[0];
     }
     arm_compute::ActivationLayerInfo info(arm_compute::ActivationLayerInfo::ActivationFunction::SWISH, beta);

--- a/modules/arm_plugin/src/arm_converter/arm_converter_activation.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter_activation.cpp
@@ -6,6 +6,9 @@
 #include <arm_compute/runtime/NEON/functions/NEElementwiseUnaryLayer.h>
 #include <arm_compute/runtime/NEON/functions/NEFloor.h>
 #include <arm_compute/runtime/NEON/functions/NEPReluLayer.h>
+#include <ngraph/runtime/reference/abs.hpp>
+#include <ngraph/runtime/reference/clamp.hpp>
+#include <ngraph/runtime/reference/floor.hpp>
 #include <ngraph/runtime/reference/hsigmoid.hpp>
 #include <ngraph/runtime/reference/hard_sigmoid.hpp>
 #include <ngraph/runtime/reference/selu.hpp>
@@ -40,13 +43,34 @@ template<> Converter::Conversion::Ptr Converter::Convert(const opset::PRelu& nod
 }
 
 template<> Converter::Conversion::Ptr Converter::Convert(const opset::Abs& node) {
-    arm_compute::ActivationLayerInfo info(arm_compute::ActivationLayerInfo::ActivationFunction::ABS);
-    return ConvertActivation(node, info, this);
+    if (node.input(0).get_element_type() == ngraph::element::f32 ||
+        node.input(0).get_element_type() == ngraph::element::f16) {
+        arm_compute::ActivationLayerInfo info(arm_compute::ActivationLayerInfo::ActivationFunction::ABS);
+        return ConvertActivation(node, info, this);
+    } else {
+        auto make = [&] (auto refFunction) {
+            return this->MakeConversion(refFunction, node.input(0), node.output(0), ngraph::shape_size(node.get_output_shape(0)));
+        };
+        return CallSwitch(
+            AP_WRAP(make, ngraph::runtime::reference::abs),
+            node.input(0), intTypes);
+    }
 }
 
 template<> Converter::Conversion::Ptr Converter::Convert(const opset::Clamp& node) {
-    arm_compute::ActivationLayerInfo info(arm_compute::ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU, node.get_max(), node.get_min());
-    return ConvertActivation(node, info, this);
+    if (node.input(0).get_element_type() == ngraph::element::f32 ||
+        node.input(0).get_element_type() == ngraph::element::f16) {
+        arm_compute::ActivationLayerInfo info(arm_compute::ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU, node.get_max(), node.get_min());
+        return ConvertActivation(node, info, this);
+    } else {
+        auto make = [&] (auto refFunction) {
+            return this->MakeConversion(refFunction, node.input(0), node.output(0),
+                static_cast<std::int32_t>(node.get_min()), static_cast<std::int32_t>(node.get_max()), ngraph::shape_size(node.get_input_shape(0)));
+        };
+        return CallSwitch(
+            AP_WRAP(make, ngraph::runtime::reference::clamp),
+            node.input(0), std::tuple<std::int32_t>{});
+    }
 }
 
 template<> Converter::Conversion::Ptr Converter::Convert(const opset::Sqrt& node) {

--- a/modules/arm_plugin/src/arm_converter/arm_converter_convert.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter_convert.cpp
@@ -131,6 +131,8 @@ template <> Converter::Conversion::Ptr Converter::Convert(const opset::Convert& 
                     return make(ngraph::runtime::reference::convert<float, std::uint16_t>);
                 case ngraph::element::Type_t::u32 :
                     return make(ngraph::runtime::reference::convert<float, std::uint16_t>);
+                case ngraph::element::Type_t::i8 :
+                    return make(ngraph::runtime::reference::convert<float, std::int8_t>);
                 case ngraph::element::Type_t::i16 :
                     return make(ngraph::runtime::reference::convert<float, std::int16_t>);
             default:

--- a/modules/arm_plugin/src/arm_converter/arm_converter_pool.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter_pool.cpp
@@ -36,7 +36,9 @@ static void FillLayerInfo(const Pool& node, arm_compute::PoolingLayerInfo& pool_
 }
 
 template<> Converter::Conversion::Ptr Converter::Convert(const opset::MaxPool& node) {
-    if (node.get_input_shape(0).size() == 4) {
+    if (node.get_input_shape(0).size() == 4 &&
+        (node.input(0).get_element_type() == ngraph::element::f32 ||
+        node.input(0).get_element_type() == ngraph::element::f16)) {
         arm_compute::PoolingLayerInfo pool_info;
         FillLayerInfo(node, pool_info);
         pool_info.pool_type = arm_compute::PoolingType::MAX;


### PR DESCRIPTION
Several fixes:
 - Fallback to reference ops for non-float data type
 - Swish check that beta parameter is available
 - Return f32->i8 reference conversion that was removed by mistake in https://github.com/openvinotoolkit/openvino_contrib/pull/486