### PR TITLE
[NVIDIA] Add Gather-8 (negative indices) support

### DIFF
--- a/modules/nvidia_plugin/src/kernels/gather.cu
+++ b/modules/nvidia_plugin/src/kernels/gather.cu
@@ -27,6 +27,9 @@ static inline __device__ void gather(unsigned data_length,
                                      const IndexType* src_index,
                                      DataType* dst_data) {
     auto dict_index = src_index[indices_index];
+    if (dict_index < 0) {
+        dict_index += index_range;
+    }
     if (dict_index >= index_range) {
         if (IsBenchmarkMode) {
             dict_index = 0;

--- a/modules/nvidia_plugin/src/ops/gather.cpp
+++ b/modules/nvidia_plugin/src/ops/gather.cpp
@@ -32,9 +32,10 @@ GatherOp::GatherOp(const CreationContext& context,
     : OperationBase(context, node, std::move(inputIds), std::move(outputIds)) {
     Expects(node.get_input_size() == 3);
     Expects(node.get_output_size() == 1);
+    const auto gather_v8 = dynamic_cast<const ov::op::v8::Gather*>(&node);
     const auto gather_v7 = dynamic_cast<const ov::op::v7::Gather*>(&node);
     const auto gather_v1 = dynamic_cast<const ov::op::v1::Gather*>(&node);
-    Expects(gather_v7 || gather_v1);
+    Expects(gather_v8 || gather_v7 || gather_v1);
 
     const auto gather_base = dynamic_cast<const ov::op::util::GatherBase*>(&node);
     Expects(gather_base);
@@ -68,8 +69,8 @@ GatherOp::GatherOp(const CreationContext& context,
     Expects(axis >= 0 && axis < dict_shape_size);
 
     int64_t batch_dims = 0;
-    if (gather_v7) {
-        batch_dims = gather_v7->get_batch_dims();
+    if (gather_v8 || gather_v7) {
+        batch_dims = gather_v8 ? gather_v8->get_batch_dims() : gather_v7->get_batch_dims();
         Expects(batch_dims >= 0 && batch_dims < dict_shape_size && batch_dims < indices_shape.size() &&
                 batch_dims <= axis);
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/gather.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/gather.cpp
@@ -342,6 +342,23 @@ INSTANTIATE_TEST_CASE_P(smoke_Gather_v7_11,
                                            ::testing::Values(smoke_11_ov_params_v7.device_)),
                         Gather7LayerTest::getTestCaseName);
 
+const GatherTestParams smoke_12_ov_params_v8 = {{2, 5}, {2, 3}, 1, -1};
+
+INSTANTIATE_TEST_CASE_P(smoke_Gather_v8_12,
+                        Gather8LayerTest,
+                        ::testing::Combine(::testing::Values(smoke_12_ov_params_v8.params_shape_),
+                                           ::testing::Values(smoke_12_ov_params_v8.indices_shape_),
+                                           ::testing::Values(std::make_tuple(smoke_12_ov_params_v8.axis_,
+                                                                             smoke_12_ov_params_v8.batch_dims_)),
+                                           ::testing::ValuesIn(smoke_12_ov_params_v8.net_precisions_),
+                                           ::testing::Values(smoke_12_ov_params_v8.input_precision_),
+                                           ::testing::Values(smoke_12_ov_params_v8.output_precision_),
+                                           ::testing::Values(smoke_12_ov_params_v8.input_layout_),
+                                           ::testing::Values(smoke_12_ov_params_v8.output_layout_),
+                                           ::testing::Values(smoke_12_ov_params_v8.device_)),
+                        Gather8LayerTest::getTestCaseName);
+
+
 // ------------- Tacotron2 shapes -------------
 const GatherTestParams tacotron2_enc_params_v1_v7 = {{148, 512}, {1, 1000}};
 


### PR DESCRIPTION
### Details:
- *added `Gather-8` support (with negative indices)*
### Ticket:
- 102832