### PR TITLE
Update benchmark_app to support NVIDIA Plugin configuration

### DIFF
--- a/modules/nvidia_plugin/utils/openvino_patches/benchmark_app_phase1.patch
+++ b/modules/nvidia_plugin/utils/openvino_patches/benchmark_app_phase1.patch
@@ -1,59 +1,63 @@
-diff --git a/inference-engine/samples/benchmark_app/CMakeLists.txt b/inference-engine/samples/benchmark_app/CMakeLists.txt
-index b37495e5e..9dc5da800 100644
---- a/inference-engine/samples/benchmark_app/CMakeLists.txt
-+++ b/inference-engine/samples/benchmark_app/CMakeLists.txt
-@@ -10,3 +10,4 @@ ie_add_sample(NAME benchmark_app
+diff --git a/samples/cpp/benchmark_app/CMakeLists.txt b/samples/cpp/benchmark_app/CMakeLists.txt
+index 4cb34fe1f4..792f4579c5 100644
+--- a/samples/cpp/benchmark_app/CMakeLists.txt
++++ b/samples/cpp/benchmark_app/CMakeLists.txt
+@@ -10,7 +10,7 @@ file (GLOB HDR ${CMAKE_CURRENT_SOURCE_DIR}/*.hpp)
+ ie_add_sample(NAME ${TARGET_NAME}
+               SOURCES ${SRC}
                HEADERS ${HDR}
-               DEPENDENCIES format_reader ie_samples_utils
-               OPENCV_DEPENDENCIES core)
-+add_dependencies(benchmark_app openvino_nvidia_gpu_plugin)
-diff --git a/inference-engine/samples/benchmark_app/benchmark_app.hpp b/inference-engine/samples/benchmark_app/benchmark_app.hpp
-index af18c908e..d55baa34c 100644
---- a/inference-engine/samples/benchmark_app/benchmark_app.hpp
-+++ b/inference-engine/samples/benchmark_app/benchmark_app.hpp
-@@ -62,6 +62,9 @@ static const char enforce_bf16_message[] = "Optional. By default floating point
-                                            "                                  'true'  - enable  bfloat16 regardless of platform support\n"
-                                            "                                  'false' - disable bfloat16 regardless of platform support";
+-              DEPENDENCIES ${GFLAGS_TARGET} format_reader ie_samples_utils)
++              DEPENDENCIES ${GFLAGS_TARGET} format_reader ie_samples_utils openvino_nvidia_gpu_plugin)
+ 
+ # Required nlohmann_json dependency
+ 
+diff --git a/samples/cpp/benchmark_app/benchmark_app.hpp b/samples/cpp/benchmark_app/benchmark_app.hpp
+index 6ea383f5e4..fab5636d01 100644
+--- a/samples/cpp/benchmark_app/benchmark_app.hpp
++++ b/samples/cpp/benchmark_app/benchmark_app.hpp
+@@ -257,6 +257,9 @@ static constexpr char inference_only_message[] =
+     " To enable full mode for static models pass \"false\" value to this argument:"
+     " ex. \"-inference_only=false\".\n";
  
 +/// @brief message for optimization mode
 +static const char op_bench_mode_message[] = "Optional. Operator level benchmark on particular device";
 +
- /// @brief message for user library argument
- static const char custom_cpu_library_message[] = "Required for CPU custom layers. Absolute path to a shared library with the kernels "
-                                                  "implementations.";
-@@ -192,6 +195,9 @@ DEFINE_string(nstreams, "", infer_num_streams_message);
- /// @brief Enforces bf16 execution with bfloat16 precision on systems having this capability
- DEFINE_bool(enforcebf16, false, enforce_bf16_message);
+ /// @brief Define flag for showing help message <br>
+ DEFINE_bool(h, false, help_message);
+ 
+@@ -387,6 +390,9 @@ DEFINE_string(scale_values, "", scale_values_message);
+ /// @brief Define flag for inference only mode <br>
+ DEFINE_bool(inference_only, true, inference_only_message);
  
 +/// @brief Optimization mode for particular device
 +DEFINE_bool(op_bench, false, op_bench_mode_message);
 +
- /// @brief Define parameter for batch size <br>
- /// Default is 0 (that means don't specify)
- DEFINE_uint32(b, 0, batch_size_message);
-@@ -288,6 +294,7 @@ static void showUsage() {
-     std::cout << "    -report_folder            " << report_folder_message << std::endl;
-     std::cout << "    -exec_graph_path          " << exec_graph_path_message << std::endl;
-     std::cout << "    -pc                       " << pc_message << std::endl;
+ /**
+  * @brief This function show a help message
+  */
+@@ -428,6 +434,7 @@ static void show_usage() {
+     std::cout << "    -json_stats             " << json_stats_message << std::endl;
+     std::cout << "    -exec_graph_path        " << exec_graph_path_message << std::endl;
+     std::cout << "    -pc                     " << pc_message << std::endl;
 +    std::cout << "    -op_bench                 " << op_bench_mode_message << std::endl;
- #ifdef USE_OPENCV
-     std::cout << "    -dump_config              " << dump_config_message << std::endl;
-     std::cout << "    -load_config              " << load_config_message << std::endl;
-diff --git a/inference-engine/samples/benchmark_app/main.cpp b/inference-engine/samples/benchmark_app/main.cpp
-index cd7ddc641..c638f4f4e 100644
---- a/inference-engine/samples/benchmark_app/main.cpp
-+++ b/inference-engine/samples/benchmark_app/main.cpp
-@@ -295,6 +295,13 @@ int main(int argc, char* argv[]) {
- 
-                 if (isFlagSetInCommandLine("nthreads"))
-                     device_config[GNA_CONFIG_KEY(LIB_N_THREADS)] = std::to_string(FLAGS_nthreads);
+     std::cout << "    -pcsort                 " << pc_sort_message << std::endl;
+     std::cout << "    -pcseq                  " << pcseq_message << std::endl;
+     std::cout << "    -dump_config            " << dump_config_message << std::endl;
+diff --git a/samples/cpp/benchmark_app/main.cpp b/samples/cpp/benchmark_app/main.cpp
+index 5be1d8eb9d..a48a835e10 100644
+--- a/samples/cpp/benchmark_app/main.cpp
++++ b/samples/cpp/benchmark_app/main.cpp
+@@ -604,6 +604,13 @@ int main(int argc, char* argv[]) {
+                     }
+                 }
+                 device_nstreams.erase(device);
 +            } else if (device == "NVIDIA") {
 +                setThroughputStreams();
 +                if (isFlagSetInCommandLine("op_bench")) {
-+                  device_config["CUDA_OPERATION_BENCHMARK"] = FLAGS_op_bench ?
-        +                                                      std::string("CUDA_YES") :
-        +                                                      std::string("CUDA_NO");
++                  device_config["NVIDIA_OPERATION_BENCHMARK"] = FLAGS_op_bench ?
++                                                              std::string("NVIDIA_YES") :
++                                                              std::string("NVIDIA_NO");
 +                }
-             } else {
-                 std::vector<std::string> supported_config_keys = ie.GetMetric(device, METRIC_KEY(SUPPORTED_CONFIG_KEYS));
-                 auto supported = [&](const std::string& key) {
+             }
+         }
+ 


### PR DESCRIPTION
Original benchmark_app doesn't support NVIDIA Plugin configuration. The patch aims to add support of the following NVIDIA Plugin configuration options in the benchmark_app:
* -op_bench option which enables per layer benchmarking to find the most optimal algorithm for each layer
* -nstreams option allows to configure number of CUDA streams

Usage example:
benchmark_app -m /path/to/model -d NVIDIA -ip FP32 -nstreams -op_bench
