### PR TITLE
[ARM plugin] Fix result shapes calculation in VariadicSplit if split length == -1

### DIFF
--- a/modules/arm_plugin/src/transformations/decompose_variadic_split.cpp
+++ b/modules/arm_plugin/src/transformations/decompose_variadic_split.cpp
@@ -57,7 +57,11 @@ ArmPlugin::pass::DecomposeVariadicSplit::DecomposeVariadicSplit() {
 
         for (size_t i = 0; i < splits.size(); i++) {
             begin_vec[axis] = end_vec[axis];
-            end_vec[axis]  += splits[i];
+            if (splits[i] == -1) {
+                end_vec[axis] += input_shape[axis] - std::accumulate(splits.begin(), splits.end(), 1);
+            } else {
+                end_vec[axis] += splits[i];
+            }
 
             auto begin  = opset::Constant::create<int64_t>(ngraph::element::i64, ngraph::Shape{size}, begin_vec);
             auto end    = opset::Constant::create<int64_t>(ngraph::element::i64, ngraph::Shape{size}, end_vec);


### PR DESCRIPTION
Fix this option: `In addition split_lengths can contain a single -1 element, which means, all remaining items along specified axis that are not consumed by other parts.`
https://docs.openvino.ai/latest/openvino_docs_ops_movement_VariadicSplit_1.html