### PR TITLE
[ARM plugin] Update transformation set

### DIFF
--- a/modules/arm_plugin/src/arm_converter/arm_converter.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter.cpp
@@ -64,9 +64,11 @@ Converter::Converter(const std::shared_ptr<const ov::Model> model, const Configu
     Register<opset::Clamp>();
     Register<opset::Sqrt>();
     Register<opset::Elu>();
+    Register<ngraph::op::v0::Gelu>();
     Register<opset::Gelu>();
     Register<opset::ArmTranspose>();
     Register<opset::Softmax>();
+    Register<opset::LogSoftmax>();
     Register<opset::ArmSplit>();
     Register<opset::LRN>();
     Register<opset::Minimum>();

--- a/modules/arm_plugin/src/arm_converter/arm_converter_activation.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter_activation.cpp
@@ -86,6 +86,11 @@ template<> Converter::Conversion::Ptr Converter::Convert(const opset::Gelu& node
     return ConvertActivation(node, info, this);
 }
 
+template<> Converter::Conversion::Ptr Converter::Convert(const ngraph::op::v0::Gelu& node) {
+    arm_compute::ActivationLayerInfo info(arm_compute::ActivationLayerInfo::ActivationFunction::GELU);
+    return ConvertActivation(node, info, this);
+}
+
 template<> Converter::Conversion::Ptr Converter::Convert(const opset::Swish& node) {
     float beta = 1.0;
     if (ov::get_constant_from_source(node.input_value(1)) != nullptr) {

--- a/modules/arm_plugin/src/arm_converter/arm_converter_softmax.cpp
+++ b/modules/arm_plugin/src/arm_converter/arm_converter_softmax.cpp
@@ -2,23 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <arm_compute/runtime/NEON/functions/NESoftmaxLayer.h>
-#include <ngraph/runtime/reference/softmax.hpp>
 #include "arm_converter/arm_converter.hpp"
 
 namespace ArmPlugin {
 template<> Converter::Conversion::Ptr Converter::Convert(const opset::Softmax& node) {
-    if (true) {
-        return MakeConversion<arm_compute::NESoftmaxLayer>(node.input(0),
-                                                        node.output(0),
-                                                        1.0f,
-                                                        static_cast<int32_t>(AxisCast(node.get_axis(), node.get_shape().size())));
-    } else {
-        auto make = [&] (auto refFunction) {
-            return this->MakeConversion(refFunction, node.input(0), node.output(0), node.get_shape(), ngraph::AxisSet{node.get_axis()});
-        };
-        return CallSwitch(
-            AP_WRAP(make, ngraph::runtime::reference::softmax),
-            node.input(0), floatTypes);
-    }
+    return MakeConversion<arm_compute::NESoftmaxLayer>(node.input(0),
+                                                       node.output(0),
+                                                       1.0f,
+                                                       static_cast<int32_t>(AxisCast(node.get_axis(), node.get_shape().size())));
+}
+
+template<> Converter::Conversion::Ptr Converter::Convert(const opset::LogSoftmax& node) {
+    auto axis = node.get_axis();
+    if (axis < 0) { axis += node.get_shape().size(); }
+    return MakeConversion<arm_compute::NELogSoftmaxLayer>(node.input(0),
+                                                          node.output(0),
+                                                          1.0f,
+                                                          static_cast<int32_t>(AxisCast(axis, node.get_shape().size())));
 }
 } // namespace ArmPlugin


### PR DESCRIPTION
- [x] Gelu : reference -> native (support v2 and v7) for aarch64
- [x] HSwish : reference -> native
- [x] LogSoftmax : support native
- [x] Reduce L1/L2 - move to common_optimization
- [x] ConvertCompressedOnlyToLegacy - disable
- [x] ConvertBroadcastToTiles - move to arm transformations
- [x] Disable common conversions and decompositions 
TODO: Fix MVN6decomposition