### PR TITLE
[NVIDIA] Fix case when axis input of Interpolate is missing

### DIFF
--- a/modules/nvidia_plugin/src/ops/interpolate_nearest.cpp
+++ b/modules/nvidia_plugin/src/ops/interpolate_nearest.cpp
@@ -20,7 +20,13 @@ std::vector<float> getScalesVector(const ov::nvidia_gpu::InterpolateNearestOp::N
     // for calculation scale for nearest mode see
     // https://docs.openvino.ai/2021.1/openvino_docs_ops_image_Interpolate_4.html
     const auto scales = ngraph::get_constant_from_source(node.input_value(2))->cast_vector<float>();
-    const auto axis = ngraph::get_constant_from_source(node.input_value(3))->cast_vector<int64_t>();
+    std::vector<int64_t> axis;
+    if (node.inputs().size() > 3) {
+        axis = ngraph::get_constant_from_source(node.input_value(3))->cast_vector<int64_t>();
+    } else {
+        axis.resize(node.get_input_partial_shape(0).rank().get_length());
+        std::iota(axis.begin(), axis.end(), 0);
+    }
 
     const auto& input_shape = node.get_input_shape(0);
     const auto& output_shape = node.get_output_shape(0);

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/interpolate.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/interpolate.cpp
@@ -91,7 +91,7 @@ const std::vector<double> defaultCubeCoeff = {
     -0.75f,
 };
 
-const std::vector<std::vector<int64_t>> smokeTest4DAxes = {{0, 1, 2, 3}};
+const std::vector<std::vector<int64_t>> smokeTest4DAxes = {{0, 1, 2, 3}, {}};
 const std::vector<std::vector<float>> smokeTest4DScales = {{1.f, 1.f, 2.f, 2.f}};
 const std::vector<std::vector<int64_t>> smokeTest2DAxes = {{2, 3}};
 const std::vector<std::vector<float>> smokeTest2DScales = {{2.f, 2.f}};


### PR DESCRIPTION
- *Fix case when axis input of Interpolate is missing (default value [0,...,rank(data) - 1])*