### PR TITLE
[ARM plugin] Use ov::pass namespace for transforamtions

### DIFF
--- a/modules/arm_plugin/src/transformations/arm_optimizations.cpp
+++ b/modules/arm_plugin/src/transformations/arm_optimizations.cpp
@@ -155,7 +155,7 @@ bool ArmPlugin::pass::ArmOptimizations::run_on_model(const std::shared_ptr<ov::M
         // This pass must be called first in pipeline
         manager.register_pass<ov::pass::InitNodeInfo>();
         manager.register_pass<pass::StoreResultName>();
-        manager.register_pass<ngraph::pass::CommonOptimizations>();
+        manager.register_pass<ov::pass::CommonOptimizations>();
         // Resolves dynamism (replaces NonZero), CF needed
         manager.register_pass<ov::pass::GraphRewrite>()->add_matcher<ov::pass::RemoveFilteringBoxesBySize>();
         manager.register_pass<ngraph::pass::ConstantFolding>();
@@ -191,7 +191,7 @@ bool ArmPlugin::pass::ArmOptimizations::run_on_model(const std::shared_ptr<ov::M
         manager.register_pass<ov::pass::GraphRewrite>()->add_matcher<ov::pass::ConvertMVN1ToMVN6>();
         manager.register_pass<ov::pass::GraphRewrite>()->add_matcher<ov::pass::ConvertQuantizeDequantize>();
         #ifndef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
-            manager.register_pass<ngraph::pass::ConvertPrecision>(ngraph::element::f16, ngraph::element::f32);
+            manager.register_pass<ov::pass::ConvertPrecision>(ngraph::element::f16, ngraph::element::f32);
         #endif
 
         auto pass_config = manager.get_pass_config();

--- a/modules/arm_plugin/src/transformations/conv_bias_fusion.cpp
+++ b/modules/arm_plugin/src/transformations/conv_bias_fusion.cpp
@@ -78,12 +78,12 @@ void ArmPlugin::pass::ConvBiasFusionBase::registerMatcher(const std::string& nam
 
         std::shared_ptr<ngraph::Node> new_conv;
         if (quantized) {
-            new_conv = std::make_shared<ngraph::op::TypeRelaxed<Conv>>(
+            new_conv = std::make_shared<ov::op::TypeRelaxed<Conv>>(
                 std::vector<ngraph::element::Type>{outputType, outputType, outputType},
                 std::vector<ngraph::element::Type>{outputType},
-                ngraph::op::TemporaryReplaceOutputType(conv->input_value(Inputs::Data), outputType).get(),
-                ngraph::op::TemporaryReplaceOutputType(conv->input_value(Inputs::Weights), outputType).get(),
-                ngraph::op::TemporaryReplaceOutputType(new_bias, outputType).get(),
+                ov::op::TemporaryReplaceOutputType(conv->input_value(Inputs::Data), outputType).get(),
+                ov::op::TemporaryReplaceOutputType(conv->input_value(Inputs::Weights), outputType).get(),
+                ov::op::TemporaryReplaceOutputType(new_bias, outputType).get(),
                 conv->get_strides(),
                 conv->get_pads_begin(),
                 conv->get_pads_end(),
@@ -124,11 +124,11 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertConvBase::convert_conv_to_
 
         std::shared_ptr<ngraph::Node> conv_arm;
         if (quantized) {
-            conv_arm = std::make_shared<ngraph::op::TypeRelaxed<ArmConv>>(
+            conv_arm = std::make_shared<ov::op::TypeRelaxed<ArmConv>>(
                 std::vector<ngraph::element::Type>{outputType, outputType},
                 std::vector<ngraph::element::Type>{outputType},
-                ngraph::op::TemporaryReplaceOutputType(conv->input_value(Inputs::Data), outputType).get(),
-                ngraph::op::TemporaryReplaceOutputType(conv->input_value(Inputs::Weights), outputType).get(),
+                ov::op::TemporaryReplaceOutputType(conv->input_value(Inputs::Data), outputType).get(),
+                ov::op::TemporaryReplaceOutputType(conv->input_value(Inputs::Weights), outputType).get(),
                 conv->get_strides(),
                 conv->get_pads_begin(),
                 conv->get_pads_end(),

--- a/modules/arm_plugin/src/transformations/normalizel2_max_fusion.cpp
+++ b/modules/arm_plugin/src/transformations/normalizel2_max_fusion.cpp
@@ -45,7 +45,7 @@ ArmPlugin::pass::NormalizeL2Fusion::NormalizeL2Fusion() {
         if (shape_size(eps_attr->get_shape()) > 1) {
             return false;
         }
-        const auto eps_attr_value = ngraph::op::util::has_constant_value<float>(exp_input, 2.0f);
+        const auto eps_attr_value = ov::op::util::has_constant_value<float>(exp_input, 2.0f);
 
         auto normalize_l2 = std::make_shared<opset::NormalizeL2>(data_input, axes_input, eps_attr_value, ngraph::op::EpsMode::MAX);
 


### PR DESCRIPTION
Replaces `ngraph::pass` namespace with `ov::pass` for common/transformations stuff of ARM plugin.