### PR TITLE
[NVIDIA] Reuse common function for query model

### DIFF
--- a/modules/nvidia_plugin/src/transformer/cuda_graph_transformer.hpp
+++ b/modules/nvidia_plugin/src/transformer/cuda_graph_transformer.hpp
@@ -15,29 +15,58 @@ namespace nvidia_gpu {
 
 class GraphTransformer {
 public:
-    std::shared_ptr<ov::Model> export_transform(const CUDA::Device& device,
-                                                const std::shared_ptr<const ov::Model>& function,
-                                                const InferenceEngine::InputsDataMap& inputInfoMap,
-                                                const InferenceEngine::OutputsDataMap& outputsInfoMap,
-                                                const Configuration& config) const;
     /**
-     * @brief Transform takes an ov::Model and applies all the necessary
-     *        graph transofrmations to achieve the maximum optimization of the
+     * @brief Transform takes an ov::Model and applies common OpenVino
+     *        graph transformations.
+     * @param function a valid shared ptr to a model, represented as an
+     *        ov::Model instance.
+     * @param config a string-string map of configuration for loading an
+     *  executable network (e.g. a model); this config influences on what exact
+     *        transformations are being applied to the original graph.
+     */
+    void common_transform(const CUDA::Device& device,
+                          const std::shared_ptr<ov::Model>& model,
+                          const InferenceEngine::InputsDataMap& inputInfoMap,
+                          const InferenceEngine::OutputsDataMap& outputsInfoMap,
+                          const Configuration& config) const;
+
+    std::shared_ptr<ov::Model> clone_and_export_transform(const CUDA::Device& device,
+                                                          const std::shared_ptr<const ov::Model>& model,
+                                                          const InferenceEngine::InputsDataMap& inputInfoMap,
+                                                          const InferenceEngine::OutputsDataMap& outputsInfoMap,
+                                                          const Configuration& config) const;
+    /**
+     * @brief Transform takes an ov::Model and applies only
+     *        CUDA-specific transformations to achieve the maximum optimization of the
      *        model for execution on a CUDA device. The transformations may
-     *        include CUDA-specific op fusions and some common OpenVino
-     *        transformations as well.
+     *        includes CUDA-specific op fusions.
      * @param function a valid shared ptr to a model, represented as an
      *        ov::Model instance.
      * @param config a string-string map of configuration for loading an
      * executable network (e.g. a model); this config influences on what exact
      *        transformations are being applied to the original graph.
-     * @return an ov::Model containing only the CUDA-optimized operations.
      */
-    std::shared_ptr<ov::Model> transform(const CUDA::Device& device,
-                                        const std::shared_ptr<const ov::Model>& function,
-                                        const InferenceEngine::InputsDataMap& inputInfoMap,
-                                        const InferenceEngine::OutputsDataMap& outputsInfoMap,
-                                        const Configuration& config) const;
+    void cuda_transform(const CUDA::Device& device,
+                        const std::shared_ptr<ov::Model>& model,
+                        const Configuration& config) const;
+
+     /**
+      * @brief Transform takes an ov::Model and applies all the necessary
+      *        CUDA-specific transformations to achieve the maximum optimization of the
+      *        model for execution on a CUDA device. The transformations may
+      *        include CUDA-specific op fusions and some common OpenVino
+      *        transformations as well.
+      * @param function a valid shared ptr to a model, represented as an
+      *        ov::Model instance.
+      * @param config a string-string map of configuration for loading an
+      * executable network (e.g. a model); this config influences on what exact
+      *        transformations are being applied to the original graph.
+      */
+    void transform(const CUDA::Device& device,
+                   const std::shared_ptr<ov::Model>& model,
+                   const InferenceEngine::InputsDataMap& inputInfoMap,
+                   const InferenceEngine::OutputsDataMap& outputsInfoMap,
+                   const Configuration& config) const;
 };
 
 }  // namespace nvidia_gpu


### PR DESCRIPTION
- *Reuse common function `InferenceEngine::GetSupportedNodes` in `QueryNetwork`*
- *Refactor transformation pipeline to avoid transformation dubplication for exported model*

Relates:
PR with some fixes in HETERO part: https://github.com/openvinotoolkit/openvino/pull/13766
PR with fix for QN test: https://github.com/openvinotoolkit/openvino/pull/14601