### PR TITLE
[Remove APIs] Modify caused by remove static const AutoBroadcastSpec NUMPY/NONE

### DIFF
--- a/modules/arm_plugin/tests/functional/shared_tests_instances/single_layer_tests/select.cpp
+++ b/modules/arm_plugin/tests/functional/shared_tests_instances/single_layer_tests/select.cpp
@@ -29,7 +29,7 @@ const std::vector<std::vector<std::vector<size_t>>> noneShapes = {
 const auto noneCases = ::testing::Combine(
     ::testing::ValuesIn(noneShapes),
     ::testing::ValuesIn(inputPrecision),
-    ::testing::Values(ngraph::op::AutoBroadcastSpec::NONE),
+    ::testing::Values(ov::op::AutoBroadcastSpec::NONE),
     ::testing::Values(CommonTestUtils::DEVICE_CPU)
 );
 
@@ -78,7 +78,7 @@ const std::vector<std::vector<std::vector<size_t>>> numpyShapes = {
 const auto numpyCases = ::testing::Combine(
     ::testing::ValuesIn(numpyShapes),
     ::testing::ValuesIn(inputPrecision),
-    ::testing::Values(ngraph::op::AutoBroadcastSpec::NUMPY),
+    ::testing::Values(ov::op::AutoBroadcastSpec::NUMPY),
     ::testing::Values(CommonTestUtils::DEVICE_CPU)
 );
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/fake_quantize.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/fake_quantize.cpp
@@ -39,7 +39,7 @@ const auto fqParams = ::testing::Combine(::testing::ValuesIn(levels),
                                          ::testing::ValuesIn(constShapes),
                                          ::testing::Values(fqArgs),
                                          ::testing::Values(inputParams),
-                                         ::testing::Values(ngraph::op::AutoBroadcastSpec()));
+                                         ::testing::Values(ov::op::AutoBroadcastSpec()));
 
 INSTANTIATE_TEST_CASE_P(smoke_CUDAFakeQuantize,
                         FakeQuantizeLayerTest,
@@ -60,7 +60,7 @@ const auto fqParamsBr = ::testing::Combine(::testing::ValuesIn(levels),
                                            ::testing::ValuesIn(constShapesBr),
                                            ::testing::Values(fqArgs),
                                            ::testing::Values(inputParams),
-                                           ::testing::Values(ngraph::op::AutoBroadcastSpec()));
+                                           ::testing::Values(ov::op::AutoBroadcastSpec()));
 
 INSTANTIATE_TEST_CASE_P(smoke_CUDAFakeQuantizeBr,
                         FakeQuantizeLayerTest,


### PR DESCRIPTION
Fix issue caused by https://github.com/openvinotoolkit/openvino/pull/15806
- Remove static const AutoBroadcastSpec NUMPY;
- Remove static const AutoBroadcastSpec NONE;