### PR TITLE
[NVIDIA] Support changes in OpenVINO: TI via Sequence

### DIFF
--- a/modules/nvidia_plugin/include/nvidia/nvidia_config.hpp
+++ b/modules/nvidia_plugin/include/nvidia/nvidia_config.hpp
@@ -61,10 +61,5 @@ DECLARE_NVIDIA_CONFIG_KEY(THROUGHPUT_STREAMS);
  */
 DECLARE_NVIDIA_CONFIG_KEY(OPERATION_BENCHMARK);
 
-/**
- * @brief Defines possibility to disable TensorIterator transformation for test purposes.
- */
-DECLARE_NVIDIA_CONFIG_KEY(DISABLE_TENSORITERATOR_TRANSFORM);
-
 }  // namespace CUDAConfigParams
 }  // namespace InferenceEngine

--- a/modules/nvidia_plugin/src/cuda_config.cpp
+++ b/modules/nvidia_plugin/src/cuda_config.cpp
@@ -70,14 +70,6 @@ Configuration::Configuration(const ConfigMap& config, const Configuration& defau
             } else {
                 throwIEException(fmt::format("operation benchmark option value {} is not supported", value));
             }
-        } else if (NVIDIA_CONFIG_KEY(DISABLE_TENSORITERATOR_TRANSFORM) == key) {
-            if (value == NVIDIA_CONFIG_VALUE(YES)) {
-                disabled_tensoriterator_transform = true;
-            } else if (value == NVIDIA_CONFIG_VALUE(NO)) {
-                disabled_tensoriterator_transform = false;
-            } else {
-                throwIEException(fmt::format("disabled_transformations option value {} is not supported", value));
-            }
         } else if (CONFIG_KEY(PERF_COUNT) == key) {
             perfCount = (CONFIG_VALUE(YES) == value);
         } else if (ov::hint::performance_mode == key) {
@@ -100,8 +92,6 @@ InferenceEngine::Parameter Configuration::Get(const std::string& name) const {
         return {perfCount};
     } else if (name == NVIDIA_CONFIG_KEY(OPERATION_BENCHMARK)) {
         return {std::string(operation_benchmark ? NVIDIA_CONFIG_VALUE(YES) : NVIDIA_CONFIG_VALUE(NO))};
-    } else if (name == NVIDIA_CONFIG_KEY(DISABLE_TENSORITERATOR_TRANSFORM)) {
-        return {std::string(disabled_tensoriterator_transform ? NVIDIA_CONFIG_VALUE(YES) : NVIDIA_CONFIG_VALUE(NO))};
     } else if (name == NVIDIA_CONFIG_KEY(THROUGHPUT_STREAMS)) {
         return {cuda_throughput_streams_};
     } else if (name == CONFIG_KEY(CPU_THROUGHPUT_STREAMS)) {

--- a/modules/nvidia_plugin/src/cuda_config.hpp
+++ b/modules/nvidia_plugin/src/cuda_config.hpp
@@ -37,7 +37,6 @@ struct Configuration {
     int deviceId = 0;
     bool perfCount = true;
     bool operation_benchmark = false;
-    bool disabled_tensoriterator_transform = false;
     std::string cuda_throughput_streams_ = std::to_string(1);
     InferenceEngine::IStreamsExecutor::Config streams_executor_config_;
     // TODO: Should be added usage of this property (What to do with NVIDIA_CONFIG_KEY(THROUGHPUT_STREAMS) ?)

--- a/modules/nvidia_plugin/src/transformer/bidirectional_lstm_sequence_composition.cpp
+++ b/modules/nvidia_plugin/src/transformer/bidirectional_lstm_sequence_composition.cpp
@@ -399,19 +399,12 @@ BidirectionalSequenceComposition::BidirectionalSequenceComposition(std::shared_p
     pass_config_->disable<ov::pass::BidirectionalGRUSequenceDecomposition>();
     // TODO: Uncomment when support for GRUSequence and RNNSequence will be added
     // pass_config_->disable<ov::pass::BidirectionalRNNSequenceDecomposition>();
-
-    pass_config_->disable<ov::pass::ConvertLSTMSequenceToTensorIterator>();
-    pass_config_->disable<ov::pass::ConvertGRUSequenceToTensorIterator>();
-    // TODO: Uncomment when support for GRUSequence and RNNSequence will be added
-    // pass_config_->disable<ov::pass::ConvertRNNSequenceToTensorIterator>();
 }
 
 bool BidirectionalSequenceComposition::run_on_model(const std::shared_ptr<ov::Model>& f) {
     RUN_ON_MODEL_SCOPE(BidirectionalSequenceComposition)
     Manager manager{pass_config_};
 
-    manager.register_pass<ov::pass::ConvertTensorIteratorToLSTMSequence>();
-    manager.register_pass<ov::pass::ConvertTensorIteratorToGRUSequence>();
     manager.register_pass<ov::pass::NopElimination>();
     manager.register_pass<Convert2LSTMSequenceToBidirectionalLSTMSequence>();
     manager.register_pass<ov::pass::CommonOptimizations>();

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/tensor_iterator.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/tensor_iterator.cpp
@@ -22,8 +22,6 @@ class TensorIteratorDisabledTransformationsTest : public TensorIteratorTest {
 protected:
     void SetUp() override {
         TensorIteratorTest::SetUp();
-
-        configuration[NVIDIA_CONFIG_KEY(DISABLE_TENSORITERATOR_TRANSFORM)] = NVIDIA_CONFIG_VALUE(YES);
     }
 };
 
@@ -43,7 +41,10 @@ std::vector<size_t> smoke_seq_lengths_clip_non_zero{20};
 std::vector<size_t> batch{1, 10};
 std::vector<size_t> hidden_size{1, 10, 384, 512, 768};
 std::vector<size_t> sequence_axis{0, 1};
-std::vector<ngraph::helpers::TensorIteratorBody> body_type = {ngraph::helpers::TensorIteratorBody::LSTM};
+std::vector<ngraph::helpers::TensorIteratorBody> body_type = {
+    ngraph::helpers::TensorIteratorBody::LSTM,
+    ngraph::helpers::TensorIteratorBody::GRU
+};
 std::vector<float> clip_zeros{0.f};
 std::vector<ov::op::RecurrentSequenceDirection> direction = {
     ov::op::RecurrentSequenceDirection::FORWARD,
@@ -101,7 +102,10 @@ std::vector<size_t> seq_lengths_clip_non_zero{20};
 std::vector<size_t> batch{1, 10};
 std::vector<size_t> hidden_size{1, 10};
 std::vector<size_t> sequence_axis{0, 1};
-std::vector<ngraph::helpers::TensorIteratorBody> body_type = {ngraph::helpers::TensorIteratorBody::LSTM};
+std::vector<ngraph::helpers::TensorIteratorBody> body_type = {
+    ngraph::helpers::TensorIteratorBody::LSTM,
+    ngraph::helpers::TensorIteratorBody::GRU
+};
 std::vector<float> clip_zeros{0.f};
 std::vector<ov::op::RecurrentSequenceDirection> direction = {
     ov::op::RecurrentSequenceDirection::FORWARD,


### PR DESCRIPTION
PR with changes in OpenVINO https://github.com/openvinotoolkit/openvino/pull/13470
- *Remove `ConvertTensorIteratorToLSTMSequence` and `ConvertTensorIteratorToGRUSequence` from NV plugin since `ConvertTensorIteratorToSequence` is called from `MOCTransformations`*
- *Call `ConvertSequenceToTensorIterator` for unsupported LSTM and GRU sequences*
- *Remove `DISABLE_TENSORITERATOR_TRANSFORM` config parameter*