### PR TITLE
'History CUDA' move to ubuntu-22.04 runner

### DIFF
--- a/.github/workflows/history_cuda.yml
+++ b/.github/workflows/history_cuda.yml
@@ -8,7 +8,7 @@ on:
       - 'modules/nvidia_plugin/**'
 jobs:
   history:
-    runs-on: lohika-ci
+    runs-on: ubuntu-22.04
     steps:
     - name: checkout master branch
       run: git -C ~/runner/openvino_contrib checkout master


### PR DESCRIPTION
Moving 'History CUDA' workload to be run on GitHub-hosted ubuntu-22.04 runner.