### PR TITLE
[ARM Plugin] Fix DecomposeVariadicSplit transformation if input node has more than 1 output 

### DIFF
--- a/modules/arm_plugin/src/transformations/decompose_variadic_split.cpp
+++ b/modules/arm_plugin/src/transformations/decompose_variadic_split.cpp
@@ -21,7 +21,7 @@ ArmPlugin::pass::DecomposeVariadicSplit::DecomposeVariadicSplit() {
         auto input = split->input_value(0).get_node_shared_ptr();
         auto axes = std::dynamic_pointer_cast<opset::Constant>(split->input_value(1).get_node_shared_ptr());
         auto split_lengths = std::dynamic_pointer_cast<opset::Constant>(split->input_value(2).get_node_shared_ptr());
-        auto input_shape = input->get_shape();
+        auto input_shape = split->get_input_shape(0);
         auto size = input_shape.size();
 
 


### PR DESCRIPTION
Propagation of https://github.com/openvinotoolkit/openvino_contrib/pull/555
