### PR TITLE
Remove the include about variant.hpp, which had been deprecated

### DIFF
--- a/modules/arm_plugin/src/opset/quantize.hpp
+++ b/modules/arm_plugin/src/opset/quantize.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <ngraph/variant.hpp>
 #include "ngraph/coordinate_diff.hpp"
 #include "ngraph_opset.hpp"
 #include "utils.hpp"

--- a/modules/arm_plugin/src/opset/utils.hpp
+++ b/modules/arm_plugin/src/opset/utils.hpp
@@ -6,7 +6,6 @@
 
 #include <ie_common.h>
 #include <ngraph/node.hpp>
-#include <ngraph/variant.hpp>
 #include "arm_compute/core/QuantizationInfo.h"
 #include "arm_compute/core/Types.h"
 

--- a/modules/arm_plugin/src/transformations/quantize_fusion.cpp
+++ b/modules/arm_plugin/src/transformations/quantize_fusion.cpp
@@ -13,7 +13,6 @@
 #include <ie_algorithm.hpp>
 
 #include <ngraph/rt_info.hpp>
-#include <ngraph/variant.hpp>
 #include <ov_ops/type_relaxed.hpp>
 
 #include "opset/opset.hpp"

--- a/modules/arm_plugin/src/transformations/quantize_fusion.hpp
+++ b/modules/arm_plugin/src/transformations/quantize_fusion.hpp
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <ngraph/pass/graph_rewrite.hpp>
-#include <ngraph/variant.hpp>
 
 namespace ArmPlugin {
 namespace pass {

--- a/modules/nvidia_plugin/src/ops/result.cpp
+++ b/modules/nvidia_plugin/src/ops/result.cpp
@@ -9,7 +9,6 @@
 #include <cuda_operation_registry.hpp>
 #include <exec_graph_info.hpp>
 #include <gsl/gsl_assert>
-#include <ngraph/variant.hpp>
 #include <transformations/rt_info/fused_names_attribute.hpp>
 #include <transformer/cuda_rt_info.hpp>
 #include <utility>

--- a/modules/nvidia_plugin/src/transformer/bidirectional_lstm_sequence_composition.cpp
+++ b/modules/nvidia_plugin/src/transformer/bidirectional_lstm_sequence_composition.cpp
@@ -12,7 +12,6 @@
 #include "openvino/pass/manager.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include <ngraph/rt_info.hpp>
-#include <ngraph/variant.hpp>
 #include <openvino/op/concat.hpp>
 #include <openvino/op/lstm_sequence.hpp>
 #include <openvino/op/reshape.hpp>

--- a/modules/nvidia_plugin/src/transformer/concat_transformation.cpp
+++ b/modules/nvidia_plugin/src/transformer/concat_transformation.cpp
@@ -8,7 +8,6 @@
 #include <exec_graph_info.hpp>
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include <ngraph/rt_info.hpp>
-#include <ngraph/variant.hpp>
 #include <openvino/op/concat.hpp>
 
 #include "nodes/concat_optimized.hpp"

--- a/modules/nvidia_plugin/src/transformer/cuda_fullyconnected_transformation.cpp
+++ b/modules/nvidia_plugin/src/transformer/cuda_fullyconnected_transformation.cpp
@@ -8,7 +8,6 @@
 #include <exec_graph_info.hpp>
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include <ngraph/rt_info.hpp>
-#include <ngraph/variant.hpp>
 #include <openvino/op/add.hpp>
 #include <openvino/op/matmul.hpp>
 #include <ops/matmul.hpp>

--- a/modules/nvidia_plugin/src/transformer/matmul_transformations.cpp
+++ b/modules/nvidia_plugin/src/transformer/matmul_transformations.cpp
@@ -10,7 +10,6 @@
 #include <gsl/span_ext>
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include <ngraph/rt_info.hpp>
-#include <ngraph/variant.hpp>
 #include <openvino/op/matmul.hpp>
 #include <openvino/op/transpose.hpp>
 

--- a/modules/nvidia_plugin/src/transformer/remove_duplicated_results_transformation.cpp
+++ b/modules/nvidia_plugin/src/transformer/remove_duplicated_results_transformation.cpp
@@ -10,7 +10,6 @@
 #include <gsl/span_ext>
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include <ngraph/rt_info.hpp>
-#include <ngraph/variant.hpp>
 #include <openvino/op/matmul.hpp>
 #include <openvino/op/transpose.hpp>
 


### PR DESCRIPTION
Signed-off-by: xuejun <Xuejun.Zhai@intel.com>
Tickets: 100091
Because variantImpl & variantwrapper related class/interfaces will be deprecated in PR: 15580
Remove the related reference to variant.hpp
