### PR TITLE
[NVIDIA]: Enable new property API

### DIFF
--- a/modules/nvidia_plugin/include/nvidia/properties.hpp
+++ b/modules/nvidia_plugin/include/nvidia/properties.hpp
@@ -1,0 +1,28 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/**
+ * @brief A header for advanced hardware related properties for NVIDIA plugin
+ *        To use in set_property, compile_model, import_model, get_property methods
+ *
+ * @file nvidia/properties.hpp
+ */
+#pragma once
+
+#include "openvino/runtime/properties.hpp"
+
+namespace ov {
+
+/**
+ * @brief Namespace with NVIDIA GPU specific properties
+ */
+namespace nvidia_gpu {
+
+/**
+ * @brief Defines if optimization should be run for CUDA libraries
+ */
+static constexpr Property<bool, PropertyMutability::RW> operation_benchmark{"NVIDIA_OPERATION_BENCHMARK"};
+
+}  // namespace nvidia_gpu
+}  // namespace ov

--- a/modules/nvidia_plugin/src/cuda_config.cpp
+++ b/modules/nvidia_plugin/src/cuda_config.cpp
@@ -10,71 +10,179 @@
 #include <error.hpp>
 #include <regex>
 
+#include "nvidia/properties.hpp"
+
 using namespace ov::nvidia_gpu;
 
 Configuration::Configuration() {}
