### PR TITLE
[apiConformance] Rename exec_graph_info and exec_network_base

### DIFF
--- a/modules/arm_plugin/tests/functional/shared_tests_instances/behavior/ov_compiled_model/compiled_model_base.cpp
+++ b/modules/arm_plugin/tests/functional/shared_tests_instances/behavior/ov_compiled_model/compiled_model_base.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "behavior/ov_executable_network/exec_network_base.hpp"
+#include "behavior/ov_compiled_model/compiled_model_base.hpp"
 #include "ie_plugin_config.hpp"
 
 using namespace ov::test::behavior;

--- a/modules/arm_plugin/tests/functional/shared_tests_instances/behavior/ov_compiled_model/core_integration.cpp
+++ b/modules/arm_plugin/tests/functional/shared_tests_instances/behavior/ov_compiled_model/core_integration.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "behavior/ov_executable_network/get_metric.hpp"
+#include "behavior/ov_compiled_model/get_metric.hpp"
 #include "openvino/runtime/core.hpp"
 
 using namespace ov::test::behavior;

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_compiled_model/ov_exec_net_import_export.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_compiled_model/ov_exec_net_import_export.cpp
@@ -4,7 +4,7 @@
 #include <common_test_utils/test_constants.hpp>
 #include <cuda_test_constants.hpp>
 
-#include "behavior/ov_executable_network/exec_graph_info.hpp"
+#include "behavior/ov_compiled_model/import_export.hpp"
 #include "ie_plugin_config.hpp"
 
 using namespace ov::test::behavior;

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_compiled_model/properties.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_compiled_model/properties.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "behavior/ov_executable_network/properties.hpp"
+#include "behavior/ov_compiled_model/properties.hpp"
 
 #include <cuda_test_constants.hpp>
 


### PR DESCRIPTION
As part of process of bring test names to gold state it was renamed files exec_network_base to import_export and exec_graph_info to compiled_model_base. Also folder ov_executable_network was renamed to ov_compiled_model. More detail , please, see in PR to OpenVINO. CI results could be checked in  [PR to PropuctConfig](https://github.com/intel-innersource/frameworks.ai.openvino.ci.product-configs/pull/1929)  with changes in all repos. (Note, that fails with macos/debian-arm and pip-conflicts_windows_vs2019_release are not related to these changes and happen sporadically)

[Same PR to OpenVINO (apiConformance) Rename exec_graph_info and exec_network_base](https://github.com/openvinotoolkit/openvino/pull/15693) 
[Same PR to PropuctConfig (apiConformance) Rename exec_graph_info and exec_network_base](https://github.com/intel-innersource/frameworks.ai.openvino.ci.product-configs/pull/1929) 
[Related tickets API INFRA Review test name](https://jira.devtools.intel.com/browse/CVS-98927)

