### PR TITLE
[NVIDIA] Fix MatMul shape broadcast when A rank is equal to B rank

### DIFF
--- a/modules/nvidia_plugin/src/ops/matmul.cpp
+++ b/modules/nvidia_plugin/src/ops/matmul.cpp
@@ -147,12 +147,11 @@ void MatMulOp::BroadcastShapes(
     } else if (matrixAShape.size() > 1 && matrixBShape.size() > 1) {
         // ND x ND: [B, ..., X, Y] x [B, ..., Y, Z] => [B, ..., X, Z]
         auto broadcastNdToMd = [](const auto& shapeToBroadcast, auto& broadcastShape) {
-            Expects(shapeToBroadcast.size() > broadcastShape.size());
-            const size_t abShapeDiff = shapeToBroadcast.size() - broadcastShape.size();
+            Expects(shapeToBroadcast.size() >= broadcastShape.size());
             std::vector<size_t> newAxies;
             newAxies.reserve(shapeToBroadcast.size());
-            newAxies.insert(newAxies.end(), shapeToBroadcast.begin(), shapeToBroadcast.begin() + abShapeDiff);
-            newAxies.insert(newAxies.end(), broadcastShape.begin(), broadcastShape.end());
+            newAxies.insert(newAxies.end(), shapeToBroadcast.begin(), shapeToBroadcast.end() - 2);
+            newAxies.insert(newAxies.end(), broadcastShape.end() - 2, broadcastShape.end());
             broadcastShape = ov::Shape{newAxies};
         };
         const size_t batchA = GetMatrixNumBatches(matrixAShape);

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/mat_mul.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/mat_mul.cpp
@@ -50,10 +50,22 @@ const std::vector<ShapeRelatedParams> smokeShapeRelatedParams = {
     {{{3, 2, 20, 10}, true}, {{3, 2, 10, 20}, true}},
 
     // ND x ND: [B, ..., X, Y] x [B, ..., Y, Z] => [B, ..., X, Z]
+    {{{3, 2, 10, 10}, false}, {{1, 1, 10, 20}, false}},
+    {{{3, 2, 10, 10}, true}, {{1, 1, 10, 20}, false}},
+    {{{3, 2, 10, 20}, false}, {{1, 1, 10, 20}, true}},
+    {{{3, 2, 20, 10}, true}, {{1, 1, 10, 20}, true}},
+
+    // ND x ND: [B, ..., X, Y] x [B, ..., Y, Z] => [B, ..., X, Z]
     {{{2, 10, 10}, false}, {{2, 10, 20}, false}},
     {{{2, 10, 10}, true}, {{2, 10, 20}, false}},
     {{{2, 10, 20}, false}, {{2, 10, 20}, true}},
     {{{2, 20, 10}, true}, {{2, 10, 20}, true}},
+
+    // ND x ND: [B, ..., X, Y] x [B, ..., Y, Z] => [B, ..., X, Z]
+    {{{2, 10, 10}, false}, {{1, 10, 20}, false}},
+    {{{2, 10, 10}, true}, {{1, 10, 20}, false}},
+    {{{2, 10, 20}, false}, {{1, 10, 20}, true}},
+    {{{2, 20, 10}, true}, {{1, 10, 20}, true}},
 
     // ND x ND: [B, ..., X, Y] x [B, ..., Y, Z] => [B, ..., X, Z]
     {{{10, 10}, false}, {{10, 20}, false}},


### PR DESCRIPTION
- *Fix MatMul shape broadcast when A rank is equal to B rank*