+
+std::vector<ov::PropertyName> Configuration::get_ro_properties() {
+    static const std::vector<ov::PropertyName> ro_properties = {
+        // Metrics
+        ov::PropertyName{ov::available_devices.name(), ov::PropertyMutability::RO},
+        ov::PropertyName{ov::caching_properties.name(), ov::PropertyMutability::RO},
+        ov::PropertyName{ov::supported_properties.name(), ov::PropertyMutability::RO},
+        ov::PropertyName{ov::range_for_streams.name(), ov::PropertyMutability::RO},
+        ov::PropertyName{ov::range_for_async_infer_requests.name(), ov::PropertyMutability::RO},
+        ov::PropertyName{ov::device::architecture.name(), ov::PropertyMutability::RO},
+        ov::PropertyName{ov::device::capabilities.name(), ov::PropertyMutability::RO},
+        ov::PropertyName{ov::device::full_name.name(), ov::PropertyMutability::RO},
+        ov::PropertyName{ov::device::uuid.name(), ov::PropertyMutability::RO}
+    };
+    return ro_properties;
+}
+
+std::vector<ov::PropertyName> Configuration::get_rw_properties() {
+    static const std::vector<ov::PropertyName> rw_properties = {
+        // Configs
+        ov::PropertyName{ov::device::id.name(), ov::PropertyMutability::RW},
+        ov::PropertyName{ov::inference_precision.name(), ov::PropertyMutability::RW},
+        ov::PropertyName{ov::num_streams.name(), ov::PropertyMutability::RW},
+        ov::PropertyName{ov::hint::num_requests.name(), ov::PropertyMutability::RW},
+        ov::PropertyName{ov::hint::performance_mode.name(), ov::PropertyMutability::RW},
+        ov::PropertyName{ov::hint::execution_mode.name(), ov::PropertyMutability::RW},
+        ov::PropertyName{ov::enable_profiling.name(), ov::PropertyMutability::RW},
+        ov::PropertyName{ov::nvidia_gpu::operation_benchmark.name(), ov::PropertyMutability::RW},
+    };
+    return rw_properties;
+}
+
+bool Configuration::is_rw_property(const std::string& name) {
+    auto supported_rw_properties = get_rw_properties();
+    return (std::find(supported_rw_properties.begin(),
+                        supported_rw_properties.end(), name) != supported_rw_properties.end());
+};
+
+std::vector<ov::PropertyName> Configuration::get_supported_properties() {
+    const std::vector<ov::PropertyName> ro_properties = get_ro_properties();
+    const std::vector<ov::PropertyName> rw_properties = get_rw_properties();
+    std::vector<ov::PropertyName> supported_properties(std::begin(ro_properties), std::end(ro_properties));
+    supported_properties.insert(std::end(supported_properties), std::begin(rw_properties), std::end(rw_properties));
+    return supported_properties;
+}
+
+std::vector<ov::PropertyName> Configuration::get_caching_properties() {
+    static const std::vector<ov::PropertyName> caching_properties = {
+        ov::PropertyName{ov::device::architecture.name(), ov::PropertyMutability::RO},
+        ov::PropertyName{ov::inference_precision.name(), ov::PropertyMutability::RW},
+        ov::PropertyName{ov::hint::execution_mode.name(), ov::PropertyMutability::RW}
+    };
+    return caching_properties;
+}
+
+void Configuration::update_device_id(const ConfigMap& config) {
+    auto it = config.find(ov::device::id.name());
+    if (it == config.end())
+        it = config.find(CONFIG_KEY(DEVICE_ID));
+    if (it != config.end()) {
+        auto value = it->second;
+        std::smatch match;
+        std::regex re_device_id(R"((NVIDIA\.)?(\d+))");
+        if (std::regex_match(value, match, re_device_id)) {
+            const std::string device_id_prefix = match[1].str();
+            const std::string device_id_value = match[2].str();
+            if (!device_id_prefix.empty() && "NVIDIA." != device_id_prefix) {
+                throwIEException(
+                    fmt::format("Prefix for deviceId should be 'NVIDIA.' (user deviceId = {}). "
+                                "For example: NVIDIA.0, NVIDIA.1 and etc.",
+                                value));
+            }
+            deviceId = std::stoi(device_id_value);
+            if (deviceId < 0) {
+                throwIEException(fmt::format(
+                    "Device ID {} is not supported. Index should be >= 0 (user index = {})", value, deviceId));
+            }
+        } else {
+            throwIEException(
+                fmt::format("Device ID {} is not supported. Supported deviceIds: 0, 1, 2, NVIDIA.0, NVIDIA.1, "
+                            "NVIDIA.2 and etc.",
+                            value));
+        }
+    }
+}
+
+ov::element::Type Configuration::get_inference_precision() const noexcept {
+    return inference_precision;
+    /*
+    Uncomment this code to switch to f16 by default
+    if (inference_precision != ov::element::undefined)
+        return inference_precision;
+    if (execution_mode == ov::hint::ExecutionMode::PERFORMANCE ||
+        execution_mode == ov::hint::ExecutionMode::UNDEFINED) {
+        if (isHalfSupported(CUDA::Device(deviceId))) {
+            return ov::element::f16;
+        }
+    }
+    return ov::element::f32; */
+}
+
+uint32_t Configuration::get_optimal_number_of_streams() const noexcept {
+    // Default number for latency mode
+    uint32_t optimal_number_of_streams = 1;
+    if ((ov::hint::PerformanceMode::THROUGHPUT == performance_mode) ||
+        (ov::hint::PerformanceMode::UNDEFINED == performance_mode && num_streams == ov::streams::AUTO)) {
+        // If user is planning to use number of requests which is lower than reasonable range of streams
+        // there is no sense to create more
+        optimal_number_of_streams = (hint_num_requests > 0) ?
+            std::min(hint_num_requests, reasonable_limit_of_streams)
+            : reasonable_limit_of_streams;
+    }
+    if (num_streams > 0) {
+        optimal_number_of_streams = num_streams;
+    }
+    return optimal_number_of_streams;
+}
 
 Configuration::Configuration(const ConfigMap& config, const Configuration& defaultCfg, bool throwOnUnsupported) {
     *this = defaultCfg;
     // If plugin needs to use InferenceEngine::StreamsExecutor it should be able to process its configuration
     auto streamExecutorConfigKeys = streams_executor_config_.SupportedKeys();
+    // Update device id first
+    update_device_id(config);
     for (auto&& c : config) {
         const auto& key = c.first;
         const auto& value = c.second;
 
-        if (NVIDIA_CONFIG_KEY(THROUGHPUT_STREAMS) == key) {
+        if (ov::num_streams == key) {
+            num_streams = ov::util::from_string(value, ov::num_streams);
+        } if (NVIDIA_CONFIG_KEY(THROUGHPUT_STREAMS) == key) {
             if (value != NVIDIA_CONFIG_VALUE(THROUGHPUT_AUTO)) {
                 try {
-                    std::stoi(value);
+                    num_streams = ov::streams::Num(std::stoi(value));
                 } catch (...) {
                     throwIEException(
                         fmt::format("NVIDIA_CONFIG_KEY(THROUGHPUT_STREAMS) = {} "
                                     "is not a number !!",
                                     value));
                 }
+            } else {
+                num_streams = ov::streams::AUTO;
             }
-            cuda_throughput_streams_ = value;
-        } else if (CONFIG_KEY(CPU_THROUGHPUT_STREAMS) == key) {
-            streams_executor_config_.SetConfig(CONFIG_KEY(CPU_THROUGHPUT_STREAMS), value);
+        } else if (ov::device::id == key || CONFIG_KEY(DEVICE_ID) == key) {
+            // Device id is updated already
+            continue;
         } else if (streamExecutorConfigKeys.end() !=
                    std::find(std::begin(streamExecutorConfigKeys), std::end(streamExecutorConfigKeys), key)) {
             streams_executor_config_.SetConfig(key, value);
-        } else if (CONFIG_KEY(DEVICE_ID) == key) {
-            std::smatch match;
-            std::regex re_device_id(R"((NVIDIA\.)?(\d+))");
-            if (std::regex_match(value, match, re_device_id)) {
-                const std::string device_id_prefix = match[1].str();
-                const std::string device_id_value = match[2].str();
-                if (!device_id_prefix.empty() && "NVIDIA." != device_id_prefix) {
-                    throwIEException(
-                        fmt::format("Prefix for deviceId should be 'NVIDIA.' (user deviceId = {}). "
-                                    "For example: NVIDIA.0, NVIDIA.1 and etc.",
-                                    value));
-                }
-                deviceId = std::stoi(device_id_value);
-                if (deviceId < 0) {
-                    throwIEException(fmt::format(
-                        "Device ID {} is not supported. Index should be >= 0 (user index = {})", value, deviceId));
-                }
-            } else {
-                throwIEException(
-                    fmt::format("Device ID {} is not supported. Supported deviceIds: 0, 1, 2, NVIDIA.0, NVIDIA.1, "
-                                "NVIDIA.2 and etc.",
-                                value));
+        } else if (ov::nvidia_gpu::operation_benchmark == key || NVIDIA_CONFIG_KEY(OPERATION_BENCHMARK) == key) {
+            operation_benchmark = ov::util::from_string(value, ov::nvidia_gpu::operation_benchmark);
+        } else if (ov::enable_profiling == key) {
+            is_profiling_enabled = ov::util::from_string(value, ov::enable_profiling);
+        } else if (ov::hint::num_requests == key) {
+            hint_num_requests = ov::util::from_string(value, ov::hint::num_requests);
+        } else if (ov::hint::inference_precision == key) {
+            auto element_type = ov::util::from_string(value, ov::inference_precision);
+            const std::set<ov::element::Type> supported_types = {
+                ov::element::undefined, ov::element::f16, ov::element::f32,
+            };
+            if (supported_types.count(element_type) == 0) {
+                throwIEException(fmt::format("Inference precision {} is not supported by plugin", value));
             }
-        } else if (NVIDIA_CONFIG_KEY(OPERATION_BENCHMARK) == key) {
-            if (value == NVIDIA_CONFIG_VALUE(YES)) {
-                operation_benchmark = true;
-            } else if (value == NVIDIA_CONFIG_VALUE(NO)) {
-                operation_benchmark = false;
-            } else {
-                throwIEException(fmt::format("operation benchmark option value {} is not supported", value));
-            }
-        } else if (CONFIG_KEY(PERF_COUNT) == key) {
-            perfCount = (CONFIG_VALUE(YES) == value);
+            inference_precision = element_type;
         } else if (ov::hint::performance_mode == key) {
-            std::stringstream strm{value};
-            strm >> performance_mode;
+            performance_mode = ov::util::from_string(value, ov::hint::performance_mode);
+        } else if (ov::hint::execution_mode == key) {
+            execution_mode = ov::util::from_string(value, ov::hint::execution_mode);
         } else if (throwOnUnsupported) {
             throwNotFound(key);
         }
@@ -86,31 +194,28 @@ InferenceEngine::Parameter Configuration::Get(const std::string& name) const {
     if ((streamExecutorConfigKeys.end() !=
          std::find(std::begin(streamExecutorConfigKeys), std::end(streamExecutorConfigKeys), name))) {
         return streams_executor_config_.GetConfig(name);
-    } else if (name == CONFIG_KEY(DEVICE_ID)) {
+    } else if (name == ov::device::id || name == CONFIG_KEY(DEVICE_ID)) {
         return {std::to_string(deviceId)};
-    } else if (name == CONFIG_KEY(PERF_COUNT)) {
-        return {perfCount};
-    } else if (name == NVIDIA_CONFIG_KEY(OPERATION_BENCHMARK)) {
-        return {std::string(operation_benchmark ? NVIDIA_CONFIG_VALUE(YES) : NVIDIA_CONFIG_VALUE(NO))};
-    } else if (name == NVIDIA_CONFIG_KEY(THROUGHPUT_STREAMS)) {
-        return {cuda_throughput_streams_};
-    } else if (name == CONFIG_KEY(CPU_THROUGHPUT_STREAMS)) {
-        return {std::to_string(streams_executor_config_._streams)};
-    } else if (name == CONFIG_KEY(CPU_BIND_THREAD)) {
-        return const_cast<InferenceEngine::IStreamsExecutor::Config&>(streams_executor_config_).GetConfig(name);
-    } else if (name == CONFIG_KEY(CPU_THREADS_NUM)) {
-        return {std::to_string(streams_executor_config_._threads)};
-    } else if (name == CONFIG_KEY_INTERNAL(CPU_THREADS_PER_STREAM)) {
-        return {std::to_string(streams_executor_config_._threadsPerStream)};
+    } else if (name == ov::enable_profiling || name == CONFIG_KEY(PERF_COUNT)) {
+        return is_profiling_enabled;
+    } else if (name == ov::nvidia_gpu::operation_benchmark || name == NVIDIA_CONFIG_KEY(OPERATION_BENCHMARK)) {
+        return operation_benchmark;
     } else if (name == ov::num_streams) {
-        return {std::to_string(streams_executor_config_._streams)};
-    } else if (name == ov::inference_num_threads) {
-        return {std::to_string(streams_executor_config_._threads)};
-        // TODO: Refactoring
-        //    } else if (name == ov::affinity) {
-        //        return {std::to_string(streams_executor_config_._threadPreferredCoreType)};
+        return (num_streams == 0) ?
+            ov::streams::Num(get_optimal_number_of_streams()) : num_streams;
+    } else if (name == NVIDIA_CONFIG_KEY(THROUGHPUT_STREAMS)) {
+        auto value = (num_streams == 0) ?
+            ov::streams::Num(get_optimal_number_of_streams()) : num_streams;
+        return (value ==  ov::streams::AUTO) ? NVIDIA_CONFIG_VALUE(THROUGHPUT_AUTO)
+                                             : ov::util::to_string(value);
+    } else if (name == ov::hint::num_requests) {
+        return hint_num_requests;
+    } else if (name == ov::hint::inference_precision) {
+        return get_inference_precision();
     } else if (name == ov::hint::performance_mode) {
         return performance_mode;
+    } else if (name == ov::hint::execution_mode) {
+        return execution_mode;
     } else {
         throwNotFound(name);
     }

--- a/modules/nvidia_plugin/src/cuda_config.hpp
+++ b/modules/nvidia_plugin/src/cuda_config.hpp
@@ -32,15 +32,27 @@ struct Configuration {
 
     InferenceEngine::Parameter Get(const std::string& name) const;
 
-    // Plugin configuration parameters
+    static std::vector<ov::PropertyName> get_supported_properties();
+    static std::vector<ov::PropertyName> get_ro_properties();
+    static std::vector<ov::PropertyName> get_rw_properties();
+    static std::vector<ov::PropertyName> get_caching_properties();
+    static bool is_rw_property(const std::string& name);
+    void update_device_id(const ConfigMap& config);
+    ov::element::Type get_inference_precision() const noexcept;
+    uint32_t get_optimal_number_of_streams() const noexcept;
 
+    // Plugin configuration parameters
+    static constexpr uint32_t reasonable_limit_of_streams = 10;
     int deviceId = 0;
-    bool perfCount = true;
-    bool operation_benchmark = false;
-    std::string cuda_throughput_streams_ = std::to_string(1);
     InferenceEngine::IStreamsExecutor::Config streams_executor_config_;
-    // TODO: Should be added usage of this property (What to do with NVIDIA_CONFIG_KEY(THROUGHPUT_STREAMS) ?)
+private:
+    bool is_profiling_enabled = false;
+    bool operation_benchmark = false;
+    uint32_t hint_num_requests = 0;
+    ov::streams::Num num_streams = 0;
     ov::hint::PerformanceMode performance_mode = ov::hint::PerformanceMode::UNDEFINED;
+    ov::hint::ExecutionMode execution_mode = ov::hint::ExecutionMode::UNDEFINED;
+    ov::element::Type inference_precision = ov::element::undefined;
 };
 
 }  // namespace nvidia_gpu

--- a/modules/nvidia_plugin/src/cuda_infer_request.cpp
+++ b/modules/nvidia_plugin/src/cuda_infer_request.cpp
@@ -91,7 +91,7 @@ CudaInferRequest::CudaInferRequest(const std::vector<std::shared_ptr<const ov::N
     : IInferRequestInternal(inputs, outputs),
       _executableNetwork(executableNetwork),
       cancellation_token_{[this] { memory_proxy_.reset(); }},
-      profiler_{_executableNetwork->cfg_.perfCount, *_executableNetwork->graph_},
+      profiler_{_executableNetwork->GetConfig(ov::enable_profiling.name()), *_executableNetwork->graph_},
       is_benchmark_mode_{isBenchmarkMode} {
     this->setPointerToExecutableNetworkInternal(executableNetwork);
     createInferRequest();
@@ -104,7 +104,7 @@ CudaInferRequest::CudaInferRequest(const InferenceEngine::InputsDataMap& network
     : IInferRequestInternal(networkInputs, networkOutputs),
       _executableNetwork(executableNetwork),
       cancellation_token_{[this] { memory_proxy_.reset(); }},
-      profiler_{_executableNetwork->cfg_.perfCount, *_executableNetwork->graph_},
+      profiler_{_executableNetwork->GetConfig(ov::enable_profiling.name()), *_executableNetwork->graph_},
       is_benchmark_mode_{isBenchmarkMode} {
     this->setPointerToExecutableNetworkInternal(executableNetwork);
     createInferRequest();

--- a/modules/nvidia_plugin/src/cuda_plugin.cpp
+++ b/modules/nvidia_plugin/src/cuda_plugin.cpp
@@ -24,6 +24,8 @@
 #include "cuda_plugin.hpp"
 #include "nvidia/nvidia_config.hpp"
 #include "openvino/runtime/properties.hpp"
+#include "cpp_interfaces/interface/ie_internal_plugin_config.hpp"
+
 using namespace ov::nvidia_gpu;
 
 Plugin::Plugin() { _pluginName = "NVIDIA"; }
@@ -126,7 +128,13 @@ InferenceEngine::Parameter Plugin::GetConfig(
 InferenceEngine::Parameter Plugin::GetMetric(const std::string& name,
                                              const std::map<std::string, InferenceEngine::Parameter>& options) const {
     using namespace InferenceEngine::CUDAMetrics;
-    if (METRIC_KEY(SUPPORTED_METRICS) == name) {
+    bool is_new_api = IsNewAPI();
+
+    if (ov::supported_properties == name) {
+        return decltype(ov::supported_properties)::value_type{Configuration::get_supported_properties()};
+    } else if (ov::caching_properties == name) {
+        return decltype(ov::caching_properties)::value_type{Configuration::get_caching_properties()};
+    } else if (METRIC_KEY(SUPPORTED_METRICS) == name) {
         std::vector<std::string> supportedMetrics = {METRIC_KEY(AVAILABLE_DEVICES),
                                                      METRIC_KEY(SUPPORTED_METRICS),
                                                      METRIC_KEY(SUPPORTED_CONFIG_KEYS),
@@ -147,41 +155,14 @@ InferenceEngine::Parameter Plugin::GetMetric(const std::string& name,
             }
         }
         IE_SET_METRIC_RETURN(SUPPORTED_CONFIG_KEYS, configKeys);
-        // TODO: Uncomment when will be required 'SUPPORTED_PROPERTIES' and check all tests
-        //    } else if (ov::supported_properties == name) {
-        //        using properties_type = decltype(ov::supported_properties)::value_type;
-        //        properties_type supportedMetrics = {
-        //            ov::supported_properties.name(),
-        //            METRIC_KEY(AVAILABLE_DEVICES),
-        //            METRIC_KEY(SUPPORTED_METRICS),
-        //            METRIC_KEY(SUPPORTED_CONFIG_KEYS),
-        //            METRIC_KEY(FULL_DEVICE_NAME),
-        //            METRIC_KEY(IMPORT_EXPORT_SUPPORT),
-        //            METRIC_KEY(DEVICE_ARCHITECTURE),
-        //            METRIC_KEY(OPTIMIZATION_CAPABILITIES),
-        //            METRIC_KEY(RANGE_FOR_ASYNC_INFER_REQUESTS)
-        //        };
-        //        properties_type configKeys = {
-        //            CONFIG_KEY(DEVICE_ID),
-        //            CONFIG_KEY(PERF_COUNT),
-        //            NVIDIA_CONFIG_KEY(THROUGHPUT_STREAMS)
-        //        };
-        //        auto streamExecutorConfigKeys = InferenceEngine::IStreamsExecutor::Config{}.SupportedKeys();
-        //        for (auto&& configKey : streamExecutorConfigKeys) {
-        //            if (configKey != InferenceEngine::PluginConfigParams::KEY_CPU_THROUGHPUT_STREAMS) {
-        //                configKeys.emplace_back(configKey);
-        //            }
-        //        }
-        //        properties_type all_properties;
-        //        all_properties.insert(all_properties.end(), supportedMetrics.begin(), supportedMetrics.end());
-        //        all_properties.insert(all_properties.end(), configKeys.begin(), configKeys.end());
-        //        return all_properties;
-    } else if (ov::available_devices == name) {
+    } else if (ov::available_devices == name || METRIC_KEY(AVAILABLE_DEVICES) == name) {
         std::vector<std::string> availableDevices = {};
         for (size_t i = 0; i < CUDA::Device::count(); ++i) {
             availableDevices.push_back(fmt::format("{}.{}", _pluginName, i));
         }
-        return decltype(ov::available_devices)::value_type{availableDevices};
+        if (is_new_api)
+            return decltype(ov::available_devices)::value_type{availableDevices};
+        IE_SET_METRIC_RETURN(AVAILABLE_DEVICES, availableDevices);
     } else if (ov::device::uuid == name) {
         const std::string deviceId = _cfg.Get(CONFIG_KEY(DEVICE_ID));
         CUDA::Device device{std::stoi(deviceId)};
@@ -189,15 +170,17 @@ InferenceEngine::Parameter Plugin::GetMetric(const std::string& name,
         ov::device::UUID uuid = {};
         std::copy(std::begin(props.uuid.bytes), std::end(props.uuid.bytes), std::begin(uuid.uuid));
         return decltype(ov::device::uuid)::value_type{uuid};
-    } else if (METRIC_KEY(FULL_DEVICE_NAME) == name) {
+    } else if (ov::device::full_name == name || METRIC_KEY(FULL_DEVICE_NAME) == name) {
         const std::string deviceId = _cfg.Get(CONFIG_KEY(DEVICE_ID));
         CUDA::Device device{std::stoi(deviceId)};
         const auto& props = device.props();
         const std::string name = props.name;
+        if (is_new_api)
+            return decltype(ov::device::full_name)::value_type{name};
         IE_SET_METRIC_RETURN(FULL_DEVICE_NAME, name);
     } else if (METRIC_KEY(IMPORT_EXPORT_SUPPORT) == name) {
         IE_SET_METRIC_RETURN(IMPORT_EXPORT_SUPPORT, true);
-    } else if (METRIC_KEY(DEVICE_ARCHITECTURE) == name) {
+    } else if (ov::device::architecture == name || METRIC_KEY(DEVICE_ARCHITECTURE) == name) {
         const std::string deviceId = _cfg.Get(CONFIG_KEY(DEVICE_ID));
         CUDA::Device device{std::stoi(deviceId)};
         const auto& props = device.props();
@@ -205,15 +188,26 @@ InferenceEngine::Parameter Plugin::GetMetric(const std::string& name,
         ss << "NVIDIA: ";
         ss << "v" << props.major;
         ss << "." << props.minor;
+        if (is_new_api)
+            return decltype(ov::device::architecture)::value_type{ss.str()};
         IE_SET_METRIC_RETURN(DEVICE_ARCHITECTURE, ss.str());
+    } else if (ov::device::capabilities == name) {
+        return decltype(ov::device::capabilities)::value_type{{
+            ov::device::capability::EXPORT_IMPORT,
+            ov::device::capability::FP32,
+            ov::device::capability::FP16}};
     } else if (METRIC_KEY(OPTIMIZATION_CAPABILITIES) == name) {
-        // TODO: fill actual list of supported capabilities: e.g. Cuda device supports only FP32
-        std::vector<std::string> capabilities = {METRIC_VALUE(FP32) /*, TEMPLATE_METRIC_VALUE(HARDWARE_CONVOLUTION)*/};
+        std::vector<std::string> capabilities = {METRIC_VALUE(FP32)};
         IE_SET_METRIC_RETURN(OPTIMIZATION_CAPABILITIES, capabilities);
-    } else if (METRIC_KEY(RANGE_FOR_ASYNC_INFER_REQUESTS) == name) {
-        // TODO: fill with actual values
+     } else if (ov::range_for_streams == name) {
+        return decltype(ov::range_for_streams)::value_type{1, Configuration::reasonable_limit_of_streams};
+    } else if (ov::range_for_async_infer_requests == name || METRIC_KEY(RANGE_FOR_ASYNC_INFER_REQUESTS) == name) {
+        if (is_new_api)
+            return decltype(ov::range_for_async_infer_requests)::value_type{1, 1, 1};
         using uint = unsigned int;
         IE_SET_METRIC_RETURN(RANGE_FOR_ASYNC_INFER_REQUESTS, std::make_tuple(uint{1}, uint{1}, uint{1}));
+    } else if (Configuration::is_rw_property(name)) {
+        return _cfg.Get(name);
     } else {
         IE_THROW(NotFound) << "Unsupported device metric: " << name;
     }

--- a/modules/nvidia_plugin/src/transformer/cuda_graph_transformer.cpp
+++ b/modules/nvidia_plugin/src/transformer/cuda_graph_transformer.cpp
@@ -44,12 +44,22 @@ void GraphTransformer::common_transform(const CUDA::Device& device,
                                         const InferenceEngine::InputsDataMap& inputInfoMap,
                                         const InferenceEngine::OutputsDataMap& outputsInfoMap,
                                         const Configuration& config) const {
+    auto inference_precision = config.get_inference_precision();
+    if (inference_precision == ov::element::f16 && !isHalfSupported(device)) {
+        throwIEException("Inference precision f16 is not supported by device!");
+    }
+    auto upscale_precision = [&]() -> bool {
+        return !isHalfSupported(device) || inference_precision == ov::element::f32;
+    };
+    auto downscale_precision = [&]() -> bool {
+        return isHalfSupported(device) && inference_precision == ov::element::f16;
+    };
     auto passConfig = std::make_shared<ov::pass::PassConfig>();
     ov::pass::Manager manager{passConfig};
 
     passConfig->enable<ov::pass::ConvertInterpolate1ToInterpolate4>();
     passConfig->disable<ov::pass::MVN6Decomposition>();
-    if (!isHalfSupported(device)) {
+    if (upscale_precision()) {
         // Allow FP16 Converts to be folded and FP16 constants to be upgraded to FP32 data type
         passConfig->disable<ov::pass::DisableDecompressionConvertConstantFolding>();
         passConfig->disable<ov::pass::ConvertCompressedOnlyToLegacy>();
@@ -73,12 +83,12 @@ void GraphTransformer::common_transform(const CUDA::Device& device,
     manager.register_pass<ov::pass::CommonOptimizations>();
     manager.register_pass<ov::pass::ReshapePRelu>();
     manager.register_pass<ov::nvidia_gpu::pass::RemoveDuplicatedResultsTransformation>();
-    if (!isHalfSupported(device)) {
+    if (upscale_precision()) {
         manager.register_pass<ov::pass::ConvertPrecision>(ov::element::f16, ov::element::f32);
-    }
-    if (!isInt8Supported(device)) {
-        manager.register_pass<ov::pass::ConvertPrecision>(
-            ov::element::i8, isHalfSupported(device) ? ov::element::f16 : ov::element::f32);
+    } else {
+        if (downscale_precision()) {
+            manager.register_pass<ov::pass::ConvertPrecision>(ov::element::f32, ov::element::f16);
+        }
     }
     manager.register_pass<ov::nvidia_gpu::pass::RemoveRedundantConvertTransformation>();
     manager.register_pass<ov::nvidia_gpu::pass::BidirectionalSequenceComposition>(passConfig);

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_executable_network/properties.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_executable_network/properties.cpp
@@ -7,6 +7,7 @@
 #include <cuda_test_constants.hpp>
 
 #include "openvino/runtime/properties.hpp"
+#include "nvidia/properties.hpp"
 
 using namespace ov::test::behavior;
 
@@ -65,8 +66,14 @@ INSTANTIATE_TEST_SUITE_P(smoke_AutoBatch_BehaviorTests,
                          OVCompiledModelPropertiesIncorrectTests::getTestCaseName);
 
 const std::vector<ov::AnyMap> default_properties = {
-    {ov::enable_profiling(true)},
+    {ov::num_streams(1)},
+    {ov::inference_precision(ov::element::undefined)},
+    {ov::hint::num_requests(0)},
+    {ov::hint::performance_mode(ov::hint::PerformanceMode::UNDEFINED)},
+    {ov::hint::execution_mode(ov::hint::ExecutionMode::UNDEFINED)},
+    {ov::enable_profiling(false)},
     {ov::device::id("0")},
+    {ov::nvidia_gpu::operation_benchmark(false)}
 };
 
 INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
@@ -76,7 +83,19 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
                          OVCompiledModelPropertiesDefaultTests::getTestCaseName);
 
 const std::vector<ov::AnyMap> properties = {
+    {ov::num_streams(8)},
+    {ov::num_streams(ov::streams::AUTO)},
+    {ov::inference_precision(ov::element::undefined)},
+    {ov::inference_precision(ov::element::f32)},
+    {ov::inference_precision(ov::element::f16)},
+    {ov::hint::performance_mode(ov::hint::PerformanceMode::UNDEFINED)},
+    {ov::hint::performance_mode(ov::hint::PerformanceMode::THROUGHPUT)},
+    {ov::hint::performance_mode(ov::hint::PerformanceMode::LATENCY)},
+    {ov::hint::execution_mode(ov::hint::ExecutionMode::UNDEFINED)},
+    {ov::hint::execution_mode(ov::hint::ExecutionMode::ACCURACY)},
+    {ov::hint::execution_mode(ov::hint::ExecutionMode::PERFORMANCE)},
     {ov::enable_profiling(true)},
+    {ov::enable_profiling(false)},
     {ov::device::id("0")},
     {ov::device::id("NVIDIA.0")},
 };

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
@@ -63,7 +63,12 @@ INSTANTIATE_TEST_SUITE_P(DISABLED_smoke_AutoBatch_BehaviorTests,
                          OVPropertiesIncorrectTests::getTestCaseName);
 
 const std::vector<ov::AnyMap> default_properties = {
-    {ov::enable_profiling(true)},
+    {ov::num_streams(1)},
+    {ov::inference_precision(ov::element::undefined)},
+    {ov::hint::num_requests(0)},
+    {ov::hint::performance_mode(ov::hint::PerformanceMode::UNDEFINED)},
+    {ov::hint::execution_mode(ov::hint::ExecutionMode::UNDEFINED)},
+    {ov::enable_profiling(false)},
     {ov::device::id(0)},
 };
 
@@ -74,7 +79,19 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
                          OVPropertiesDefaultTests::getTestCaseName);
 
 const std::vector<ov::AnyMap> properties = {
+    {ov::num_streams(8)},
+    {ov::num_streams(ov::streams::AUTO)},
+    {ov::inference_precision(ov::element::undefined)},
+    {ov::inference_precision(ov::element::f32)},
+    {ov::inference_precision(ov::element::f16)},
+    {ov::hint::performance_mode(ov::hint::PerformanceMode::UNDEFINED)},
+    {ov::hint::performance_mode(ov::hint::PerformanceMode::THROUGHPUT)},
+    {ov::hint::performance_mode(ov::hint::PerformanceMode::LATENCY)},
+    {ov::hint::execution_mode(ov::hint::ExecutionMode::UNDEFINED)},
+    {ov::hint::execution_mode(ov::hint::ExecutionMode::ACCURACY)},
+    {ov::hint::execution_mode(ov::hint::ExecutionMode::PERFORMANCE)},
     {ov::enable_profiling(true)},
+    {ov::enable_profiling(false)},
     {ov::device::id(0)},
 };
 

--- a/modules/nvidia_plugin/tests/functional/skip_tests_config.cpp
+++ b/modules/nvidia_plugin/tests/functional/skip_tests_config.cpp
@@ -108,9 +108,6 @@ std::vector<std::string> disabledTestPatterns() {
         // CVS-71891
         R"(.*ReferenceTileTest.*rType=i4.*)",
         R"(.*ReferenceTileTest.*rType=u4.*)",
-        R"(.*DeviceID.*)",
-        // 98963
-        R"(.*CachingSupportCase*.*CompileModelCacheTestBase.*)",
         R"(.*CachingSupportCase*.*ReadConcatSplitAssign.*)",
         // 98989
         R"(.*GroupConvolutionBias(Add|AddAdd)ActivationLayerTest.*IS=\(2\.16\.12\.6\).*K\(3\.3\).*S\(1\.1\).*PB\(0\.3\).*PE\(0\.3\).*D=\(1\.1\).*O=(8|32).*G=2.*AP=explicit.*netPRC=FP16*.*)",

--- a/modules/nvidia_plugin/tests/unit/executable_network.cpp
+++ b/modules/nvidia_plugin/tests/unit/executable_network.cpp
@@ -18,8 +18,12 @@
 
 using namespace ov::nvidia_gpu;
 
-class ExecNetworkTest : public testing::Test {
+using PropertiesParams = std::map<std::string, std::string>;
+
+class ExecNetworkTest : public testing::Test,
+                        public testing::WithParamInterface<PropertiesParams> {
     void SetUp() override {
+        properties = this->GetParam();
         function_ = CreateMatMulTestNetwork();
         super_function_ = CreateSuperOperationTestNetwork();
     }
@@ -27,6 +31,17 @@ class ExecNetworkTest : public testing::Test {
     void TearDown() override {}
 
 public:
+    static std::string getTestCaseName(testing::TestParamInfo<PropertiesParams> obj) {
+        std::string target_device;
+        PropertiesParams properties = obj.param;
+        std::replace(target_device.begin(), target_device.end(), ':', '.');
+        std::ostringstream result;
+        result << "properties";
+        for (auto& item : properties) {
+            result << "_" << item.first << "=" << item.second;
+        }
+        return result.str();
+    }
     auto GetExecSequence(const std::shared_ptr<ExecutableNetwork>& execNetwork) {
         const auto& graph = *execNetwork->graph_;
         std::vector<OperationBase::Ptr> execSequence{};
@@ -39,75 +54,166 @@ public:
 
     std::shared_ptr<ngraph::Function> function_;
     std::shared_ptr<ngraph::Function> super_function_;
+    PropertiesParams properties;
 };
 
-TEST_F(ExecNetworkTest, BuildExecutableSequence_MatMul_Success) {
+std::vector<PropertiesParams> default_properties = {
+    {
+        {ov::device::id.name(), "0"},
+    },
+};
+
+using MatMulExecNetworkTest = ExecNetworkTest;
+TEST_P(MatMulExecNetworkTest, BuildExecutableSequence_MatMul_Success) {
     auto dummyCNNNetwork = InferenceEngine::CNNNetwork{function_};
     Configuration cfg;
     auto plugin = std::make_shared<Plugin>();
     auto execNetwork = std::dynamic_pointer_cast<ExecutableNetwork>(
-        plugin->LoadExeNetworkImpl(dummyCNNNetwork, {{CONFIG_KEY(DEVICE_ID), "0"}}));
+        plugin->LoadExeNetworkImpl(dummyCNNNetwork, properties));
     const auto& execSequence = GetExecSequence(execNetwork);
     ASSERT_EQ(execSequence.size(), 3);
     ASSERT_EQ(std::type_index(typeid(*execSequence[1].get())), std::type_index(typeid(MatMulOp)));
 }
 
-TEST_F(ExecNetworkTest, BuildExecutableSequence_SuperOperation_Failed) {
+INSTANTIATE_TEST_SUITE_P(ExecNetworkTest,
+                         MatMulExecNetworkTest,
+                         ::testing::ValuesIn(default_properties),
+                         ExecNetworkTest::getTestCaseName);
+
+using ExecutableSequenceExecNetworkTest = ExecNetworkTest;
+TEST_P(ExecutableSequenceExecNetworkTest, BuildExecutableSequence_SuperOperation_Failed) {
     auto dummyCNNNetwork = InferenceEngine::CNNNetwork{super_function_};
     Configuration cfg;
     auto plugin = std::make_shared<Plugin>();
-    ASSERT_THROW(plugin->LoadExeNetworkImpl(dummyCNNNetwork, {{CONFIG_KEY(DEVICE_ID), "0"}}),
+    ASSERT_THROW(plugin->LoadExeNetworkImpl(dummyCNNNetwork, properties),
                  InferenceEngine::details::InferenceEngineException);
 }
 
-TEST_F(ExecNetworkTest, LoadExecNetwork_OptimalNumberInferRequests_1_Success) {
+INSTANTIATE_TEST_SUITE_P(ExecNetworkTest,
+                         ExecutableSequenceExecNetworkTest,
+                         ::testing::ValuesIn(default_properties),
+                         ExecNetworkTest::getTestCaseName);
+
+std::vector<PropertiesParams> num_streams_1_properties = {
+    {
+        {CONFIG_KEY(DEVICE_ID), "0"},
+        {NVIDIA_CONFIG_KEY(THROUGHPUT_STREAMS), "1"},
+    },
+    {
+        {ov::device::id.name(), "0"},
+        {ov::num_streams.name(), "1"},
+    },
+    {
+        {ov::device::id.name(), "0"},
+        {ov::hint::performance_mode.name(), ov::util::to_string(ov::hint::PerformanceMode::THROUGHPUT)},
+        {ov::num_streams.name(), "1"},
+    },
+    {
+        {ov::device::id.name(), "0"},
+        {ov::hint::performance_mode.name(), ov::util::to_string(ov::hint::PerformanceMode::LATENCY)},
+    },
+    {
+        {ov::device::id.name(), "0"},
+        {ov::hint::performance_mode.name(), ov::util::to_string(ov::hint::PerformanceMode::LATENCY)},
+        {ov::num_streams.name(), "1"},
+    },
+    {
+        {ov::device::id.name(), "0"},
+        {ov::hint::performance_mode.name(), ov::util::to_string(ov::hint::PerformanceMode::UNDEFINED)},
+    },
+    {
+        {ov::device::id.name(), "0"},
+        {ov::hint::performance_mode.name(), ov::util::to_string(ov::hint::PerformanceMode::UNDEFINED)},
+        {ov::num_streams.name(), "1"},
+    },
+};
+
+using NumStreams1ExecNetworkTest = ExecNetworkTest;
+TEST_P(NumStreams1ExecNetworkTest, LoadExecNetwork_OptimalNumberInferRequests_1_Success) {
     using namespace std::chrono_literals;
 
     auto dummyCNNNetwork = InferenceEngine::CNNNetwork{function_};
     Configuration cfg;
     auto plugin = std::make_shared<Plugin>();
     constexpr auto total_streams = 1;
-    auto execNetwork =
-        plugin->LoadExeNetworkImpl(dummyCNNNetwork,
-                                   {
-                                       {CONFIG_KEY(DEVICE_ID), "0"},
-                                       {NVIDIA_CONFIG_KEY(THROUGHPUT_STREAMS), std::to_string(total_streams)},
-                                   });
+    auto execNetwork = plugin->LoadExeNetworkImpl(dummyCNNNetwork, properties);
     auto cudaExecNetwork = std::dynamic_pointer_cast<ExecutableNetwork>(execNetwork);
     auto& memoryManagerPool = GetMemoryManagerPool(cudaExecNetwork);
     ASSERT_EQ(memoryManagerPool->Size(), total_streams);
 }
 
-TEST_F(ExecNetworkTest, LoadExecNetwork_OptimalNumberInferRequests_8_Success) {
-    using namespace std::chrono_literals;
+INSTANTIATE_TEST_SUITE_P(ExecNetworkTest,
+                         NumStreams1ExecNetworkTest,
+                         ::testing::ValuesIn(num_streams_1_properties),
+                         ExecNetworkTest::getTestCaseName);
 
+std::vector<PropertiesParams> num_streams_8_properties = {
+    {
+        {CONFIG_KEY(DEVICE_ID), "0"},
+        {NVIDIA_CONFIG_KEY(THROUGHPUT_STREAMS), "8"},
+    },
+    {
+        {ov::device::id.name(), "0"},
+        {ov::num_streams.name(), "8"},
+    },
+    {
+        {ov::device::id.name(), "0"},
+        {ov::hint::performance_mode.name(), ov::util::to_string(ov::hint::PerformanceMode::THROUGHPUT)},
+        {ov::num_streams.name(), "8"},
+    },
+    {
+        {ov::device::id.name(), "0"},
+        {ov::hint::performance_mode.name(), ov::util::to_string(ov::hint::PerformanceMode::LATENCY)},
+        {ov::num_streams.name(), "8"},
+    },
+    {
+        {ov::device::id.name(), "0"},
+        {ov::hint::performance_mode.name(), ov::util::to_string(ov::hint::PerformanceMode::UNDEFINED)},
+        {ov::num_streams.name(), "8"},
+    },
+};
+
+using NumStreams8ExecNetworkTest = ExecNetworkTest;
+TEST_P(NumStreams8ExecNetworkTest, LoadExecNetwork_OptimalNumberInferRequests_8_Success) {
+    using namespace std::chrono_literals;
     auto dummyCNNNetwork = InferenceEngine::CNNNetwork{function_};
     Configuration cfg;
     auto plugin = std::make_shared<Plugin>();
     constexpr auto total_streams = 8;
-    auto execNetwork =
-        plugin->LoadExeNetworkImpl(dummyCNNNetwork,
-                                   {
-                                       {CONFIG_KEY(DEVICE_ID), "0"},
-                                       {NVIDIA_CONFIG_KEY(THROUGHPUT_STREAMS), std::to_string(total_streams)},
-                                   });
+    auto execNetwork = plugin->LoadExeNetworkImpl(dummyCNNNetwork, properties);
     auto cudaExecNetwork = std::dynamic_pointer_cast<ExecutableNetwork>(execNetwork);
     auto& memoryManagerPool = GetMemoryManagerPool(cudaExecNetwork);
     ASSERT_EQ(memoryManagerPool->Size(), total_streams);
 }
 
-TEST_F(ExecNetworkTest, LoadExecNetwork_OptimalNumberInferRequests_Auto_Success) {
-    using namespace std::chrono_literals;
+INSTANTIATE_TEST_SUITE_P(ExecNetworkTest,
+                         NumStreams8ExecNetworkTest,
+                         ::testing::ValuesIn(num_streams_8_properties),
+                         ExecNetworkTest::getTestCaseName);
 
+
+std::vector<PropertiesParams> num_streams_auto_properties = {
+    {
+        {CONFIG_KEY(DEVICE_ID), "0"},
+        {NVIDIA_CONFIG_KEY(THROUGHPUT_STREAMS), NVIDIA_CONFIG_VALUE(THROUGHPUT_AUTO)},
+    },
+    {
+        {ov::device::id.name(), "0"},
+        {ov::num_streams.name(), ov::util::to_string(ov::streams::AUTO)},
+    },
+    {
+        {ov::device::id.name(), "0"},
+        {ov::hint::performance_mode.name(), ov::util::to_string(ov::hint::PerformanceMode::THROUGHPUT)},
+    }
+};
+
+using NumStreamsAUTOExecNetworkTest = ExecNetworkTest;
+TEST_P(NumStreamsAUTOExecNetworkTest, LoadExecNetwork_OptimalNumberInferRequests_Auto_Success) {
+    using namespace std::chrono_literals;
     auto dummyCNNNetwork = InferenceEngine::CNNNetwork{function_};
     Configuration cfg;
     auto plugin = std::make_shared<Plugin>();
-    auto execNetwork =
-        plugin->LoadExeNetworkImpl(dummyCNNNetwork,
-                                   {
-                                       {CONFIG_KEY(DEVICE_ID), "0"},
-                                       {NVIDIA_CONFIG_KEY(THROUGHPUT_STREAMS), NVIDIA_CONFIG_VALUE(THROUGHPUT_AUTO)},
-                                   });
+    auto execNetwork = plugin->LoadExeNetworkImpl(dummyCNNNetwork, properties);
     auto cudaExecNetwork = std::dynamic_pointer_cast<ExecutableNetwork>(execNetwork);
     auto& memoryManagerPool = GetMemoryManagerPool(cudaExecNetwork);
     ASSERT_GT(memoryManagerPool->Size(), 1);


### PR DESCRIPTION
### Details:
 - *Enable new property API for NVIDIA plugin*
 - *Performance counters are turned off by default now*
 - *ov::inference_precision and ov::hint::execution_mode are also supported, but default behaviour is not changed. Additional accuracy numbers are required to turn default precision to f16*

hello_query_device output:
```
[ INFO ] NVIDIA
[ INFO ]        SUPPORTED_PROPERTIES: 
[ INFO ]                Immutable: AVAILABLE_DEVICES : NVIDIA.0
[ INFO ]                Immutable: CACHING_PROPERTIES : DEVICE_ARCHITECTURE INFERENCE_PRECISION_HINT EXECUTION_MODE_HINT
[ INFO ]                Immutable: RANGE_FOR_STREAMS : 1 10
[ INFO ]                Immutable: RANGE_FOR_ASYNC_INFER_REQUESTS : 1 1 1
[ INFO ]                Immutable: DEVICE_ARCHITECTURE : NVIDIA: v8.6
[ INFO ]                Immutable: OPTIMIZATION_CAPABILITIES : EXPORT_IMPORT FP32 FP16
[ INFO ]                Immutable: FULL_DEVICE_NAME : NVIDIA GeForce RTX 3090
[ INFO ]                Immutable: DEVICE_UUID : f588fd9d4813c2f6e139426adc056c0b
[ INFO ]                Mutable: DEVICE_ID : 0
[ INFO ]                Mutable: INFERENCE_PRECISION_HINT : undefined
[ INFO ]                Mutable: NUM_STREAMS : 1
[ INFO ]                Mutable: PERFORMANCE_HINT_NUM_REQUESTS : 0
[ INFO ]                Mutable: PERFORMANCE_HINT : ""
[ INFO ]                Mutable: EXECUTION_MODE_HINT : UNDEFINED
[ INFO ]                Mutable: PERF_COUNT : NO
[ INFO ]                Mutable: NVIDIA_OPERATION_BENCHMARK : NO
```
### Tickets:
 - *102672*
 - *98963*
 - *102655 (partially)*
