### PR TITLE
[NVIDIA] Disable some tests to pass CI

### DIFF
--- a/modules/nvidia_plugin/tests/functional/skip_tests_config.cpp
+++ b/modules/nvidia_plugin/tests/functional/skip_tests_config.cpp
@@ -116,6 +116,9 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*GroupConvolutionBias(Add|AddAdd)ActivationLayerTest.*IS=\(2\.16\.12\.6\).*K\(3\.3\).*S\(1\.1\).*PB\(0\.3\).*PE\(0\.3\).*D=\(1\.1\).*O=(8|32).*G=2.*AP=explicit.*netPRC=FP16*.*)",
         // 101751, 101746, 101747, 101748, 101755
         R"(.*(d|D)ynamic*.*)",
+        // 101753
+        R"(.*TensorIteratorDisabledTransformationsTest*.*GRU_direction=reverse*.*)",
+        R"(.*GRUCellCommon_01*.*FP16*.*)",
     };
 
 #ifdef _WIN32


### PR DESCRIPTION
*Disable some tests which are not working currently on CI. CUDNN 8.1.0 is installed currently where there is problem with CUDNN_RNN_ALGO_STANDARD implementation for RNN component*: https://github.com/openvinotoolkit/openvino_contrib/blob/ef910366978efc2508a514259286219fbc302d51/modules/nvidia_plugin/src/ops/rnn_components/rnn_cudnn_components.cpp#L410

*That's why CUDNN_RNN_ALGO_PERSIST_STATIC is used, but it leads to CUDNN_STATUS_NOT_SUPPORTED. Problem have to insvestigated, disable some tests temporarely*

Tickets:
- *[101753](https://jira.devtools.intel.com/browse/CVS-101753)*