### PR TITLE
Fix deprecated version error about NGRAPH_RTTI_DEFINITION

### DIFF
--- a/modules/arm_plugin/src/transformations/arm_optimizations.cpp
+++ b/modules/arm_plugin/src/transformations/arm_optimizations.cpp
@@ -105,7 +105,7 @@
 
 #include "arm_optimizations.hpp"
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ArmOptimizations, "ArmOptimizations", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ArmOptimizations, "ArmOptimizations");
 void ArmPlugin::pass::ArmOptimizations::Dump(const std::shared_ptr<ov::Model>& m, const std::string& postfix) {
     if (_dump) {
         ngraph::pass::VisualizeTree{m->get_friendly_name() + "_" + postfix +

--- a/modules/arm_plugin/src/transformations/arm_optimizations.cpp
+++ b/modules/arm_plugin/src/transformations/arm_optimizations.cpp
@@ -105,7 +105,6 @@
 
 #include "arm_optimizations.hpp"
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ArmOptimizations, "ArmOptimizations");
 void ArmPlugin::pass::ArmOptimizations::Dump(const std::shared_ptr<ov::Model>& m, const std::string& postfix) {
     if (_dump) {
         ngraph::pass::VisualizeTree{m->get_friendly_name() + "_" + postfix +

--- a/modules/arm_plugin/src/transformations/arm_optimizations.cpp
+++ b/modules/arm_plugin/src/transformations/arm_optimizations.cpp
@@ -105,7 +105,7 @@
 
 #include "arm_optimizations.hpp"
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ArmOptimizations, "ArmOptimizations");
+OPENVINO_OP(ArmPlugin::pass::ArmOptimizations, "ArmOptimizations");
 void ArmPlugin::pass::ArmOptimizations::Dump(const std::shared_ptr<ov::Model>& m, const std::string& postfix) {
     if (_dump) {
         ngraph::pass::VisualizeTree{m->get_friendly_name() + "_" + postfix +

--- a/modules/arm_plugin/src/transformations/arm_optimizations.cpp
+++ b/modules/arm_plugin/src/transformations/arm_optimizations.cpp
@@ -105,7 +105,7 @@
 
 #include "arm_optimizations.hpp"
 
-OPENVINO_OP(ArmPlugin::pass::ArmOptimizations, "ArmOptimizations");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ArmOptimizations, "ArmOptimizations");
 void ArmPlugin::pass::ArmOptimizations::Dump(const std::shared_ptr<ov::Model>& m, const std::string& postfix) {
     if (_dump) {
         ngraph::pass::VisualizeTree{m->get_friendly_name() + "_" + postfix +

--- a/modules/arm_plugin/src/transformations/arm_optimizations.hpp
+++ b/modules/arm_plugin/src/transformations/arm_optimizations.hpp
@@ -11,7 +11,7 @@ namespace pass {
 
 class ArmOptimizations: public ov::pass::ModelPass {
 public:
-    OPENVINO_OP("ArmOptimizations");
+    OPENVINO_RTTI("ArmOptimizations");
     ArmOptimizations(const bool lpt, const bool dump) : _lpt{lpt}, _dump{dump} {}
     bool run_on_model(const std::shared_ptr<ov::Model> &m) override;
 

--- a/modules/arm_plugin/src/transformations/arm_optimizations.hpp
+++ b/modules/arm_plugin/src/transformations/arm_optimizations.hpp
@@ -11,7 +11,7 @@ namespace pass {
 
 class ArmOptimizations: public ov::pass::ModelPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ArmOptimizations");
     ArmOptimizations(const bool lpt, const bool dump) : _lpt{lpt}, _dump{dump} {}
     bool run_on_model(const std::shared_ptr<ov::Model> &m) override;
 

--- a/modules/arm_plugin/src/transformations/conv_bias_fusion.cpp
+++ b/modules/arm_plugin/src/transformations/conv_bias_fusion.cpp
@@ -19,7 +19,7 @@ using namespace ArmPlugin;
 enum Layout {N, C, H, W};
 enum Inputs {Data, Weights, Bias};
 
-OPENVINO_OP(ArmPlugin::pass::ConvBiasFusionBase, "ConvBiasFusionBase");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvBiasFusionBase, "ConvBiasFusionBase");
 template <class Conv, class Eltwise>
 void ArmPlugin::pass::ConvBiasFusionBase::registerMatcher(const std::string& name) {
     auto conv_pattern = ngraph::pattern::wrap_type<Conv>(ngraph::pattern::consumers_count(1));
@@ -108,7 +108,7 @@ void ArmPlugin::pass::ConvBiasFusionBase::registerMatcher(const std::string& nam
     });
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertConvBase, "ConvertConvBase");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertConvBase, "ConvertConvBase");
 template <class Conv, class ArmConv>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertConvBase::convert_conv_to_arm_conv() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -154,7 +154,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertConvBase::convert_conv_to_
 
 // ----------------------------------------ConvertConvolution----------------------------------------
 
-OPENVINO_OP(ArmPlugin::pass::ConvertSingleConvolutionToArm, "ConvertSingleConvolutionToArm");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSingleConvolutionToArm, "ConvertSingleConvolutionToArm");
 ArmPlugin::pass::ConvertSingleConvolutionToArm::ConvertSingleConvolutionToArm() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
         ngraph::pattern::wrap_type<opset::Convolution>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -163,7 +163,7 @@ ArmPlugin::pass::ConvertSingleConvolutionToArm::ConvertSingleConvolutionToArm() 
     register_matcher(m, convert_conv_to_arm_conv<opset::Convolution, opset::ArmConvolution>());
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertGroupConvolutionToArm, "ConvertGroupConvolutionToArm");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGroupConvolutionToArm, "ConvertGroupConvolutionToArm");
 ArmPlugin::pass::ConvertGroupConvolutionToArm::ConvertGroupConvolutionToArm() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::GroupConvolution>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -173,12 +173,12 @@ ArmPlugin::pass::ConvertGroupConvolutionToArm::ConvertGroupConvolutionToArm() {
 }
 
 // ------------------------------------------ConvBiasFusion------------------------------------------
-OPENVINO_OP(ArmPlugin::pass::ConvAddFusion, "ConvAddFusion");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvAddFusion, "ConvAddFusion");
 ArmPlugin::pass::ConvAddFusion::ConvAddFusion() {
     registerMatcher<opset::ArmConvolution, opset::Add>("ConvAddFusion");
 }
 
-OPENVINO_OP(ArmPlugin::pass::GroupConvAddFusion, "GroupConvAddFusion");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::GroupConvAddFusion, "GroupConvAddFusion");
 ArmPlugin::pass::GroupConvAddFusion::GroupConvAddFusion() {
     registerMatcher<opset::ArmGroupConvolution, opset::Add>("GroupConvAddFusion");
 }

--- a/modules/arm_plugin/src/transformations/conv_bias_fusion.cpp
+++ b/modules/arm_plugin/src/transformations/conv_bias_fusion.cpp
@@ -19,7 +19,7 @@ using namespace ArmPlugin;
 enum Layout {N, C, H, W};
 enum Inputs {Data, Weights, Bias};
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvBiasFusionBase, "ConvBiasFusionBase", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvBiasFusionBase, "ConvBiasFusionBase");
 template <class Conv, class Eltwise>
 void ArmPlugin::pass::ConvBiasFusionBase::registerMatcher(const std::string& name) {
     auto conv_pattern = ngraph::pattern::wrap_type<Conv>(ngraph::pattern::consumers_count(1));
@@ -108,7 +108,7 @@ void ArmPlugin::pass::ConvBiasFusionBase::registerMatcher(const std::string& nam
     });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertConvBase, "ConvertConvBase", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertConvBase, "ConvertConvBase");
 template <class Conv, class ArmConv>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertConvBase::convert_conv_to_arm_conv() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -154,7 +154,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertConvBase::convert_conv_to_
 
 // ----------------------------------------ConvertConvolution----------------------------------------
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSingleConvolutionToArm, "ConvertSingleConvolutionToArm", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSingleConvolutionToArm, "ConvertSingleConvolutionToArm");
 ArmPlugin::pass::ConvertSingleConvolutionToArm::ConvertSingleConvolutionToArm() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
         ngraph::pattern::wrap_type<opset::Convolution>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -163,7 +163,7 @@ ArmPlugin::pass::ConvertSingleConvolutionToArm::ConvertSingleConvolutionToArm() 
     register_matcher(m, convert_conv_to_arm_conv<opset::Convolution, opset::ArmConvolution>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGroupConvolutionToArm, "ConvertGroupConvolutionToArm", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGroupConvolutionToArm, "ConvertGroupConvolutionToArm");
 ArmPlugin::pass::ConvertGroupConvolutionToArm::ConvertGroupConvolutionToArm() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::GroupConvolution>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -173,12 +173,12 @@ ArmPlugin::pass::ConvertGroupConvolutionToArm::ConvertGroupConvolutionToArm() {
 }
 
 // ------------------------------------------ConvBiasFusion------------------------------------------
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvAddFusion, "ConvAddFusion", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvAddFusion, "ConvAddFusion");
 ArmPlugin::pass::ConvAddFusion::ConvAddFusion() {
     registerMatcher<opset::ArmConvolution, opset::Add>("ConvAddFusion");
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::GroupConvAddFusion, "GroupConvAddFusion", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::GroupConvAddFusion, "GroupConvAddFusion");
 ArmPlugin::pass::GroupConvAddFusion::GroupConvAddFusion() {
     registerMatcher<opset::ArmGroupConvolution, opset::Add>("GroupConvAddFusion");
 }

--- a/modules/arm_plugin/src/transformations/conv_bias_fusion.cpp
+++ b/modules/arm_plugin/src/transformations/conv_bias_fusion.cpp
@@ -19,7 +19,7 @@ using namespace ArmPlugin;
 enum Layout {N, C, H, W};
 enum Inputs {Data, Weights, Bias};
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvBiasFusionBase, "ConvBiasFusionBase");
+OPENVINO_OP(ArmPlugin::pass::ConvBiasFusionBase, "ConvBiasFusionBase");
 template <class Conv, class Eltwise>
 void ArmPlugin::pass::ConvBiasFusionBase::registerMatcher(const std::string& name) {
     auto conv_pattern = ngraph::pattern::wrap_type<Conv>(ngraph::pattern::consumers_count(1));
@@ -108,7 +108,7 @@ void ArmPlugin::pass::ConvBiasFusionBase::registerMatcher(const std::string& nam
     });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertConvBase, "ConvertConvBase");
+OPENVINO_OP(ArmPlugin::pass::ConvertConvBase, "ConvertConvBase");
 template <class Conv, class ArmConv>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertConvBase::convert_conv_to_arm_conv() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -154,7 +154,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertConvBase::convert_conv_to_
 
 // ----------------------------------------ConvertConvolution----------------------------------------
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSingleConvolutionToArm, "ConvertSingleConvolutionToArm");
+OPENVINO_OP(ArmPlugin::pass::ConvertSingleConvolutionToArm, "ConvertSingleConvolutionToArm");
 ArmPlugin::pass::ConvertSingleConvolutionToArm::ConvertSingleConvolutionToArm() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
         ngraph::pattern::wrap_type<opset::Convolution>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -163,7 +163,7 @@ ArmPlugin::pass::ConvertSingleConvolutionToArm::ConvertSingleConvolutionToArm() 
     register_matcher(m, convert_conv_to_arm_conv<opset::Convolution, opset::ArmConvolution>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGroupConvolutionToArm, "ConvertGroupConvolutionToArm");
+OPENVINO_OP(ArmPlugin::pass::ConvertGroupConvolutionToArm, "ConvertGroupConvolutionToArm");
 ArmPlugin::pass::ConvertGroupConvolutionToArm::ConvertGroupConvolutionToArm() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::GroupConvolution>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -173,12 +173,12 @@ ArmPlugin::pass::ConvertGroupConvolutionToArm::ConvertGroupConvolutionToArm() {
 }
 
 // ------------------------------------------ConvBiasFusion------------------------------------------
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvAddFusion, "ConvAddFusion");
+OPENVINO_OP(ArmPlugin::pass::ConvAddFusion, "ConvAddFusion");
 ArmPlugin::pass::ConvAddFusion::ConvAddFusion() {
     registerMatcher<opset::ArmConvolution, opset::Add>("ConvAddFusion");
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::GroupConvAddFusion, "GroupConvAddFusion");
+OPENVINO_OP(ArmPlugin::pass::GroupConvAddFusion, "GroupConvAddFusion");
 ArmPlugin::pass::GroupConvAddFusion::GroupConvAddFusion() {
     registerMatcher<opset::ArmGroupConvolution, opset::Add>("GroupConvAddFusion");
 }

--- a/modules/arm_plugin/src/transformations/conv_bias_fusion.cpp
+++ b/modules/arm_plugin/src/transformations/conv_bias_fusion.cpp
@@ -19,7 +19,6 @@ using namespace ArmPlugin;
 enum Layout {N, C, H, W};
 enum Inputs {Data, Weights, Bias};
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvBiasFusionBase, "ConvBiasFusionBase");
 template <class Conv, class Eltwise>
 void ArmPlugin::pass::ConvBiasFusionBase::registerMatcher(const std::string& name) {
     auto conv_pattern = ngraph::pattern::wrap_type<Conv>(ngraph::pattern::consumers_count(1));
@@ -108,7 +107,6 @@ void ArmPlugin::pass::ConvBiasFusionBase::registerMatcher(const std::string& nam
     });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertConvBase, "ConvertConvBase");
 template <class Conv, class ArmConv>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertConvBase::convert_conv_to_arm_conv() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -154,7 +152,6 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertConvBase::convert_conv_to_
 
 // ----------------------------------------ConvertConvolution----------------------------------------
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSingleConvolutionToArm, "ConvertSingleConvolutionToArm");
 ArmPlugin::pass::ConvertSingleConvolutionToArm::ConvertSingleConvolutionToArm() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
         ngraph::pattern::wrap_type<opset::Convolution>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -163,7 +160,6 @@ ArmPlugin::pass::ConvertSingleConvolutionToArm::ConvertSingleConvolutionToArm() 
     register_matcher(m, convert_conv_to_arm_conv<opset::Convolution, opset::ArmConvolution>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGroupConvolutionToArm, "ConvertGroupConvolutionToArm");
 ArmPlugin::pass::ConvertGroupConvolutionToArm::ConvertGroupConvolutionToArm() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::GroupConvolution>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -173,12 +169,10 @@ ArmPlugin::pass::ConvertGroupConvolutionToArm::ConvertGroupConvolutionToArm() {
 }
 
 // ------------------------------------------ConvBiasFusion------------------------------------------
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvAddFusion, "ConvAddFusion");
 ArmPlugin::pass::ConvAddFusion::ConvAddFusion() {
     registerMatcher<opset::ArmConvolution, opset::Add>("ConvAddFusion");
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::GroupConvAddFusion, "GroupConvAddFusion");
 ArmPlugin::pass::GroupConvAddFusion::GroupConvAddFusion() {
     registerMatcher<opset::ArmGroupConvolution, opset::Add>("GroupConvAddFusion");
 }

--- a/modules/arm_plugin/src/transformations/conv_bias_fusion.hpp
+++ b/modules/arm_plugin/src/transformations/conv_bias_fusion.hpp
@@ -11,39 +11,39 @@ namespace pass {
 
 class ConvertConvBase: public ngraph::pass::MatcherPass {
 protected:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertConvBase");
     template <class Conv, class ArmConv>
     ngraph::matcher_pass_callback convert_conv_to_arm_conv();
 };
 
 class ConvertSingleConvolutionToArm: public ConvertConvBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertSingleConvolutionToArm");
     ConvertSingleConvolutionToArm();
 };
 
 class ConvertGroupConvolutionToArm: public ConvertConvBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertGroupConvolutionToArm");
     ConvertGroupConvolutionToArm();
 };
 
 class ConvBiasFusionBase: public ngraph::pass::MatcherPass {
 protected:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvBiasFusionBase");
     template <class Conv, class Bias>
     void registerMatcher(const std::string& name);
 };
 
 class ConvAddFusion: public ConvBiasFusionBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvAddFusion");
     ConvAddFusion();
 };
 
 class GroupConvAddFusion: public ConvBiasFusionBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("GroupConvAddFusion");
     GroupConvAddFusion();
 };
 

--- a/modules/arm_plugin/src/transformations/conv_bias_fusion.hpp
+++ b/modules/arm_plugin/src/transformations/conv_bias_fusion.hpp
@@ -11,39 +11,39 @@ namespace pass {
 
 class ConvertConvBase: public ngraph::pass::MatcherPass {
 protected:
-    OPENVINO_OP("ConvertConvBase");
+    OPENVINO_RTTI("ConvertConvBase");
     template <class Conv, class ArmConv>
     ngraph::matcher_pass_callback convert_conv_to_arm_conv();
 };
 
 class ConvertSingleConvolutionToArm: public ConvertConvBase {
 public:
-    OPENVINO_OP("ConvertSingleConvolutionToArm");
+    OPENVINO_RTTI("ConvertSingleConvolutionToArm");
     ConvertSingleConvolutionToArm();
 };
 
 class ConvertGroupConvolutionToArm: public ConvertConvBase {
 public:
-    OPENVINO_OP("ConvertGroupConvolutionToArm");
+    OPENVINO_RTTI("ConvertGroupConvolutionToArm");
     ConvertGroupConvolutionToArm();
 };
 
 class ConvBiasFusionBase: public ngraph::pass::MatcherPass {
 protected:
-    OPENVINO_OP("ConvBiasFusionBase");
+    OPENVINO_RTTI("ConvBiasFusionBase");
     template <class Conv, class Bias>
     void registerMatcher(const std::string& name);
 };
 
 class ConvAddFusion: public ConvBiasFusionBase {
 public:
-    OPENVINO_OP("ConvAddFusion");
+    OPENVINO_RTTI("ConvAddFusion");
     ConvAddFusion();
 };
 
 class GroupConvAddFusion: public ConvBiasFusionBase {
 public:
-    OPENVINO_OP("GroupConvAddFusion");
+    OPENVINO_RTTI("GroupConvAddFusion");
     GroupConvAddFusion();
 };
 

--- a/modules/arm_plugin/src/transformations/convert_batch_norm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_batch_norm.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include "opset/opset.hpp"
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertBatchNormInference, "ConvertBatchNormInference");
+OPENVINO_OP(ArmPlugin::pass::ConvertBatchNormInference, "ConvertBatchNormInference");
 ArmPlugin::pass::ConvertBatchNormInference::ConvertBatchNormInference() {
     auto batch_norm = ngraph::pattern::wrap_type<opset::BatchNormInference>();
 

--- a/modules/arm_plugin/src/transformations/convert_batch_norm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_batch_norm.cpp
@@ -10,7 +10,6 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include "opset/opset.hpp"
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertBatchNormInference, "ConvertBatchNormInference");
 ArmPlugin::pass::ConvertBatchNormInference::ConvertBatchNormInference() {
     auto batch_norm = ngraph::pattern::wrap_type<opset::BatchNormInference>();
 

--- a/modules/arm_plugin/src/transformations/convert_batch_norm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_batch_norm.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include "opset/opset.hpp"
 
-OPENVINO_OP(ArmPlugin::pass::ConvertBatchNormInference, "ConvertBatchNormInference");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertBatchNormInference, "ConvertBatchNormInference");
 ArmPlugin::pass::ConvertBatchNormInference::ConvertBatchNormInference() {
     auto batch_norm = ngraph::pattern::wrap_type<opset::BatchNormInference>();
 

--- a/modules/arm_plugin/src/transformations/convert_batch_norm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_batch_norm.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include "opset/opset.hpp"
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertBatchNormInference, "ConvertBatchNormInference", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertBatchNormInference, "ConvertBatchNormInference");
 ArmPlugin::pass::ConvertBatchNormInference::ConvertBatchNormInference() {
     auto batch_norm = ngraph::pattern::wrap_type<opset::BatchNormInference>();
 

--- a/modules/arm_plugin/src/transformations/convert_batch_norm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_batch_norm.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertBatchNormInference: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertBatchNormInference");
+    OPENVINO_RTTI("ConvertBatchNormInference");
     ConvertBatchNormInference();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_batch_norm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_batch_norm.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertBatchNormInference: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertBatchNormInference");
     ConvertBatchNormInference();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_batchnorm_v0_to_v5.cpp
+++ b/modules/arm_plugin/src/transformations/convert_batchnorm_v0_to_v5.cpp
@@ -8,7 +8,7 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(pass::ConvertBatchNormInferenceV0toV5, "ConvertBatchNormInferenceV0toV5", 0);
+NGRAPH_RTTI_DEFINITION(pass::ConvertBatchNormInferenceV0toV5, "ConvertBatchNormInferenceV0toV5");
 
 pass::ConvertBatchNormInferenceV0toV5::ConvertBatchNormInferenceV0toV5() {
     register_matcher(

--- a/modules/arm_plugin/src/transformations/convert_batchnorm_v0_to_v5.cpp
+++ b/modules/arm_plugin/src/transformations/convert_batchnorm_v0_to_v5.cpp
@@ -8,8 +8,6 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(pass::ConvertBatchNormInferenceV0toV5, "ConvertBatchNormInferenceV0toV5");
-
 pass::ConvertBatchNormInferenceV0toV5::ConvertBatchNormInferenceV0toV5() {
     register_matcher(
         std::make_shared<ngraph::pattern::Matcher>(

--- a/modules/arm_plugin/src/transformations/convert_batchnorm_v0_to_v5.cpp
+++ b/modules/arm_plugin/src/transformations/convert_batchnorm_v0_to_v5.cpp
@@ -8,7 +8,7 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(pass::ConvertBatchNormInferenceV0toV5, "ConvertBatchNormInferenceV0toV5");
+OPENVINO_OP(pass::ConvertBatchNormInferenceV0toV5, "ConvertBatchNormInferenceV0toV5");
 
 pass::ConvertBatchNormInferenceV0toV5::ConvertBatchNormInferenceV0toV5() {
     register_matcher(

--- a/modules/arm_plugin/src/transformations/convert_batchnorm_v0_to_v5.cpp
+++ b/modules/arm_plugin/src/transformations/convert_batchnorm_v0_to_v5.cpp
@@ -8,7 +8,7 @@
 
 using namespace ArmPlugin;
 
-OPENVINO_OP(pass::ConvertBatchNormInferenceV0toV5, "ConvertBatchNormInferenceV0toV5");
+NGRAPH_RTTI_DEFINITION(pass::ConvertBatchNormInferenceV0toV5, "ConvertBatchNormInferenceV0toV5");
 
 pass::ConvertBatchNormInferenceV0toV5::ConvertBatchNormInferenceV0toV5() {
     register_matcher(

--- a/modules/arm_plugin/src/transformations/convert_batchnorm_v0_to_v5.hpp
+++ b/modules/arm_plugin/src/transformations/convert_batchnorm_v0_to_v5.hpp
@@ -15,6 +15,6 @@ class ConvertBatchNormInferenceV0toV5;
 
 class ArmPlugin::pass::ConvertBatchNormInferenceV0toV5 : public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertBatchNormInferenceV0toV5");
+    OPENVINO_RTTI("ConvertBatchNormInferenceV0toV5");
     ConvertBatchNormInferenceV0toV5();
 };

--- a/modules/arm_plugin/src/transformations/convert_batchnorm_v0_to_v5.hpp
+++ b/modules/arm_plugin/src/transformations/convert_batchnorm_v0_to_v5.hpp
@@ -15,6 +15,6 @@ class ConvertBatchNormInferenceV0toV5;
 
 class ArmPlugin::pass::ConvertBatchNormInferenceV0toV5 : public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertBatchNormInferenceV0toV5");
     ConvertBatchNormInferenceV0toV5();
 };

--- a/modules/arm_plugin/src/transformations/convert_ceiling.cpp
+++ b/modules/arm_plugin/src/transformations/convert_ceiling.cpp
@@ -10,8 +10,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertCeiling, "ConvertCeiling");
-
 ArmPlugin::pass::ConvertCeiling::ConvertCeiling() {
     auto ceil = ngraph::pattern::wrap_type<opset::Ceiling>();
 

--- a/modules/arm_plugin/src/transformations/convert_ceiling.cpp
+++ b/modules/arm_plugin/src/transformations/convert_ceiling.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertCeiling, "ConvertCeiling", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertCeiling, "ConvertCeiling");
 
 ArmPlugin::pass::ConvertCeiling::ConvertCeiling() {
     auto ceil = ngraph::pattern::wrap_type<opset::Ceiling>();

--- a/modules/arm_plugin/src/transformations/convert_ceiling.cpp
+++ b/modules/arm_plugin/src/transformations/convert_ceiling.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertCeiling, "ConvertCeiling");
+OPENVINO_OP(ArmPlugin::pass::ConvertCeiling, "ConvertCeiling");
 
 ArmPlugin::pass::ConvertCeiling::ConvertCeiling() {
     auto ceil = ngraph::pattern::wrap_type<opset::Ceiling>();

--- a/modules/arm_plugin/src/transformations/convert_ceiling.cpp
+++ b/modules/arm_plugin/src/transformations/convert_ceiling.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ConvertCeiling, "ConvertCeiling");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertCeiling, "ConvertCeiling");
 
 ArmPlugin::pass::ConvertCeiling::ConvertCeiling() {
     auto ceil = ngraph::pattern::wrap_type<opset::Ceiling>();

--- a/modules/arm_plugin/src/transformations/convert_ceiling.hpp
+++ b/modules/arm_plugin/src/transformations/convert_ceiling.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertCeiling: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertCeiling");
     ConvertCeiling();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_ceiling.hpp
+++ b/modules/arm_plugin/src/transformations/convert_ceiling.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertCeiling: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertCeiling");
+    OPENVINO_RTTI("ConvertCeiling");
     ConvertCeiling();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_comparison.cpp
+++ b/modules/arm_plugin/src/transformations/convert_comparison.cpp
@@ -8,7 +8,7 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertComparisionBase, "ConvertComparisionBase", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertComparisionBase, "ConvertComparisionBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertComparisionBase::convert_comparision() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -56,7 +56,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertComparisionBase::convert_c
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertEqual, "ConvertEqual", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertEqual, "ConvertEqual");
 ArmPlugin::pass::ConvertEqual::ConvertEqual() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Equal>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -65,7 +65,7 @@ ArmPlugin::pass::ConvertEqual::ConvertEqual() {
     register_matcher(m, convert_comparision<opset::Equal>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertNotEqual, "ConvertNotEqual", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertNotEqual, "ConvertNotEqual");
 ArmPlugin::pass::ConvertNotEqual::ConvertNotEqual() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::NotEqual>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -74,7 +74,7 @@ ArmPlugin::pass::ConvertNotEqual::ConvertNotEqual() {
     register_matcher(m, convert_comparision<opset::NotEqual>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGreater, "ConvertGreater", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGreater, "ConvertGreater");
 ArmPlugin::pass::ConvertGreater::ConvertGreater() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Greater>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -83,7 +83,7 @@ ArmPlugin::pass::ConvertGreater::ConvertGreater() {
     register_matcher(m, convert_comparision<opset::Greater>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGreaterEqual, "ConvertGreaterEqual", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGreaterEqual, "ConvertGreaterEqual");
 ArmPlugin::pass::ConvertGreaterEqual::ConvertGreaterEqual() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::GreaterEqual>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -92,7 +92,7 @@ ArmPlugin::pass::ConvertGreaterEqual::ConvertGreaterEqual() {
     register_matcher(m, convert_comparision<opset::GreaterEqual>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLess, "ConvertLess", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLess, "ConvertLess");
 ArmPlugin::pass::ConvertLess::ConvertLess() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Less>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -101,7 +101,7 @@ ArmPlugin::pass::ConvertLess::ConvertLess() {
     register_matcher(m, convert_comparision<opset::Less>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLessEqual, "ConvertLessEqual", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLessEqual, "ConvertLessEqual");
 ArmPlugin::pass::ConvertLessEqual::ConvertLessEqual() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::LessEqual>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_comparison.cpp
+++ b/modules/arm_plugin/src/transformations/convert_comparison.cpp
@@ -8,7 +8,6 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertComparisionBase, "ConvertComparisionBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertComparisionBase::convert_comparision() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -56,7 +55,6 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertComparisionBase::convert_c
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertEqual, "ConvertEqual");
 ArmPlugin::pass::ConvertEqual::ConvertEqual() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Equal>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -65,7 +63,6 @@ ArmPlugin::pass::ConvertEqual::ConvertEqual() {
     register_matcher(m, convert_comparision<opset::Equal>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertNotEqual, "ConvertNotEqual");
 ArmPlugin::pass::ConvertNotEqual::ConvertNotEqual() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::NotEqual>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -74,7 +71,6 @@ ArmPlugin::pass::ConvertNotEqual::ConvertNotEqual() {
     register_matcher(m, convert_comparision<opset::NotEqual>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGreater, "ConvertGreater");
 ArmPlugin::pass::ConvertGreater::ConvertGreater() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Greater>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -83,7 +79,6 @@ ArmPlugin::pass::ConvertGreater::ConvertGreater() {
     register_matcher(m, convert_comparision<opset::Greater>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGreaterEqual, "ConvertGreaterEqual");
 ArmPlugin::pass::ConvertGreaterEqual::ConvertGreaterEqual() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::GreaterEqual>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -92,7 +87,6 @@ ArmPlugin::pass::ConvertGreaterEqual::ConvertGreaterEqual() {
     register_matcher(m, convert_comparision<opset::GreaterEqual>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLess, "ConvertLess");
 ArmPlugin::pass::ConvertLess::ConvertLess() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Less>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -101,7 +95,6 @@ ArmPlugin::pass::ConvertLess::ConvertLess() {
     register_matcher(m, convert_comparision<opset::Less>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLessEqual, "ConvertLessEqual");
 ArmPlugin::pass::ConvertLessEqual::ConvertLessEqual() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::LessEqual>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_comparison.cpp
+++ b/modules/arm_plugin/src/transformations/convert_comparison.cpp
@@ -8,7 +8,7 @@
 
 using namespace ArmPlugin;
 
-OPENVINO_OP(ArmPlugin::pass::ConvertComparisionBase, "ConvertComparisionBase");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertComparisionBase, "ConvertComparisionBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertComparisionBase::convert_comparision() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -56,7 +56,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertComparisionBase::convert_c
     };
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertEqual, "ConvertEqual");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertEqual, "ConvertEqual");
 ArmPlugin::pass::ConvertEqual::ConvertEqual() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Equal>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -65,7 +65,7 @@ ArmPlugin::pass::ConvertEqual::ConvertEqual() {
     register_matcher(m, convert_comparision<opset::Equal>());
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertNotEqual, "ConvertNotEqual");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertNotEqual, "ConvertNotEqual");
 ArmPlugin::pass::ConvertNotEqual::ConvertNotEqual() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::NotEqual>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -74,7 +74,7 @@ ArmPlugin::pass::ConvertNotEqual::ConvertNotEqual() {
     register_matcher(m, convert_comparision<opset::NotEqual>());
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertGreater, "ConvertGreater");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGreater, "ConvertGreater");
 ArmPlugin::pass::ConvertGreater::ConvertGreater() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Greater>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -83,7 +83,7 @@ ArmPlugin::pass::ConvertGreater::ConvertGreater() {
     register_matcher(m, convert_comparision<opset::Greater>());
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertGreaterEqual, "ConvertGreaterEqual");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGreaterEqual, "ConvertGreaterEqual");
 ArmPlugin::pass::ConvertGreaterEqual::ConvertGreaterEqual() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::GreaterEqual>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -92,7 +92,7 @@ ArmPlugin::pass::ConvertGreaterEqual::ConvertGreaterEqual() {
     register_matcher(m, convert_comparision<opset::GreaterEqual>());
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertLess, "ConvertLess");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLess, "ConvertLess");
 ArmPlugin::pass::ConvertLess::ConvertLess() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Less>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -101,7 +101,7 @@ ArmPlugin::pass::ConvertLess::ConvertLess() {
     register_matcher(m, convert_comparision<opset::Less>());
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertLessEqual, "ConvertLessEqual");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLessEqual, "ConvertLessEqual");
 ArmPlugin::pass::ConvertLessEqual::ConvertLessEqual() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::LessEqual>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_comparison.cpp
+++ b/modules/arm_plugin/src/transformations/convert_comparison.cpp
@@ -8,7 +8,7 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertComparisionBase, "ConvertComparisionBase");
+OPENVINO_OP(ArmPlugin::pass::ConvertComparisionBase, "ConvertComparisionBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertComparisionBase::convert_comparision() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -56,7 +56,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertComparisionBase::convert_c
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertEqual, "ConvertEqual");
+OPENVINO_OP(ArmPlugin::pass::ConvertEqual, "ConvertEqual");
 ArmPlugin::pass::ConvertEqual::ConvertEqual() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Equal>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -65,7 +65,7 @@ ArmPlugin::pass::ConvertEqual::ConvertEqual() {
     register_matcher(m, convert_comparision<opset::Equal>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertNotEqual, "ConvertNotEqual");
+OPENVINO_OP(ArmPlugin::pass::ConvertNotEqual, "ConvertNotEqual");
 ArmPlugin::pass::ConvertNotEqual::ConvertNotEqual() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::NotEqual>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -74,7 +74,7 @@ ArmPlugin::pass::ConvertNotEqual::ConvertNotEqual() {
     register_matcher(m, convert_comparision<opset::NotEqual>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGreater, "ConvertGreater");
+OPENVINO_OP(ArmPlugin::pass::ConvertGreater, "ConvertGreater");
 ArmPlugin::pass::ConvertGreater::ConvertGreater() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Greater>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -83,7 +83,7 @@ ArmPlugin::pass::ConvertGreater::ConvertGreater() {
     register_matcher(m, convert_comparision<opset::Greater>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGreaterEqual, "ConvertGreaterEqual");
+OPENVINO_OP(ArmPlugin::pass::ConvertGreaterEqual, "ConvertGreaterEqual");
 ArmPlugin::pass::ConvertGreaterEqual::ConvertGreaterEqual() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::GreaterEqual>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -92,7 +92,7 @@ ArmPlugin::pass::ConvertGreaterEqual::ConvertGreaterEqual() {
     register_matcher(m, convert_comparision<opset::GreaterEqual>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLess, "ConvertLess");
+OPENVINO_OP(ArmPlugin::pass::ConvertLess, "ConvertLess");
 ArmPlugin::pass::ConvertLess::ConvertLess() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Less>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -101,7 +101,7 @@ ArmPlugin::pass::ConvertLess::ConvertLess() {
     register_matcher(m, convert_comparision<opset::Less>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLessEqual, "ConvertLessEqual");
+OPENVINO_OP(ArmPlugin::pass::ConvertLessEqual, "ConvertLessEqual");
 ArmPlugin::pass::ConvertLessEqual::ConvertLessEqual() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::LessEqual>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_comparison.hpp
+++ b/modules/arm_plugin/src/transformations/convert_comparison.hpp
@@ -11,44 +11,44 @@ namespace pass {
 
 class ConvertComparisionBase : public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertComparisionBase");
+    OPENVINO_RTTI("ConvertComparisionBase");
     template <class T>
     ngraph::matcher_pass_callback convert_comparision();
 };
 
 class ConvertEqual: public ConvertComparisionBase {
 public:
-    OPENVINO_OP("ConvertEqual");
+    OPENVINO_RTTI("ConvertEqual");
     ConvertEqual();
 };
 
 class ConvertNotEqual: public ConvertComparisionBase {
 public:
-    OPENVINO_OP("ConvertNotEqual");
+    OPENVINO_RTTI("ConvertNotEqual");
     ConvertNotEqual();
 };
 
 class ConvertGreater: public ConvertComparisionBase {
 public:
-    OPENVINO_OP("ConvertGreater");
+    OPENVINO_RTTI("ConvertGreater");
     ConvertGreater();
 };
 
 class ConvertGreaterEqual: public ConvertComparisionBase {
 public:
-    OPENVINO_OP("ConvertGreaterEqual");
+    OPENVINO_RTTI("ConvertGreaterEqual");
     ConvertGreaterEqual();
 };
 
 class ConvertLess: public ConvertComparisionBase {
 public:
-    OPENVINO_OP("ConvertLess");
+    OPENVINO_RTTI("ConvertLess");
     ConvertLess();
 };
 
 class ConvertLessEqual: public ConvertComparisionBase {
 public:
-    OPENVINO_OP("ConvertLessEqual");
+    OPENVINO_RTTI("ConvertLessEqual");
     ConvertLessEqual();
 };
 

--- a/modules/arm_plugin/src/transformations/convert_comparison.hpp
+++ b/modules/arm_plugin/src/transformations/convert_comparison.hpp
@@ -11,44 +11,44 @@ namespace pass {
 
 class ConvertComparisionBase : public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertComparisionBase");
     template <class T>
     ngraph::matcher_pass_callback convert_comparision();
 };
 
 class ConvertEqual: public ConvertComparisionBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertEqual");
     ConvertEqual();
 };
 
 class ConvertNotEqual: public ConvertComparisionBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertNotEqual");
     ConvertNotEqual();
 };
 
 class ConvertGreater: public ConvertComparisionBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertGreater");
     ConvertGreater();
 };
 
 class ConvertGreaterEqual: public ConvertComparisionBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertGreaterEqual");
     ConvertGreaterEqual();
 };
 
 class ConvertLess: public ConvertComparisionBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertLess");
     ConvertLess();
 };
 
 class ConvertLessEqual: public ConvertComparisionBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertLessEqual");
     ConvertLessEqual();
 };
 

--- a/modules/arm_plugin/src/transformations/convert_concat.cpp
+++ b/modules/arm_plugin/src/transformations/convert_concat.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertConcat, "ConvertConcat");
+OPENVINO_OP(ArmPlugin::pass::ConvertConcat, "ConvertConcat");
 ArmPlugin::pass::ConvertConcat::ConvertConcat() {
     auto concat = ngraph::pattern::wrap_type<opset::Concat>();
 

--- a/modules/arm_plugin/src/transformations/convert_concat.cpp
+++ b/modules/arm_plugin/src/transformations/convert_concat.cpp
@@ -7,7 +7,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertConcat, "ConvertConcat");
 ArmPlugin::pass::ConvertConcat::ConvertConcat() {
     auto concat = ngraph::pattern::wrap_type<opset::Concat>();
 

--- a/modules/arm_plugin/src/transformations/convert_concat.cpp
+++ b/modules/arm_plugin/src/transformations/convert_concat.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertConcat, "ConvertConcat", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertConcat, "ConvertConcat");
 ArmPlugin::pass::ConvertConcat::ConvertConcat() {
     auto concat = ngraph::pattern::wrap_type<opset::Concat>();
 

--- a/modules/arm_plugin/src/transformations/convert_concat.cpp
+++ b/modules/arm_plugin/src/transformations/convert_concat.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ConvertConcat, "ConvertConcat");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertConcat, "ConvertConcat");
 ArmPlugin::pass::ConvertConcat::ConvertConcat() {
     auto concat = ngraph::pattern::wrap_type<opset::Concat>();
 

--- a/modules/arm_plugin/src/transformations/convert_concat.hpp
+++ b/modules/arm_plugin/src/transformations/convert_concat.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertConcat: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertConcat");
     ConvertConcat();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_concat.hpp
+++ b/modules/arm_plugin/src/transformations/convert_concat.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertConcat: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertConcat");
+    OPENVINO_RTTI("ConvertConcat");
     ConvertConcat();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_conv1d_to_conv2d.cpp
+++ b/modules/arm_plugin/src/transformations/convert_conv1d_to_conv2d.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ConvertConv1DBase, "ConvertConv1DBase");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertConv1DBase, "ConvertConv1DBase");
 template <class Conv>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertConv1DBase::convert_conv1d_to_conv2d() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -56,7 +56,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertConv1DBase::convert_conv1d
     };
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertConv1D, "ConvertConv1D");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertConv1D, "ConvertConv1D");
 ArmPlugin::pass::ConvertConv1D::ConvertConv1D() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
         ngraph::pattern::wrap_type<opset::Convolution>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -65,7 +65,7 @@ ArmPlugin::pass::ConvertConv1D::ConvertConv1D() {
     register_matcher(m, convert_conv1d_to_conv2d<opset::Convolution>());
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertGroupConv1D, "ConvertGroupConv1D");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGroupConv1D, "ConvertGroupConv1D");
 ArmPlugin::pass::ConvertGroupConv1D::ConvertGroupConv1D() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::GroupConvolution>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_conv1d_to_conv2d.cpp
+++ b/modules/arm_plugin/src/transformations/convert_conv1d_to_conv2d.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertConv1DBase, "ConvertConv1DBase");
+OPENVINO_OP(ArmPlugin::pass::ConvertConv1DBase, "ConvertConv1DBase");
 template <class Conv>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertConv1DBase::convert_conv1d_to_conv2d() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -56,7 +56,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertConv1DBase::convert_conv1d
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertConv1D, "ConvertConv1D");
+OPENVINO_OP(ArmPlugin::pass::ConvertConv1D, "ConvertConv1D");
 ArmPlugin::pass::ConvertConv1D::ConvertConv1D() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
         ngraph::pattern::wrap_type<opset::Convolution>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -65,7 +65,7 @@ ArmPlugin::pass::ConvertConv1D::ConvertConv1D() {
     register_matcher(m, convert_conv1d_to_conv2d<opset::Convolution>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGroupConv1D, "ConvertGroupConv1D");
+OPENVINO_OP(ArmPlugin::pass::ConvertGroupConv1D, "ConvertGroupConv1D");
 ArmPlugin::pass::ConvertGroupConv1D::ConvertGroupConv1D() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::GroupConvolution>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_conv1d_to_conv2d.cpp
+++ b/modules/arm_plugin/src/transformations/convert_conv1d_to_conv2d.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertConv1DBase, "ConvertConv1DBase", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertConv1DBase, "ConvertConv1DBase");
 template <class Conv>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertConv1DBase::convert_conv1d_to_conv2d() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -56,7 +56,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertConv1DBase::convert_conv1d
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertConv1D, "ConvertConv1D", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertConv1D, "ConvertConv1D");
 ArmPlugin::pass::ConvertConv1D::ConvertConv1D() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
         ngraph::pattern::wrap_type<opset::Convolution>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -65,7 +65,7 @@ ArmPlugin::pass::ConvertConv1D::ConvertConv1D() {
     register_matcher(m, convert_conv1d_to_conv2d<opset::Convolution>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGroupConv1D, "ConvertGroupConv1D", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGroupConv1D, "ConvertGroupConv1D");
 ArmPlugin::pass::ConvertGroupConv1D::ConvertGroupConv1D() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::GroupConvolution>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_conv1d_to_conv2d.cpp
+++ b/modules/arm_plugin/src/transformations/convert_conv1d_to_conv2d.cpp
@@ -10,7 +10,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertConv1DBase, "ConvertConv1DBase");
 template <class Conv>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertConv1DBase::convert_conv1d_to_conv2d() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -56,7 +55,6 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertConv1DBase::convert_conv1d
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertConv1D, "ConvertConv1D");
 ArmPlugin::pass::ConvertConv1D::ConvertConv1D() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
         ngraph::pattern::wrap_type<opset::Convolution>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -65,7 +63,6 @@ ArmPlugin::pass::ConvertConv1D::ConvertConv1D() {
     register_matcher(m, convert_conv1d_to_conv2d<opset::Convolution>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGroupConv1D, "ConvertGroupConv1D");
 ArmPlugin::pass::ConvertGroupConv1D::ConvertGroupConv1D() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::GroupConvolution>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_conv1d_to_conv2d.hpp
+++ b/modules/arm_plugin/src/transformations/convert_conv1d_to_conv2d.hpp
@@ -10,20 +10,20 @@ namespace pass {
 
 class ConvertConv1DBase: public ngraph::pass::MatcherPass {
 protected:
-    OPENVINO_OP("ConvertConv1DBase");
+    OPENVINO_RTTI("ConvertConv1DBase");
     template <class Conv>
     ngraph::matcher_pass_callback convert_conv1d_to_conv2d();
 };
 
 class ConvertConv1D: public ConvertConv1DBase {
 public:
-    OPENVINO_OP("ConvertConv1D");
+    OPENVINO_RTTI("ConvertConv1D");
     ConvertConv1D();
 };
 
 class ConvertGroupConv1D: public ConvertConv1DBase {
 public:
-    OPENVINO_OP("ConvertGroupConv1D");
+    OPENVINO_RTTI("ConvertGroupConv1D");
     ConvertGroupConv1D();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_conv1d_to_conv2d.hpp
+++ b/modules/arm_plugin/src/transformations/convert_conv1d_to_conv2d.hpp
@@ -10,20 +10,20 @@ namespace pass {
 
 class ConvertConv1DBase: public ngraph::pass::MatcherPass {
 protected:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertConv1DBase");
     template <class Conv>
     ngraph::matcher_pass_callback convert_conv1d_to_conv2d();
 };
 
 class ConvertConv1D: public ConvertConv1DBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertConv1D");
     ConvertConv1D();
 };
 
 class ConvertGroupConv1D: public ConvertConv1DBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertGroupConv1D");
     ConvertGroupConv1D();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_convert.cpp
+++ b/modules/arm_plugin/src/transformations/convert_convert.cpp
@@ -10,7 +10,7 @@
 
 using type = ngraph::element::Type_t;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmConvertBase, "ConvertArmConvertBase", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmConvertBase, "ConvertArmConvertBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertArmConvertBase::convert_to_arm_convert() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -38,7 +38,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertArmConvertBase::convert_to
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmConvert, "ConvertArmConvert", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmConvert, "ConvertArmConvert");
 ArmPlugin::pass::ConvertArmConvert::ConvertArmConvert() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Convert>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape())}),
@@ -46,7 +46,7 @@ ArmPlugin::pass::ConvertArmConvert::ConvertArmConvert() {
     register_matcher(m, convert_to_arm_convert<opset::Convert>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmConvertLike, "ConvertArmConvertLike", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmConvertLike, "ConvertArmConvertLike");
 ArmPlugin::pass::ConvertArmConvertLike::ConvertArmConvertLike() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::ConvertLike>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_convert.cpp
+++ b/modules/arm_plugin/src/transformations/convert_convert.cpp
@@ -10,7 +10,6 @@
 
 using type = ngraph::element::Type_t;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmConvertBase, "ConvertArmConvertBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertArmConvertBase::convert_to_arm_convert() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -38,7 +37,6 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertArmConvertBase::convert_to
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmConvert, "ConvertArmConvert");
 ArmPlugin::pass::ConvertArmConvert::ConvertArmConvert() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Convert>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape())}),
@@ -46,7 +44,6 @@ ArmPlugin::pass::ConvertArmConvert::ConvertArmConvert() {
     register_matcher(m, convert_to_arm_convert<opset::Convert>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmConvertLike, "ConvertArmConvertLike");
 ArmPlugin::pass::ConvertArmConvertLike::ConvertArmConvertLike() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::ConvertLike>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_convert.cpp
+++ b/modules/arm_plugin/src/transformations/convert_convert.cpp
@@ -10,7 +10,7 @@
 
 using type = ngraph::element::Type_t;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmConvertBase, "ConvertArmConvertBase");
+OPENVINO_OP(ArmPlugin::pass::ConvertArmConvertBase, "ConvertArmConvertBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertArmConvertBase::convert_to_arm_convert() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -38,7 +38,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertArmConvertBase::convert_to
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmConvert, "ConvertArmConvert");
+OPENVINO_OP(ArmPlugin::pass::ConvertArmConvert, "ConvertArmConvert");
 ArmPlugin::pass::ConvertArmConvert::ConvertArmConvert() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Convert>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape())}),
@@ -46,7 +46,7 @@ ArmPlugin::pass::ConvertArmConvert::ConvertArmConvert() {
     register_matcher(m, convert_to_arm_convert<opset::Convert>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmConvertLike, "ConvertArmConvertLike");
+OPENVINO_OP(ArmPlugin::pass::ConvertArmConvertLike, "ConvertArmConvertLike");
 ArmPlugin::pass::ConvertArmConvertLike::ConvertArmConvertLike() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::ConvertLike>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_convert.cpp
+++ b/modules/arm_plugin/src/transformations/convert_convert.cpp
@@ -10,7 +10,7 @@
 
 using type = ngraph::element::Type_t;
 
-OPENVINO_OP(ArmPlugin::pass::ConvertArmConvertBase, "ConvertArmConvertBase");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmConvertBase, "ConvertArmConvertBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertArmConvertBase::convert_to_arm_convert() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -38,7 +38,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertArmConvertBase::convert_to
     };
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertArmConvert, "ConvertArmConvert");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmConvert, "ConvertArmConvert");
 ArmPlugin::pass::ConvertArmConvert::ConvertArmConvert() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Convert>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape())}),
@@ -46,7 +46,7 @@ ArmPlugin::pass::ConvertArmConvert::ConvertArmConvert() {
     register_matcher(m, convert_to_arm_convert<opset::Convert>());
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertArmConvertLike, "ConvertArmConvertLike");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmConvertLike, "ConvertArmConvertLike");
 ArmPlugin::pass::ConvertArmConvertLike::ConvertArmConvertLike() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::ConvertLike>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_convert.hpp
+++ b/modules/arm_plugin/src/transformations/convert_convert.hpp
@@ -10,20 +10,20 @@ namespace pass {
 
 class ConvertArmConvertBase : public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertArmConvertBase");
     template <class T>
     ngraph::matcher_pass_callback convert_to_arm_convert();
 };
 
 class ConvertArmConvert : public ConvertArmConvertBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertArmConvert");
     ConvertArmConvert();
 };
 
 class ConvertArmConvertLike : public ConvertArmConvertBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertArmConvertLike");
     ConvertArmConvertLike();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_convert.hpp
+++ b/modules/arm_plugin/src/transformations/convert_convert.hpp
@@ -10,20 +10,20 @@ namespace pass {
 
 class ConvertArmConvertBase : public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertArmConvertBase");
+    OPENVINO_RTTI("ConvertArmConvertBase");
     template <class T>
     ngraph::matcher_pass_callback convert_to_arm_convert();
 };
 
 class ConvertArmConvert : public ConvertArmConvertBase {
 public:
-    OPENVINO_OP("ConvertArmConvert");
+    OPENVINO_RTTI("ConvertArmConvert");
     ConvertArmConvert();
 };
 
 class ConvertArmConvertLike : public ConvertArmConvertBase {
 public:
-    OPENVINO_OP("ConvertArmConvertLike");
+    OPENVINO_RTTI("ConvertArmConvertLike");
     ConvertArmConvertLike();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_eltwise.cpp
+++ b/modules/arm_plugin/src/transformations/convert_eltwise.cpp
@@ -11,7 +11,7 @@
 
 using namespace ArmPlugin;
 
-OPENVINO_OP(ArmPlugin::pass::ConvertEltwiseBase, "ConvertEltwiseBase");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertEltwiseBase, "ConvertEltwiseBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertEltwiseBase::convert_eltwise() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -36,7 +36,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertEltwiseBase::convert_eltwi
     };
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertAdd, "ConvertAdd");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertAdd, "ConvertAdd");
 ArmPlugin::pass::ConvertAdd::ConvertAdd() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Add>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -45,7 +45,7 @@ ArmPlugin::pass::ConvertAdd::ConvertAdd() {
     register_matcher(m, convert_eltwise<opset::Add>());
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertSubtract, "ConvertSubtract");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSubtract, "ConvertSubtract");
 ArmPlugin::pass::ConvertSubtract::ConvertSubtract() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Subtract>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -54,7 +54,7 @@ ArmPlugin::pass::ConvertSubtract::ConvertSubtract() {
     register_matcher(m, convert_eltwise<opset::Subtract>());
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertMultiply, "ConvertMultiply");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMultiply, "ConvertMultiply");
 ArmPlugin::pass::ConvertMultiply::ConvertMultiply() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Multiply>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -63,7 +63,7 @@ ArmPlugin::pass::ConvertMultiply::ConvertMultiply() {
     register_matcher(m, convert_eltwise<opset::Multiply>());
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertMinimum, "ConvertMinimum");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMinimum, "ConvertMinimum");
 ArmPlugin::pass::ConvertMinimum::ConvertMinimum() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Minimum>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -72,7 +72,7 @@ ArmPlugin::pass::ConvertMinimum::ConvertMinimum() {
     register_matcher(m, convert_eltwise<opset::Minimum>());
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertMaximum, "ConvertMaximum");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMaximum, "ConvertMaximum");
 ArmPlugin::pass::ConvertMaximum::ConvertMaximum() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Maximum>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_eltwise.cpp
+++ b/modules/arm_plugin/src/transformations/convert_eltwise.cpp
@@ -11,7 +11,7 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertEltwiseBase, "ConvertEltwiseBase", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertEltwiseBase, "ConvertEltwiseBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertEltwiseBase::convert_eltwise() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -36,7 +36,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertEltwiseBase::convert_eltwi
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertAdd, "ConvertAdd", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertAdd, "ConvertAdd");
 ArmPlugin::pass::ConvertAdd::ConvertAdd() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Add>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -45,7 +45,7 @@ ArmPlugin::pass::ConvertAdd::ConvertAdd() {
     register_matcher(m, convert_eltwise<opset::Add>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSubtract, "ConvertSubtract", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSubtract, "ConvertSubtract");
 ArmPlugin::pass::ConvertSubtract::ConvertSubtract() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Subtract>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -54,7 +54,7 @@ ArmPlugin::pass::ConvertSubtract::ConvertSubtract() {
     register_matcher(m, convert_eltwise<opset::Subtract>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMultiply, "ConvertMultiply", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMultiply, "ConvertMultiply");
 ArmPlugin::pass::ConvertMultiply::ConvertMultiply() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Multiply>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -63,7 +63,7 @@ ArmPlugin::pass::ConvertMultiply::ConvertMultiply() {
     register_matcher(m, convert_eltwise<opset::Multiply>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMinimum, "ConvertMinimum", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMinimum, "ConvertMinimum");
 ArmPlugin::pass::ConvertMinimum::ConvertMinimum() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Minimum>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -72,7 +72,7 @@ ArmPlugin::pass::ConvertMinimum::ConvertMinimum() {
     register_matcher(m, convert_eltwise<opset::Minimum>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMaximum, "ConvertMaximum", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMaximum, "ConvertMaximum");
 ArmPlugin::pass::ConvertMaximum::ConvertMaximum() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Maximum>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_eltwise.cpp
+++ b/modules/arm_plugin/src/transformations/convert_eltwise.cpp
@@ -11,7 +11,7 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertEltwiseBase, "ConvertEltwiseBase");
+OPENVINO_OP(ArmPlugin::pass::ConvertEltwiseBase, "ConvertEltwiseBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertEltwiseBase::convert_eltwise() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -36,7 +36,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertEltwiseBase::convert_eltwi
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertAdd, "ConvertAdd");
+OPENVINO_OP(ArmPlugin::pass::ConvertAdd, "ConvertAdd");
 ArmPlugin::pass::ConvertAdd::ConvertAdd() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Add>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -45,7 +45,7 @@ ArmPlugin::pass::ConvertAdd::ConvertAdd() {
     register_matcher(m, convert_eltwise<opset::Add>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSubtract, "ConvertSubtract");
+OPENVINO_OP(ArmPlugin::pass::ConvertSubtract, "ConvertSubtract");
 ArmPlugin::pass::ConvertSubtract::ConvertSubtract() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Subtract>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -54,7 +54,7 @@ ArmPlugin::pass::ConvertSubtract::ConvertSubtract() {
     register_matcher(m, convert_eltwise<opset::Subtract>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMultiply, "ConvertMultiply");
+OPENVINO_OP(ArmPlugin::pass::ConvertMultiply, "ConvertMultiply");
 ArmPlugin::pass::ConvertMultiply::ConvertMultiply() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Multiply>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -63,7 +63,7 @@ ArmPlugin::pass::ConvertMultiply::ConvertMultiply() {
     register_matcher(m, convert_eltwise<opset::Multiply>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMinimum, "ConvertMinimum");
+OPENVINO_OP(ArmPlugin::pass::ConvertMinimum, "ConvertMinimum");
 ArmPlugin::pass::ConvertMinimum::ConvertMinimum() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Minimum>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -72,7 +72,7 @@ ArmPlugin::pass::ConvertMinimum::ConvertMinimum() {
     register_matcher(m, convert_eltwise<opset::Minimum>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMaximum, "ConvertMaximum");
+OPENVINO_OP(ArmPlugin::pass::ConvertMaximum, "ConvertMaximum");
 ArmPlugin::pass::ConvertMaximum::ConvertMaximum() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Maximum>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_eltwise.cpp
+++ b/modules/arm_plugin/src/transformations/convert_eltwise.cpp
@@ -11,7 +11,6 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertEltwiseBase, "ConvertEltwiseBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertEltwiseBase::convert_eltwise() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -36,7 +35,6 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertEltwiseBase::convert_eltwi
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertAdd, "ConvertAdd");
 ArmPlugin::pass::ConvertAdd::ConvertAdd() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Add>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -45,7 +43,6 @@ ArmPlugin::pass::ConvertAdd::ConvertAdd() {
     register_matcher(m, convert_eltwise<opset::Add>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSubtract, "ConvertSubtract");
 ArmPlugin::pass::ConvertSubtract::ConvertSubtract() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Subtract>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -54,7 +51,6 @@ ArmPlugin::pass::ConvertSubtract::ConvertSubtract() {
     register_matcher(m, convert_eltwise<opset::Subtract>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMultiply, "ConvertMultiply");
 ArmPlugin::pass::ConvertMultiply::ConvertMultiply() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Multiply>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -63,7 +59,6 @@ ArmPlugin::pass::ConvertMultiply::ConvertMultiply() {
     register_matcher(m, convert_eltwise<opset::Multiply>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMinimum, "ConvertMinimum");
 ArmPlugin::pass::ConvertMinimum::ConvertMinimum() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Minimum>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -72,7 +67,6 @@ ArmPlugin::pass::ConvertMinimum::ConvertMinimum() {
     register_matcher(m, convert_eltwise<opset::Minimum>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMaximum, "ConvertMaximum");
 ArmPlugin::pass::ConvertMaximum::ConvertMaximum() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Maximum>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_eltwise.hpp
+++ b/modules/arm_plugin/src/transformations/convert_eltwise.hpp
@@ -12,38 +12,38 @@ namespace pass {
 
 class ConvertEltwiseBase : public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertEltwiseBase");
+    OPENVINO_RTTI("ConvertEltwiseBase");
     template <class T>
     ngraph::matcher_pass_callback convert_eltwise();
 };
 
 class ConvertAdd: public ConvertEltwiseBase {
 public:
-    OPENVINO_OP("ConvertAdd");
+    OPENVINO_RTTI("ConvertAdd");
     ConvertAdd();
 };
 
 class ConvertSubtract: public ConvertEltwiseBase {
 public:
-    OPENVINO_OP("ConvertSubtract");
+    OPENVINO_RTTI("ConvertSubtract");
     ConvertSubtract();
 };
 
 class ConvertMultiply: public ConvertEltwiseBase {
 public:
-    OPENVINO_OP("ConvertMultiply");
+    OPENVINO_RTTI("ConvertMultiply");
     ConvertMultiply();
 };
 
 class ConvertMinimum: public ConvertEltwiseBase {
 public:
-    OPENVINO_OP("ConvertMinimum");
+    OPENVINO_RTTI("ConvertMinimum");
     ConvertMinimum();
 };
 
 class ConvertMaximum: public ConvertEltwiseBase {
 public:
-    OPENVINO_OP("ConvertMaximum");
+    OPENVINO_RTTI("ConvertMaximum");
     ConvertMaximum();
 };
 

--- a/modules/arm_plugin/src/transformations/convert_eltwise.hpp
+++ b/modules/arm_plugin/src/transformations/convert_eltwise.hpp
@@ -12,38 +12,38 @@ namespace pass {
 
 class ConvertEltwiseBase : public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertEltwiseBase");
     template <class T>
     ngraph::matcher_pass_callback convert_eltwise();
 };
 
 class ConvertAdd: public ConvertEltwiseBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertAdd");
     ConvertAdd();
 };
 
 class ConvertSubtract: public ConvertEltwiseBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertSubtract");
     ConvertSubtract();
 };
 
 class ConvertMultiply: public ConvertEltwiseBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertMultiply");
     ConvertMultiply();
 };
 
 class ConvertMinimum: public ConvertEltwiseBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertMinimum");
     ConvertMinimum();
 };
 
 class ConvertMaximum: public ConvertEltwiseBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertMaximum");
     ConvertMaximum();
 };
 

--- a/modules/arm_plugin/src/transformations/convert_fft_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_fft_arm.cpp
@@ -86,7 +86,7 @@ static bool convert_fft(const std::shared_ptr<T>& fft, bool inverse) {
     return true;
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertDFT, "ConvertDFT");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertDFT, "ConvertDFT");
 ArmPlugin::pass::ConvertDFT::ConvertDFT() {
     auto fft = ngraph::pattern::wrap_type<opset::DFT>();
 
@@ -98,7 +98,7 @@ ArmPlugin::pass::ConvertDFT::ConvertDFT() {
     register_matcher(m, callback);
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertIDFT, "ConvertIDFT");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertIDFT, "ConvertIDFT");
 ArmPlugin::pass::ConvertIDFT::ConvertIDFT() {
     auto fft = ngraph::pattern::wrap_type<opset::IDFT>();
 

--- a/modules/arm_plugin/src/transformations/convert_fft_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_fft_arm.cpp
@@ -86,7 +86,7 @@ static bool convert_fft(const std::shared_ptr<T>& fft, bool inverse) {
     return true;
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertDFT, "ConvertDFT");
+OPENVINO_OP(ArmPlugin::pass::ConvertDFT, "ConvertDFT");
 ArmPlugin::pass::ConvertDFT::ConvertDFT() {
     auto fft = ngraph::pattern::wrap_type<opset::DFT>();
 
@@ -98,7 +98,7 @@ ArmPlugin::pass::ConvertDFT::ConvertDFT() {
     register_matcher(m, callback);
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertIDFT, "ConvertIDFT");
+OPENVINO_OP(ArmPlugin::pass::ConvertIDFT, "ConvertIDFT");
 ArmPlugin::pass::ConvertIDFT::ConvertIDFT() {
     auto fft = ngraph::pattern::wrap_type<opset::IDFT>();
 

--- a/modules/arm_plugin/src/transformations/convert_fft_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_fft_arm.cpp
@@ -86,7 +86,6 @@ static bool convert_fft(const std::shared_ptr<T>& fft, bool inverse) {
     return true;
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertDFT, "ConvertDFT");
 ArmPlugin::pass::ConvertDFT::ConvertDFT() {
     auto fft = ngraph::pattern::wrap_type<opset::DFT>();
 
@@ -98,7 +97,6 @@ ArmPlugin::pass::ConvertDFT::ConvertDFT() {
     register_matcher(m, callback);
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertIDFT, "ConvertIDFT");
 ArmPlugin::pass::ConvertIDFT::ConvertIDFT() {
     auto fft = ngraph::pattern::wrap_type<opset::IDFT>();
 

--- a/modules/arm_plugin/src/transformations/convert_fft_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_fft_arm.cpp
@@ -86,7 +86,7 @@ static bool convert_fft(const std::shared_ptr<T>& fft, bool inverse) {
     return true;
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertDFT, "ConvertDFT", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertDFT, "ConvertDFT");
 ArmPlugin::pass::ConvertDFT::ConvertDFT() {
     auto fft = ngraph::pattern::wrap_type<opset::DFT>();
 
@@ -98,7 +98,7 @@ ArmPlugin::pass::ConvertDFT::ConvertDFT() {
     register_matcher(m, callback);
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertIDFT, "ConvertIDFT", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertIDFT, "ConvertIDFT");
 ArmPlugin::pass::ConvertIDFT::ConvertIDFT() {
     auto fft = ngraph::pattern::wrap_type<opset::IDFT>();
 

--- a/modules/arm_plugin/src/transformations/convert_fft_arm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_fft_arm.hpp
@@ -10,12 +10,12 @@ namespace pass {
 
 class ConvertDFT: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertDFT");
+    OPENVINO_RTTI("ConvertDFT");
     ConvertDFT();
 };
 class ConvertIDFT: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertIDFT");
+    OPENVINO_RTTI("ConvertIDFT");
     ConvertIDFT();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_fft_arm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_fft_arm.hpp
@@ -10,12 +10,12 @@ namespace pass {
 
 class ConvertDFT: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertDFT");
     ConvertDFT();
 };
 class ConvertIDFT: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertIDFT");
     ConvertIDFT();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_gather_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_gather_arm.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGather, "ConvertGather", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGather, "ConvertGather");
 ArmPlugin::pass::ConvertGather::ConvertGather() {
     auto gather = ngraph::pattern::wrap_type<opset::Gather>();
 

--- a/modules/arm_plugin/src/transformations/convert_gather_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_gather_arm.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ConvertGather, "ConvertGather");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGather, "ConvertGather");
 ArmPlugin::pass::ConvertGather::ConvertGather() {
     auto gather = ngraph::pattern::wrap_type<opset::Gather>();
 

--- a/modules/arm_plugin/src/transformations/convert_gather_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_gather_arm.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGather, "ConvertGather");
+OPENVINO_OP(ArmPlugin::pass::ConvertGather, "ConvertGather");
 ArmPlugin::pass::ConvertGather::ConvertGather() {
     auto gather = ngraph::pattern::wrap_type<opset::Gather>();
 

--- a/modules/arm_plugin/src/transformations/convert_gather_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_gather_arm.cpp
@@ -7,7 +7,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGather, "ConvertGather");
 ArmPlugin::pass::ConvertGather::ConvertGather() {
     auto gather = ngraph::pattern::wrap_type<opset::Gather>();
 

--- a/modules/arm_plugin/src/transformations/convert_gather_arm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_gather_arm.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertGather: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertGather");
     ConvertGather();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_gather_arm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_gather_arm.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertGather: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertGather");
+    OPENVINO_RTTI("ConvertGather");
     ConvertGather();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_grn_to_normalizel2.cpp
+++ b/modules/arm_plugin/src/transformations/convert_grn_to_normalizel2.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGRN, "ConvertGRN");
+OPENVINO_OP(ArmPlugin::pass::ConvertGRN, "ConvertGRN");
 ArmPlugin::pass::ConvertGRN::ConvertGRN() {
     auto grn = ngraph::pattern::wrap_type<opset::GRN>();
 

--- a/modules/arm_plugin/src/transformations/convert_grn_to_normalizel2.cpp
+++ b/modules/arm_plugin/src/transformations/convert_grn_to_normalizel2.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ConvertGRN, "ConvertGRN");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGRN, "ConvertGRN");
 ArmPlugin::pass::ConvertGRN::ConvertGRN() {
     auto grn = ngraph::pattern::wrap_type<opset::GRN>();
 

--- a/modules/arm_plugin/src/transformations/convert_grn_to_normalizel2.cpp
+++ b/modules/arm_plugin/src/transformations/convert_grn_to_normalizel2.cpp
@@ -10,7 +10,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGRN, "ConvertGRN");
 ArmPlugin::pass::ConvertGRN::ConvertGRN() {
     auto grn = ngraph::pattern::wrap_type<opset::GRN>();
 

--- a/modules/arm_plugin/src/transformations/convert_grn_to_normalizel2.cpp
+++ b/modules/arm_plugin/src/transformations/convert_grn_to_normalizel2.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGRN, "ConvertGRN", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGRN, "ConvertGRN");
 ArmPlugin::pass::ConvertGRN::ConvertGRN() {
     auto grn = ngraph::pattern::wrap_type<opset::GRN>();
 

--- a/modules/arm_plugin/src/transformations/convert_grn_to_normalizel2.hpp
+++ b/modules/arm_plugin/src/transformations/convert_grn_to_normalizel2.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertGRN: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertGRN");
     ConvertGRN();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_grn_to_normalizel2.hpp
+++ b/modules/arm_plugin/src/transformations/convert_grn_to_normalizel2.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertGRN: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertGRN");
+    OPENVINO_RTTI("ConvertGRN");
     ConvertGRN();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_group_conv.cpp
+++ b/modules/arm_plugin/src/transformations/convert_group_conv.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGroupConvolution, "ConvertGroupConvolution");
+OPENVINO_OP(ArmPlugin::pass::ConvertGroupConvolution, "ConvertGroupConvolution");
 ArmPlugin::pass::ConvertGroupConvolution::ConvertGroupConvolution() {
     auto gconv = ngraph::pattern::wrap_type<opset::GroupConvolution>();
 

--- a/modules/arm_plugin/src/transformations/convert_group_conv.cpp
+++ b/modules/arm_plugin/src/transformations/convert_group_conv.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGroupConvolution, "ConvertGroupConvolution", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGroupConvolution, "ConvertGroupConvolution");
 ArmPlugin::pass::ConvertGroupConvolution::ConvertGroupConvolution() {
     auto gconv = ngraph::pattern::wrap_type<opset::GroupConvolution>();
 

--- a/modules/arm_plugin/src/transformations/convert_group_conv.cpp
+++ b/modules/arm_plugin/src/transformations/convert_group_conv.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ConvertGroupConvolution, "ConvertGroupConvolution");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGroupConvolution, "ConvertGroupConvolution");
 ArmPlugin::pass::ConvertGroupConvolution::ConvertGroupConvolution() {
     auto gconv = ngraph::pattern::wrap_type<opset::GroupConvolution>();
 

--- a/modules/arm_plugin/src/transformations/convert_group_conv.cpp
+++ b/modules/arm_plugin/src/transformations/convert_group_conv.cpp
@@ -10,7 +10,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertGroupConvolution, "ConvertGroupConvolution");
 ArmPlugin::pass::ConvertGroupConvolution::ConvertGroupConvolution() {
     auto gconv = ngraph::pattern::wrap_type<opset::GroupConvolution>();
 

--- a/modules/arm_plugin/src/transformations/convert_group_conv.hpp
+++ b/modules/arm_plugin/src/transformations/convert_group_conv.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertGroupConvolution: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertGroupConvolution");
     ConvertGroupConvolution();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_group_conv.hpp
+++ b/modules/arm_plugin/src/transformations/convert_group_conv.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertGroupConvolution: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertGroupConvolution");
+    OPENVINO_RTTI("ConvertGroupConvolution");
     ConvertGroupConvolution();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_inputs_precision.cpp
+++ b/modules/arm_plugin/src/transformations/convert_inputs_precision.cpp
@@ -11,7 +11,7 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertPrecisionBase, "ConvertPrecisionBase", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertPrecisionBase, "ConvertPrecisionBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertPrecisionBase::convert_precision(const std::vector<int>& indices) {
     return [=](ngraph::pattern::Matcher& m) {
@@ -36,7 +36,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertPrecisionBase::convert_pre
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertPReluPrecision, "ConvertPReluPrecision", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertPReluPrecision, "ConvertPReluPrecision");
 ArmPlugin::pass::ConvertPReluPrecision::ConvertPReluPrecision() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::PRelu>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -45,7 +45,7 @@ ArmPlugin::pass::ConvertPReluPrecision::ConvertPReluPrecision() {
     register_matcher(m, convert_precision<opset::PRelu>({1}));
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertProposalPrecision, "ConvertProposalPrecision", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertProposalPrecision, "ConvertProposalPrecision");
 ArmPlugin::pass::ConvertProposalPrecision::ConvertProposalPrecision() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Proposal>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -55,7 +55,7 @@ ArmPlugin::pass::ConvertProposalPrecision::ConvertProposalPrecision() {
     register_matcher(m, convert_precision<opset::Proposal>({1, 2}));
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertInterpolatePrecision, "ConvertInterpolatePrecision", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertInterpolatePrecision, "ConvertInterpolatePrecision");
 ArmPlugin::pass::ConvertInterpolatePrecision::ConvertInterpolatePrecision() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Interpolate>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_inputs_precision.cpp
+++ b/modules/arm_plugin/src/transformations/convert_inputs_precision.cpp
@@ -11,7 +11,6 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertPrecisionBase, "ConvertPrecisionBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertPrecisionBase::convert_precision(const std::vector<int>& indices) {
     return [=](ngraph::pattern::Matcher& m) {
@@ -36,7 +35,6 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertPrecisionBase::convert_pre
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertPReluPrecision, "ConvertPReluPrecision");
 ArmPlugin::pass::ConvertPReluPrecision::ConvertPReluPrecision() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::PRelu>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -45,7 +43,6 @@ ArmPlugin::pass::ConvertPReluPrecision::ConvertPReluPrecision() {
     register_matcher(m, convert_precision<opset::PRelu>({1}));
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertProposalPrecision, "ConvertProposalPrecision");
 ArmPlugin::pass::ConvertProposalPrecision::ConvertProposalPrecision() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Proposal>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -55,7 +52,6 @@ ArmPlugin::pass::ConvertProposalPrecision::ConvertProposalPrecision() {
     register_matcher(m, convert_precision<opset::Proposal>({1, 2}));
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertInterpolatePrecision, "ConvertInterpolatePrecision");
 ArmPlugin::pass::ConvertInterpolatePrecision::ConvertInterpolatePrecision() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Interpolate>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_inputs_precision.cpp
+++ b/modules/arm_plugin/src/transformations/convert_inputs_precision.cpp
@@ -11,7 +11,7 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertPrecisionBase, "ConvertPrecisionBase");
+OPENVINO_OP(ArmPlugin::pass::ConvertPrecisionBase, "ConvertPrecisionBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertPrecisionBase::convert_precision(const std::vector<int>& indices) {
     return [=](ngraph::pattern::Matcher& m) {
@@ -36,7 +36,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertPrecisionBase::convert_pre
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertPReluPrecision, "ConvertPReluPrecision");
+OPENVINO_OP(ArmPlugin::pass::ConvertPReluPrecision, "ConvertPReluPrecision");
 ArmPlugin::pass::ConvertPReluPrecision::ConvertPReluPrecision() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::PRelu>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -45,7 +45,7 @@ ArmPlugin::pass::ConvertPReluPrecision::ConvertPReluPrecision() {
     register_matcher(m, convert_precision<opset::PRelu>({1}));
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertProposalPrecision, "ConvertProposalPrecision");
+OPENVINO_OP(ArmPlugin::pass::ConvertProposalPrecision, "ConvertProposalPrecision");
 ArmPlugin::pass::ConvertProposalPrecision::ConvertProposalPrecision() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Proposal>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -55,7 +55,7 @@ ArmPlugin::pass::ConvertProposalPrecision::ConvertProposalPrecision() {
     register_matcher(m, convert_precision<opset::Proposal>({1, 2}));
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertInterpolatePrecision, "ConvertInterpolatePrecision");
+OPENVINO_OP(ArmPlugin::pass::ConvertInterpolatePrecision, "ConvertInterpolatePrecision");
 ArmPlugin::pass::ConvertInterpolatePrecision::ConvertInterpolatePrecision() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Interpolate>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_inputs_precision.cpp
+++ b/modules/arm_plugin/src/transformations/convert_inputs_precision.cpp
@@ -11,7 +11,7 @@
 
 using namespace ArmPlugin;
 
-OPENVINO_OP(ArmPlugin::pass::ConvertPrecisionBase, "ConvertPrecisionBase");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertPrecisionBase, "ConvertPrecisionBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertPrecisionBase::convert_precision(const std::vector<int>& indices) {
     return [=](ngraph::pattern::Matcher& m) {
@@ -36,7 +36,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertPrecisionBase::convert_pre
     };
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertPReluPrecision, "ConvertPReluPrecision");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertPReluPrecision, "ConvertPReluPrecision");
 ArmPlugin::pass::ConvertPReluPrecision::ConvertPReluPrecision() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::PRelu>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -45,7 +45,7 @@ ArmPlugin::pass::ConvertPReluPrecision::ConvertPReluPrecision() {
     register_matcher(m, convert_precision<opset::PRelu>({1}));
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertProposalPrecision, "ConvertProposalPrecision");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertProposalPrecision, "ConvertProposalPrecision");
 ArmPlugin::pass::ConvertProposalPrecision::ConvertProposalPrecision() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Proposal>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -55,7 +55,7 @@ ArmPlugin::pass::ConvertProposalPrecision::ConvertProposalPrecision() {
     register_matcher(m, convert_precision<opset::Proposal>({1, 2}));
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertInterpolatePrecision, "ConvertInterpolatePrecision");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertInterpolatePrecision, "ConvertInterpolatePrecision");
 ArmPlugin::pass::ConvertInterpolatePrecision::ConvertInterpolatePrecision() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::Interpolate>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_inputs_precision.hpp
+++ b/modules/arm_plugin/src/transformations/convert_inputs_precision.hpp
@@ -12,26 +12,26 @@ namespace pass {
 
 class ConvertPrecisionBase : public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertPrecisionBase");
+    OPENVINO_RTTI("ConvertPrecisionBase");
     template <class T>
     ngraph::matcher_pass_callback convert_precision(const std::vector<int>& indices);
 };
 
 class ConvertPReluPrecision: public ConvertPrecisionBase {
 public:
-    OPENVINO_OP("ConvertPReluPrecision");
+    OPENVINO_RTTI("ConvertPReluPrecision");
     ConvertPReluPrecision();
 };
 
 class ConvertProposalPrecision: public ConvertPrecisionBase {
 public:
-    OPENVINO_OP("ConvertProposalPrecision");
+    OPENVINO_RTTI("ConvertProposalPrecision");
     ConvertProposalPrecision();
 };
 
 class ConvertInterpolatePrecision: public ConvertPrecisionBase {
 public:
-    OPENVINO_OP("ConvertInterpolatePrecision");
+    OPENVINO_RTTI("ConvertInterpolatePrecision");
     ConvertInterpolatePrecision();
 };
 

--- a/modules/arm_plugin/src/transformations/convert_inputs_precision.hpp
+++ b/modules/arm_plugin/src/transformations/convert_inputs_precision.hpp
@@ -12,26 +12,26 @@ namespace pass {
 
 class ConvertPrecisionBase : public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertPrecisionBase");
     template <class T>
     ngraph::matcher_pass_callback convert_precision(const std::vector<int>& indices);
 };
 
 class ConvertPReluPrecision: public ConvertPrecisionBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertPReluPrecision");
     ConvertPReluPrecision();
 };
 
 class ConvertProposalPrecision: public ConvertPrecisionBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertProposalPrecision");
     ConvertProposalPrecision();
 };
 
 class ConvertInterpolatePrecision: public ConvertPrecisionBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertInterpolatePrecision");
     ConvertInterpolatePrecision();
 };
 

--- a/modules/arm_plugin/src/transformations/convert_interpolate_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_interpolate_arm.cpp
@@ -65,7 +65,6 @@ bool isSupportedConfiguration(const ngraph::op::v4::Interpolate& node) {
     return false;
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertInterpolate, "ConvertInterpolate");
 ArmPlugin::pass::ConvertInterpolate::ConvertInterpolate() {
     auto interp = ngraph::pattern::wrap_type<opset::Interpolate>();
 

--- a/modules/arm_plugin/src/transformations/convert_interpolate_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_interpolate_arm.cpp
@@ -65,7 +65,7 @@ bool isSupportedConfiguration(const ngraph::op::v4::Interpolate& node) {
     return false;
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertInterpolate, "ConvertInterpolate", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertInterpolate, "ConvertInterpolate");
 ArmPlugin::pass::ConvertInterpolate::ConvertInterpolate() {
     auto interp = ngraph::pattern::wrap_type<opset::Interpolate>();
 

--- a/modules/arm_plugin/src/transformations/convert_interpolate_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_interpolate_arm.cpp
@@ -65,7 +65,7 @@ bool isSupportedConfiguration(const ngraph::op::v4::Interpolate& node) {
     return false;
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertInterpolate, "ConvertInterpolate");
+OPENVINO_OP(ArmPlugin::pass::ConvertInterpolate, "ConvertInterpolate");
 ArmPlugin::pass::ConvertInterpolate::ConvertInterpolate() {
     auto interp = ngraph::pattern::wrap_type<opset::Interpolate>();
 

--- a/modules/arm_plugin/src/transformations/convert_interpolate_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_interpolate_arm.cpp
@@ -65,7 +65,7 @@ bool isSupportedConfiguration(const ngraph::op::v4::Interpolate& node) {
     return false;
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertInterpolate, "ConvertInterpolate");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertInterpolate, "ConvertInterpolate");
 ArmPlugin::pass::ConvertInterpolate::ConvertInterpolate() {
     auto interp = ngraph::pattern::wrap_type<opset::Interpolate>();
 

--- a/modules/arm_plugin/src/transformations/convert_interpolate_arm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_interpolate_arm.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertInterpolate: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertInterpolate");
     ConvertInterpolate();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_interpolate_arm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_interpolate_arm.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertInterpolate: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertInterpolate");
+    OPENVINO_RTTI("ConvertInterpolate");
     ConvertInterpolate();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_logical.cpp
+++ b/modules/arm_plugin/src/transformations/convert_logical.cpp
@@ -9,7 +9,7 @@
 
 using namespace ArmPlugin;
 
-OPENVINO_OP(ArmPlugin::pass::ConvertLogicalBase, "ConvertLogicalBase");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalBase, "ConvertLogicalBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertLogicalBase::convert_logical() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -40,7 +40,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertLogicalBase::convert_logic
     };
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertLogicalNot, "ConvertLogicalNot");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalNot, "ConvertLogicalNot");
 ArmPlugin::pass::ConvertLogicalNot::ConvertLogicalNot() {
     auto logical_not = std::make_shared<opset::LogicalNot>(ngraph::pattern::any_input());
 
@@ -67,7 +67,7 @@ ArmPlugin::pass::ConvertLogicalNot::ConvertLogicalNot() {
     register_matcher(m, callback);
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertLogicalAnd, "ConvertLogicalAnd");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalAnd, "ConvertLogicalAnd");
 ArmPlugin::pass::ConvertLogicalAnd::ConvertLogicalAnd() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::LogicalAnd>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -76,7 +76,7 @@ ArmPlugin::pass::ConvertLogicalAnd::ConvertLogicalAnd() {
     register_matcher(m, convert_logical<opset::LogicalAnd>());
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertLogicalOr, "ConvertLogicalOr");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalOr, "ConvertLogicalOr");
 ArmPlugin::pass::ConvertLogicalOr::ConvertLogicalOr() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::LogicalOr>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -85,7 +85,7 @@ ArmPlugin::pass::ConvertLogicalOr::ConvertLogicalOr() {
     register_matcher(m, convert_logical<opset::LogicalOr>());
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertLogicalXor, "ConvertLogicalXor");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalXor, "ConvertLogicalXor");
 ArmPlugin::pass::ConvertLogicalXor::ConvertLogicalXor() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::LogicalXor>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_logical.cpp
+++ b/modules/arm_plugin/src/transformations/convert_logical.cpp
@@ -9,7 +9,7 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalBase, "ConvertLogicalBase", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalBase, "ConvertLogicalBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertLogicalBase::convert_logical() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -40,7 +40,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertLogicalBase::convert_logic
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalNot, "ConvertLogicalNot", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalNot, "ConvertLogicalNot");
 ArmPlugin::pass::ConvertLogicalNot::ConvertLogicalNot() {
     auto logical_not = std::make_shared<opset::LogicalNot>(ngraph::pattern::any_input());
 
@@ -67,7 +67,7 @@ ArmPlugin::pass::ConvertLogicalNot::ConvertLogicalNot() {
     register_matcher(m, callback);
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalAnd, "ConvertLogicalAnd", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalAnd, "ConvertLogicalAnd");
 ArmPlugin::pass::ConvertLogicalAnd::ConvertLogicalAnd() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::LogicalAnd>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -76,7 +76,7 @@ ArmPlugin::pass::ConvertLogicalAnd::ConvertLogicalAnd() {
     register_matcher(m, convert_logical<opset::LogicalAnd>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalOr, "ConvertLogicalOr", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalOr, "ConvertLogicalOr");
 ArmPlugin::pass::ConvertLogicalOr::ConvertLogicalOr() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::LogicalOr>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -85,7 +85,7 @@ ArmPlugin::pass::ConvertLogicalOr::ConvertLogicalOr() {
     register_matcher(m, convert_logical<opset::LogicalOr>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalXor, "ConvertLogicalXor", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalXor, "ConvertLogicalXor");
 ArmPlugin::pass::ConvertLogicalXor::ConvertLogicalXor() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::LogicalXor>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_logical.cpp
+++ b/modules/arm_plugin/src/transformations/convert_logical.cpp
@@ -9,7 +9,7 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalBase, "ConvertLogicalBase");
+OPENVINO_OP(ArmPlugin::pass::ConvertLogicalBase, "ConvertLogicalBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertLogicalBase::convert_logical() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -40,7 +40,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertLogicalBase::convert_logic
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalNot, "ConvertLogicalNot");
+OPENVINO_OP(ArmPlugin::pass::ConvertLogicalNot, "ConvertLogicalNot");
 ArmPlugin::pass::ConvertLogicalNot::ConvertLogicalNot() {
     auto logical_not = std::make_shared<opset::LogicalNot>(ngraph::pattern::any_input());
 
@@ -67,7 +67,7 @@ ArmPlugin::pass::ConvertLogicalNot::ConvertLogicalNot() {
     register_matcher(m, callback);
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalAnd, "ConvertLogicalAnd");
+OPENVINO_OP(ArmPlugin::pass::ConvertLogicalAnd, "ConvertLogicalAnd");
 ArmPlugin::pass::ConvertLogicalAnd::ConvertLogicalAnd() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::LogicalAnd>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -76,7 +76,7 @@ ArmPlugin::pass::ConvertLogicalAnd::ConvertLogicalAnd() {
     register_matcher(m, convert_logical<opset::LogicalAnd>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalOr, "ConvertLogicalOr");
+OPENVINO_OP(ArmPlugin::pass::ConvertLogicalOr, "ConvertLogicalOr");
 ArmPlugin::pass::ConvertLogicalOr::ConvertLogicalOr() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::LogicalOr>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -85,7 +85,7 @@ ArmPlugin::pass::ConvertLogicalOr::ConvertLogicalOr() {
     register_matcher(m, convert_logical<opset::LogicalOr>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalXor, "ConvertLogicalXor");
+OPENVINO_OP(ArmPlugin::pass::ConvertLogicalXor, "ConvertLogicalXor");
 ArmPlugin::pass::ConvertLogicalXor::ConvertLogicalXor() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::LogicalXor>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_logical.cpp
+++ b/modules/arm_plugin/src/transformations/convert_logical.cpp
@@ -9,7 +9,6 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalBase, "ConvertLogicalBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertLogicalBase::convert_logical() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -40,7 +39,6 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertLogicalBase::convert_logic
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalNot, "ConvertLogicalNot");
 ArmPlugin::pass::ConvertLogicalNot::ConvertLogicalNot() {
     auto logical_not = std::make_shared<opset::LogicalNot>(ngraph::pattern::any_input());
 
@@ -67,7 +65,6 @@ ArmPlugin::pass::ConvertLogicalNot::ConvertLogicalNot() {
     register_matcher(m, callback);
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalAnd, "ConvertLogicalAnd");
 ArmPlugin::pass::ConvertLogicalAnd::ConvertLogicalAnd() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::LogicalAnd>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -76,7 +73,6 @@ ArmPlugin::pass::ConvertLogicalAnd::ConvertLogicalAnd() {
     register_matcher(m, convert_logical<opset::LogicalAnd>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalOr, "ConvertLogicalOr");
 ArmPlugin::pass::ConvertLogicalOr::ConvertLogicalOr() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::LogicalOr>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -85,7 +81,6 @@ ArmPlugin::pass::ConvertLogicalOr::ConvertLogicalOr() {
     register_matcher(m, convert_logical<opset::LogicalOr>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertLogicalXor, "ConvertLogicalXor");
 ArmPlugin::pass::ConvertLogicalXor::ConvertLogicalXor() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::LogicalXor>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_logical.hpp
+++ b/modules/arm_plugin/src/transformations/convert_logical.hpp
@@ -11,32 +11,32 @@ namespace pass {
 
 class ConvertLogicalBase : public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertLogicalBase");
+    OPENVINO_RTTI("ConvertLogicalBase");
     template <class T>
     ngraph::matcher_pass_callback convert_logical();
 };
 
 class ConvertLogicalNot: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertLogicalNot");
+    OPENVINO_RTTI("ConvertLogicalNot");
     ConvertLogicalNot();
 };
 
 class ConvertLogicalAnd: public ConvertLogicalBase {
 public:
-    OPENVINO_OP("ConvertLogicalAnd");
+    OPENVINO_RTTI("ConvertLogicalAnd");
     ConvertLogicalAnd();
 };
 
 class ConvertLogicalOr: public ConvertLogicalBase {
 public:
-    OPENVINO_OP("ConvertLogicalOr");
+    OPENVINO_RTTI("ConvertLogicalOr");
     ConvertLogicalOr();
 };
 
 class ConvertLogicalXor: public ConvertLogicalBase {
 public:
-    OPENVINO_OP("ConvertLogicalXor");
+    OPENVINO_RTTI("ConvertLogicalXor");
     ConvertLogicalXor();
 };
 

--- a/modules/arm_plugin/src/transformations/convert_logical.hpp
+++ b/modules/arm_plugin/src/transformations/convert_logical.hpp
@@ -11,32 +11,32 @@ namespace pass {
 
 class ConvertLogicalBase : public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertLogicalBase");
     template <class T>
     ngraph::matcher_pass_callback convert_logical();
 };
 
 class ConvertLogicalNot: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertLogicalNot");
     ConvertLogicalNot();
 };
 
 class ConvertLogicalAnd: public ConvertLogicalBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertLogicalAnd");
     ConvertLogicalAnd();
 };
 
 class ConvertLogicalOr: public ConvertLogicalBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertLogicalOr");
     ConvertLogicalOr();
 };
 
 class ConvertLogicalXor: public ConvertLogicalBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertLogicalXor");
     ConvertLogicalXor();
 };
 

--- a/modules/arm_plugin/src/transformations/convert_mat_mul.cpp
+++ b/modules/arm_plugin/src/transformations/convert_mat_mul.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMatMulToFC, "ConvertMatMulToFC");
+OPENVINO_OP(ArmPlugin::pass::ConvertMatMulToFC, "ConvertMatMulToFC");
 ArmPlugin::pass::ConvertMatMulToFC::ConvertMatMulToFC() {
     auto matmul = ngraph::pattern::wrap_type<opset::MatMul>();
 

--- a/modules/arm_plugin/src/transformations/convert_mat_mul.cpp
+++ b/modules/arm_plugin/src/transformations/convert_mat_mul.cpp
@@ -10,7 +10,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMatMulToFC, "ConvertMatMulToFC");
 ArmPlugin::pass::ConvertMatMulToFC::ConvertMatMulToFC() {
     auto matmul = ngraph::pattern::wrap_type<opset::MatMul>();
 

--- a/modules/arm_plugin/src/transformations/convert_mat_mul.cpp
+++ b/modules/arm_plugin/src/transformations/convert_mat_mul.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMatMulToFC, "ConvertMatMulToFC", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMatMulToFC, "ConvertMatMulToFC");
 ArmPlugin::pass::ConvertMatMulToFC::ConvertMatMulToFC() {
     auto matmul = ngraph::pattern::wrap_type<opset::MatMul>();
 

--- a/modules/arm_plugin/src/transformations/convert_mat_mul.cpp
+++ b/modules/arm_plugin/src/transformations/convert_mat_mul.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ConvertMatMulToFC, "ConvertMatMulToFC");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMatMulToFC, "ConvertMatMulToFC");
 ArmPlugin::pass::ConvertMatMulToFC::ConvertMatMulToFC() {
     auto matmul = ngraph::pattern::wrap_type<opset::MatMul>();
 

--- a/modules/arm_plugin/src/transformations/convert_mat_mul.hpp
+++ b/modules/arm_plugin/src/transformations/convert_mat_mul.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertMatMulToFC: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertMatMulToFC");
+    OPENVINO_RTTI("ConvertMatMulToFC");
     ConvertMatMulToFC();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_mat_mul.hpp
+++ b/modules/arm_plugin/src/transformations/convert_mat_mul.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertMatMulToFC: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertMatMulToFC");
     ConvertMatMulToFC();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_maxpool_v8.cpp
+++ b/modules/arm_plugin/src/transformations/convert_maxpool_v8.cpp
@@ -8,8 +8,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMaxPoolV8, "ConvertMaxPoolV8");
-
 ArmPlugin::pass::ConvertMaxPoolV8::ConvertMaxPoolV8() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::v8::ArmMaxPool>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape())},

--- a/modules/arm_plugin/src/transformations/convert_maxpool_v8.cpp
+++ b/modules/arm_plugin/src/transformations/convert_maxpool_v8.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMaxPoolV8, "ConvertMaxPoolV8");
+OPENVINO_OP(ArmPlugin::pass::ConvertMaxPoolV8, "ConvertMaxPoolV8");
 
 ArmPlugin::pass::ConvertMaxPoolV8::ConvertMaxPoolV8() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(

--- a/modules/arm_plugin/src/transformations/convert_maxpool_v8.cpp
+++ b/modules/arm_plugin/src/transformations/convert_maxpool_v8.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ConvertMaxPoolV8, "ConvertMaxPoolV8");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMaxPoolV8, "ConvertMaxPoolV8");
 
 ArmPlugin::pass::ConvertMaxPoolV8::ConvertMaxPoolV8() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(

--- a/modules/arm_plugin/src/transformations/convert_maxpool_v8.cpp
+++ b/modules/arm_plugin/src/transformations/convert_maxpool_v8.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMaxPoolV8, "ConvertMaxPoolV8", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMaxPoolV8, "ConvertMaxPoolV8");
 
 ArmPlugin::pass::ConvertMaxPoolV8::ConvertMaxPoolV8() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(

--- a/modules/arm_plugin/src/transformations/convert_maxpool_v8.hpp
+++ b/modules/arm_plugin/src/transformations/convert_maxpool_v8.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertMaxPoolV8: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertMaxPoolV8");
     ConvertMaxPoolV8();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_maxpool_v8.hpp
+++ b/modules/arm_plugin/src/transformations/convert_maxpool_v8.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertMaxPoolV8: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertMaxPoolV8");
+    OPENVINO_RTTI("ConvertMaxPoolV8");
     ConvertMaxPoolV8();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_mvn_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_mvn_arm.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMVN, "ConvertMVN");
+OPENVINO_OP(ArmPlugin::pass::ConvertMVN, "ConvertMVN");
 ArmPlugin::pass::ConvertMVN::ConvertMVN() {
     auto mvn = ngraph::pattern::wrap_type<opset::MVN>();
 

--- a/modules/arm_plugin/src/transformations/convert_mvn_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_mvn_arm.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ConvertMVN, "ConvertMVN");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMVN, "ConvertMVN");
 ArmPlugin::pass::ConvertMVN::ConvertMVN() {
     auto mvn = ngraph::pattern::wrap_type<opset::MVN>();
 

--- a/modules/arm_plugin/src/transformations/convert_mvn_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_mvn_arm.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMVN, "ConvertMVN", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMVN, "ConvertMVN");
 ArmPlugin::pass::ConvertMVN::ConvertMVN() {
     auto mvn = ngraph::pattern::wrap_type<opset::MVN>();
 

--- a/modules/arm_plugin/src/transformations/convert_mvn_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_mvn_arm.cpp
@@ -7,7 +7,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMVN, "ConvertMVN");
 ArmPlugin::pass::ConvertMVN::ConvertMVN() {
     auto mvn = ngraph::pattern::wrap_type<opset::MVN>();
 

--- a/modules/arm_plugin/src/transformations/convert_mvn_arm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_mvn_arm.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertMVN: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertMVN");
+    OPENVINO_RTTI("ConvertMVN");
     ConvertMVN();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_mvn_arm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_mvn_arm.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertMVN: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertMVN");
     ConvertMVN();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_normalizel2_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_normalizel2_arm.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertNormalizeL2ToArm, "ConvertNormalizeL2ToArm", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertNormalizeL2ToArm, "ConvertNormalizeL2ToArm");
 ArmPlugin::pass::ConvertNormalizeL2ToArm::ConvertNormalizeL2ToArm() {
     auto norml2 = ngraph::pattern::wrap_type<opset::NormalizeL2>();
 

--- a/modules/arm_plugin/src/transformations/convert_normalizel2_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_normalizel2_arm.cpp
@@ -7,7 +7,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertNormalizeL2ToArm, "ConvertNormalizeL2ToArm");
 ArmPlugin::pass::ConvertNormalizeL2ToArm::ConvertNormalizeL2ToArm() {
     auto norml2 = ngraph::pattern::wrap_type<opset::NormalizeL2>();
 

--- a/modules/arm_plugin/src/transformations/convert_normalizel2_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_normalizel2_arm.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ConvertNormalizeL2ToArm, "ConvertNormalizeL2ToArm");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertNormalizeL2ToArm, "ConvertNormalizeL2ToArm");
 ArmPlugin::pass::ConvertNormalizeL2ToArm::ConvertNormalizeL2ToArm() {
     auto norml2 = ngraph::pattern::wrap_type<opset::NormalizeL2>();
 

--- a/modules/arm_plugin/src/transformations/convert_normalizel2_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_normalizel2_arm.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertNormalizeL2ToArm, "ConvertNormalizeL2ToArm");
+OPENVINO_OP(ArmPlugin::pass::ConvertNormalizeL2ToArm, "ConvertNormalizeL2ToArm");
 ArmPlugin::pass::ConvertNormalizeL2ToArm::ConvertNormalizeL2ToArm() {
     auto norml2 = ngraph::pattern::wrap_type<opset::NormalizeL2>();
 

--- a/modules/arm_plugin/src/transformations/convert_normalizel2_arm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_normalizel2_arm.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertNormalizeL2ToArm: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertNormalizeL2ToArm");
+    OPENVINO_RTTI("ConvertNormalizeL2ToArm");
     ConvertNormalizeL2ToArm();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_normalizel2_arm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_normalizel2_arm.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertNormalizeL2ToArm: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertNormalizeL2ToArm");
     ConvertNormalizeL2ToArm();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_pool1d_to_pool2d.cpp
+++ b/modules/arm_plugin/src/transformations/convert_pool1d_to_pool2d.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ConvertMaxPool1D, "ConvertMaxPool1D");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMaxPool1D, "ConvertMaxPool1D");
 ArmPlugin::pass::ConvertMaxPool1D::ConvertMaxPool1D() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
         ngraph::pattern::wrap_type<opset::v1::ArmMaxPool>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape())},
@@ -52,7 +52,7 @@ ArmPlugin::pass::ConvertMaxPool1D::ConvertMaxPool1D() {
     });
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertAvgPool1D, "ConvertAvgPool1D");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertAvgPool1D, "ConvertAvgPool1D");
 ArmPlugin::pass::ConvertAvgPool1D::ConvertAvgPool1D() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::v1::ArmAvgPool>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape())},

--- a/modules/arm_plugin/src/transformations/convert_pool1d_to_pool2d.cpp
+++ b/modules/arm_plugin/src/transformations/convert_pool1d_to_pool2d.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMaxPool1D, "ConvertMaxPool1D", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMaxPool1D, "ConvertMaxPool1D");
 ArmPlugin::pass::ConvertMaxPool1D::ConvertMaxPool1D() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
         ngraph::pattern::wrap_type<opset::v1::ArmMaxPool>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape())},
@@ -52,7 +52,7 @@ ArmPlugin::pass::ConvertMaxPool1D::ConvertMaxPool1D() {
     });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertAvgPool1D, "ConvertAvgPool1D", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertAvgPool1D, "ConvertAvgPool1D");
 ArmPlugin::pass::ConvertAvgPool1D::ConvertAvgPool1D() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::v1::ArmAvgPool>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape())},

--- a/modules/arm_plugin/src/transformations/convert_pool1d_to_pool2d.cpp
+++ b/modules/arm_plugin/src/transformations/convert_pool1d_to_pool2d.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMaxPool1D, "ConvertMaxPool1D");
+OPENVINO_OP(ArmPlugin::pass::ConvertMaxPool1D, "ConvertMaxPool1D");
 ArmPlugin::pass::ConvertMaxPool1D::ConvertMaxPool1D() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
         ngraph::pattern::wrap_type<opset::v1::ArmMaxPool>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape())},
@@ -52,7 +52,7 @@ ArmPlugin::pass::ConvertMaxPool1D::ConvertMaxPool1D() {
     });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertAvgPool1D, "ConvertAvgPool1D");
+OPENVINO_OP(ArmPlugin::pass::ConvertAvgPool1D, "ConvertAvgPool1D");
 ArmPlugin::pass::ConvertAvgPool1D::ConvertAvgPool1D() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::v1::ArmAvgPool>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape())},

--- a/modules/arm_plugin/src/transformations/convert_pool1d_to_pool2d.cpp
+++ b/modules/arm_plugin/src/transformations/convert_pool1d_to_pool2d.cpp
@@ -10,7 +10,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertMaxPool1D, "ConvertMaxPool1D");
 ArmPlugin::pass::ConvertMaxPool1D::ConvertMaxPool1D() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
         ngraph::pattern::wrap_type<opset::v1::ArmMaxPool>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape())},
@@ -52,7 +51,6 @@ ArmPlugin::pass::ConvertMaxPool1D::ConvertMaxPool1D() {
     });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertAvgPool1D, "ConvertAvgPool1D");
 ArmPlugin::pass::ConvertAvgPool1D::ConvertAvgPool1D() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::v1::ArmAvgPool>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape())},

--- a/modules/arm_plugin/src/transformations/convert_pool1d_to_pool2d.hpp
+++ b/modules/arm_plugin/src/transformations/convert_pool1d_to_pool2d.hpp
@@ -10,13 +10,13 @@ namespace pass {
 
 class ConvertMaxPool1D: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertMaxPool1D");
     ConvertMaxPool1D();
 };
 
 class ConvertAvgPool1D: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertAvgPool1D");
     ConvertAvgPool1D();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_pool1d_to_pool2d.hpp
+++ b/modules/arm_plugin/src/transformations/convert_pool1d_to_pool2d.hpp
@@ -10,13 +10,13 @@ namespace pass {
 
 class ConvertMaxPool1D: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertMaxPool1D");
+    OPENVINO_RTTI("ConvertMaxPool1D");
     ConvertMaxPool1D();
 };
 
 class ConvertAvgPool1D: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertAvgPool1D");
+    OPENVINO_RTTI("ConvertAvgPool1D");
     ConvertAvgPool1D();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_pool_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_pool_arm.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmMaxPoolV1, "ConvertArmMaxPoolV1");
+OPENVINO_OP(ArmPlugin::pass::ConvertArmMaxPoolV1, "ConvertArmMaxPoolV1");
 ArmPlugin::pass::ConvertArmMaxPoolV1::ConvertArmMaxPoolV1() {
     auto max_pool = ngraph::pattern::wrap_type<ov::op::v1::MaxPool>();
 
@@ -34,7 +34,7 @@ ArmPlugin::pass::ConvertArmMaxPoolV1::ConvertArmMaxPoolV1() {
     register_matcher(m, callback);
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmMaxPoolV8, "ConvertArmMaxPoolV8");
+OPENVINO_OP(ArmPlugin::pass::ConvertArmMaxPoolV8, "ConvertArmMaxPoolV8");
 ArmPlugin::pass::ConvertArmMaxPoolV8::ConvertArmMaxPoolV8() {
     auto max_pool = ngraph::pattern::wrap_type<ov::op::v8::MaxPool>();
 
@@ -64,7 +64,7 @@ ArmPlugin::pass::ConvertArmMaxPoolV8::ConvertArmMaxPoolV8() {
     register_matcher(m, callback);
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmAvgPool, "ConvertArmAvgPool");
+OPENVINO_OP(ArmPlugin::pass::ConvertArmAvgPool, "ConvertArmAvgPool");
 ArmPlugin::pass::ConvertArmAvgPool::ConvertArmAvgPool() {
     auto avg_pool = ngraph::pattern::wrap_type<ov::op::v1::AvgPool>();
 

--- a/modules/arm_plugin/src/transformations/convert_pool_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_pool_arm.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmMaxPoolV1, "ConvertArmMaxPoolV1", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmMaxPoolV1, "ConvertArmMaxPoolV1");
 ArmPlugin::pass::ConvertArmMaxPoolV1::ConvertArmMaxPoolV1() {
     auto max_pool = ngraph::pattern::wrap_type<ov::op::v1::MaxPool>();
 
@@ -34,7 +34,7 @@ ArmPlugin::pass::ConvertArmMaxPoolV1::ConvertArmMaxPoolV1() {
     register_matcher(m, callback);
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmMaxPoolV8, "ConvertArmMaxPoolV8", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmMaxPoolV8, "ConvertArmMaxPoolV8");
 ArmPlugin::pass::ConvertArmMaxPoolV8::ConvertArmMaxPoolV8() {
     auto max_pool = ngraph::pattern::wrap_type<ov::op::v8::MaxPool>();
 
@@ -64,7 +64,7 @@ ArmPlugin::pass::ConvertArmMaxPoolV8::ConvertArmMaxPoolV8() {
     register_matcher(m, callback);
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmAvgPool, "ConvertArmAvgPool", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmAvgPool, "ConvertArmAvgPool");
 ArmPlugin::pass::ConvertArmAvgPool::ConvertArmAvgPool() {
     auto avg_pool = ngraph::pattern::wrap_type<ov::op::v1::AvgPool>();
 

--- a/modules/arm_plugin/src/transformations/convert_pool_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_pool_arm.cpp
@@ -7,7 +7,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmMaxPoolV1, "ConvertArmMaxPoolV1");
 ArmPlugin::pass::ConvertArmMaxPoolV1::ConvertArmMaxPoolV1() {
     auto max_pool = ngraph::pattern::wrap_type<ov::op::v1::MaxPool>();
 
@@ -34,7 +33,6 @@ ArmPlugin::pass::ConvertArmMaxPoolV1::ConvertArmMaxPoolV1() {
     register_matcher(m, callback);
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmMaxPoolV8, "ConvertArmMaxPoolV8");
 ArmPlugin::pass::ConvertArmMaxPoolV8::ConvertArmMaxPoolV8() {
     auto max_pool = ngraph::pattern::wrap_type<ov::op::v8::MaxPool>();
 
@@ -64,7 +62,6 @@ ArmPlugin::pass::ConvertArmMaxPoolV8::ConvertArmMaxPoolV8() {
     register_matcher(m, callback);
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmAvgPool, "ConvertArmAvgPool");
 ArmPlugin::pass::ConvertArmAvgPool::ConvertArmAvgPool() {
     auto avg_pool = ngraph::pattern::wrap_type<ov::op::v1::AvgPool>();
 

--- a/modules/arm_plugin/src/transformations/convert_pool_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_pool_arm.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ConvertArmMaxPoolV1, "ConvertArmMaxPoolV1");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmMaxPoolV1, "ConvertArmMaxPoolV1");
 ArmPlugin::pass::ConvertArmMaxPoolV1::ConvertArmMaxPoolV1() {
     auto max_pool = ngraph::pattern::wrap_type<ov::op::v1::MaxPool>();
 
@@ -34,7 +34,7 @@ ArmPlugin::pass::ConvertArmMaxPoolV1::ConvertArmMaxPoolV1() {
     register_matcher(m, callback);
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertArmMaxPoolV8, "ConvertArmMaxPoolV8");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmMaxPoolV8, "ConvertArmMaxPoolV8");
 ArmPlugin::pass::ConvertArmMaxPoolV8::ConvertArmMaxPoolV8() {
     auto max_pool = ngraph::pattern::wrap_type<ov::op::v8::MaxPool>();
 
@@ -64,7 +64,7 @@ ArmPlugin::pass::ConvertArmMaxPoolV8::ConvertArmMaxPoolV8() {
     register_matcher(m, callback);
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertArmAvgPool, "ConvertArmAvgPool");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertArmAvgPool, "ConvertArmAvgPool");
 ArmPlugin::pass::ConvertArmAvgPool::ConvertArmAvgPool() {
     auto avg_pool = ngraph::pattern::wrap_type<ov::op::v1::AvgPool>();
 

--- a/modules/arm_plugin/src/transformations/convert_pool_arm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_pool_arm.hpp
@@ -10,19 +10,19 @@ namespace pass {
 
 class ConvertArmMaxPoolV1: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertArmMaxPoolV1");
+    OPENVINO_RTTI("ConvertArmMaxPoolV1");
     ConvertArmMaxPoolV1();
 };
 
 class ConvertArmMaxPoolV8: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertArmMaxPoolV8");
+    OPENVINO_RTTI("ConvertArmMaxPoolV8");
     ConvertArmMaxPoolV8();
 };
 
 class ConvertArmAvgPool: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertArmAvgPool");
+    OPENVINO_RTTI("ConvertArmAvgPool");
     ConvertArmAvgPool();
 };
 

--- a/modules/arm_plugin/src/transformations/convert_pool_arm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_pool_arm.hpp
@@ -10,19 +10,19 @@ namespace pass {
 
 class ConvertArmMaxPoolV1: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertArmMaxPoolV1");
     ConvertArmMaxPoolV1();
 };
 
 class ConvertArmMaxPoolV8: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertArmMaxPoolV8");
     ConvertArmMaxPoolV8();
 };
 
 class ConvertArmAvgPool: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertArmAvgPool");
     ConvertArmAvgPool();
 };
 

--- a/modules/arm_plugin/src/transformations/convert_reduce_multi_axis.cpp
+++ b/modules/arm_plugin/src/transformations/convert_reduce_multi_axis.cpp
@@ -9,7 +9,6 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertReduceMultiAxisBase, "ConvertReduceMultiAxisBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertReduceMultiAxisBase::convert_reduce() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -47,7 +46,6 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertReduceMultiAxisBase::conve
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertReduceProd, "ConvertReduceProd");
 ArmPlugin::pass::ConvertReduceProd::ConvertReduceProd() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::ReduceProd>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -56,7 +54,6 @@ ArmPlugin::pass::ConvertReduceProd::ConvertReduceProd() {
     register_matcher(m, convert_reduce<opset::ReduceProd>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertReduceMin, "ConvertReduceMin");
 ArmPlugin::pass::ConvertReduceMin::ConvertReduceMin() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::ReduceMin>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_reduce_multi_axis.cpp
+++ b/modules/arm_plugin/src/transformations/convert_reduce_multi_axis.cpp
@@ -9,7 +9,7 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertReduceMultiAxisBase, "ConvertReduceMultiAxisBase");
+OPENVINO_OP(ArmPlugin::pass::ConvertReduceMultiAxisBase, "ConvertReduceMultiAxisBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertReduceMultiAxisBase::convert_reduce() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -47,7 +47,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertReduceMultiAxisBase::conve
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertReduceProd, "ConvertReduceProd");
+OPENVINO_OP(ArmPlugin::pass::ConvertReduceProd, "ConvertReduceProd");
 ArmPlugin::pass::ConvertReduceProd::ConvertReduceProd() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::ReduceProd>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -56,7 +56,7 @@ ArmPlugin::pass::ConvertReduceProd::ConvertReduceProd() {
     register_matcher(m, convert_reduce<opset::ReduceProd>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertReduceMin, "ConvertReduceMin");
+OPENVINO_OP(ArmPlugin::pass::ConvertReduceMin, "ConvertReduceMin");
 ArmPlugin::pass::ConvertReduceMin::ConvertReduceMin() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::ReduceMin>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_reduce_multi_axis.cpp
+++ b/modules/arm_plugin/src/transformations/convert_reduce_multi_axis.cpp
@@ -9,7 +9,7 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertReduceMultiAxisBase, "ConvertReduceMultiAxisBase", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertReduceMultiAxisBase, "ConvertReduceMultiAxisBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertReduceMultiAxisBase::convert_reduce() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -47,7 +47,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertReduceMultiAxisBase::conve
     };
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertReduceProd, "ConvertReduceProd", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertReduceProd, "ConvertReduceProd");
 ArmPlugin::pass::ConvertReduceProd::ConvertReduceProd() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::ReduceProd>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -56,7 +56,7 @@ ArmPlugin::pass::ConvertReduceProd::ConvertReduceProd() {
     register_matcher(m, convert_reduce<opset::ReduceProd>());
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertReduceMin, "ConvertReduceMin", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertReduceMin, "ConvertReduceMin");
 ArmPlugin::pass::ConvertReduceMin::ConvertReduceMin() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::ReduceMin>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_reduce_multi_axis.cpp
+++ b/modules/arm_plugin/src/transformations/convert_reduce_multi_axis.cpp
@@ -9,7 +9,7 @@
 
 using namespace ArmPlugin;
 
-OPENVINO_OP(ArmPlugin::pass::ConvertReduceMultiAxisBase, "ConvertReduceMultiAxisBase");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertReduceMultiAxisBase, "ConvertReduceMultiAxisBase");
 template <class T>
 ngraph::matcher_pass_callback ArmPlugin::pass::ConvertReduceMultiAxisBase::convert_reduce() {
     return [&](ngraph::pattern::Matcher& m) {
@@ -47,7 +47,7 @@ ngraph::matcher_pass_callback ArmPlugin::pass::ConvertReduceMultiAxisBase::conve
     };
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertReduceProd, "ConvertReduceProd");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertReduceProd, "ConvertReduceProd");
 ArmPlugin::pass::ConvertReduceProd::ConvertReduceProd() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::ReduceProd>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -56,7 +56,7 @@ ArmPlugin::pass::ConvertReduceProd::ConvertReduceProd() {
     register_matcher(m, convert_reduce<opset::ReduceProd>());
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertReduceMin, "ConvertReduceMin");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertReduceMin, "ConvertReduceMin");
 ArmPlugin::pass::ConvertReduceMin::ConvertReduceMin() {
     auto m = std::make_shared<ngraph::pattern::Matcher>(
             ngraph::pattern::wrap_type<opset::ReduceMin>({ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),

--- a/modules/arm_plugin/src/transformations/convert_reduce_multi_axis.hpp
+++ b/modules/arm_plugin/src/transformations/convert_reduce_multi_axis.hpp
@@ -11,20 +11,20 @@ namespace pass {
 
 class ConvertReduceMultiAxisBase : public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertReduceMultiAxisBase");
+    OPENVINO_RTTI("ConvertReduceMultiAxisBase");
     template <class T>
     ngraph::matcher_pass_callback convert_reduce();
 };
 
 class ConvertReduceProd: public ConvertReduceMultiAxisBase {
 public:
-    OPENVINO_OP("ConvertReduceProd");
+    OPENVINO_RTTI("ConvertReduceProd");
     ConvertReduceProd();
 };
 
 class ConvertReduceMin: public ConvertReduceMultiAxisBase {
 public:
-    OPENVINO_OP("ConvertReduceMin");
+    OPENVINO_RTTI("ConvertReduceMin");
     ConvertReduceMin();
 };
 

--- a/modules/arm_plugin/src/transformations/convert_reduce_multi_axis.hpp
+++ b/modules/arm_plugin/src/transformations/convert_reduce_multi_axis.hpp
@@ -11,20 +11,20 @@ namespace pass {
 
 class ConvertReduceMultiAxisBase : public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertReduceMultiAxisBase");
     template <class T>
     ngraph::matcher_pass_callback convert_reduce();
 };
 
 class ConvertReduceProd: public ConvertReduceMultiAxisBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertReduceProd");
     ConvertReduceProd();
 };
 
 class ConvertReduceMin: public ConvertReduceMultiAxisBase {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertReduceMin");
     ConvertReduceMin();
 };
 

--- a/modules/arm_plugin/src/transformations/convert_reorg.cpp
+++ b/modules/arm_plugin/src/transformations/convert_reorg.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertReorgYolo, "ConvertReorgYolo");
+OPENVINO_OP(ArmPlugin::pass::ConvertReorgYolo, "ConvertReorgYolo");
 ArmPlugin::pass::ConvertReorgYolo::ConvertReorgYolo() {
     auto reorg = ngraph::pattern::wrap_type<opset::ReorgYolo>();
 

--- a/modules/arm_plugin/src/transformations/convert_reorg.cpp
+++ b/modules/arm_plugin/src/transformations/convert_reorg.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ConvertReorgYolo, "ConvertReorgYolo");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertReorgYolo, "ConvertReorgYolo");
 ArmPlugin::pass::ConvertReorgYolo::ConvertReorgYolo() {
     auto reorg = ngraph::pattern::wrap_type<opset::ReorgYolo>();
 

--- a/modules/arm_plugin/src/transformations/convert_reorg.cpp
+++ b/modules/arm_plugin/src/transformations/convert_reorg.cpp
@@ -10,7 +10,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertReorgYolo, "ConvertReorgYolo");
 ArmPlugin::pass::ConvertReorgYolo::ConvertReorgYolo() {
     auto reorg = ngraph::pattern::wrap_type<opset::ReorgYolo>();
 

--- a/modules/arm_plugin/src/transformations/convert_reorg.cpp
+++ b/modules/arm_plugin/src/transformations/convert_reorg.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertReorgYolo, "ConvertReorgYolo", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertReorgYolo, "ConvertReorgYolo");
 ArmPlugin::pass::ConvertReorgYolo::ConvertReorgYolo() {
     auto reorg = ngraph::pattern::wrap_type<opset::ReorgYolo>();
 

--- a/modules/arm_plugin/src/transformations/convert_reorg.hpp
+++ b/modules/arm_plugin/src/transformations/convert_reorg.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertReorgYolo: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertReorgYolo");
+    OPENVINO_RTTI("ConvertReorgYolo");
     ConvertReorgYolo();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_reorg.hpp
+++ b/modules/arm_plugin/src/transformations/convert_reorg.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertReorgYolo: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertReorgYolo");
     ConvertReorgYolo();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_rnn_cell.cpp
+++ b/modules/arm_plugin/src/transformations/convert_rnn_cell.cpp
@@ -13,7 +13,7 @@
 
 enum RNNInput {InputData, HiddenState, Weights, RecurrenceWeights, Bias};
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertRNNCell, "ConvertRNNCell", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertRNNCell, "ConvertRNNCell");
 ArmPlugin::pass::ConvertRNNCell::ConvertRNNCell() {
     auto rnn_cell = ngraph::pattern::wrap_type<opset::RNNCell>();
     ngraph::matcher_pass_callback callback = [this](ngraph::pattern::Matcher& m) {

--- a/modules/arm_plugin/src/transformations/convert_rnn_cell.cpp
+++ b/modules/arm_plugin/src/transformations/convert_rnn_cell.cpp
@@ -13,7 +13,6 @@
 
 enum RNNInput {InputData, HiddenState, Weights, RecurrenceWeights, Bias};
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertRNNCell, "ConvertRNNCell");
 ArmPlugin::pass::ConvertRNNCell::ConvertRNNCell() {
     auto rnn_cell = ngraph::pattern::wrap_type<opset::RNNCell>();
     ngraph::matcher_pass_callback callback = [this](ngraph::pattern::Matcher& m) {

--- a/modules/arm_plugin/src/transformations/convert_rnn_cell.cpp
+++ b/modules/arm_plugin/src/transformations/convert_rnn_cell.cpp
@@ -13,7 +13,7 @@
 
 enum RNNInput {InputData, HiddenState, Weights, RecurrenceWeights, Bias};
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertRNNCell, "ConvertRNNCell");
+OPENVINO_OP(ArmPlugin::pass::ConvertRNNCell, "ConvertRNNCell");
 ArmPlugin::pass::ConvertRNNCell::ConvertRNNCell() {
     auto rnn_cell = ngraph::pattern::wrap_type<opset::RNNCell>();
     ngraph::matcher_pass_callback callback = [this](ngraph::pattern::Matcher& m) {

--- a/modules/arm_plugin/src/transformations/convert_rnn_cell.cpp
+++ b/modules/arm_plugin/src/transformations/convert_rnn_cell.cpp
@@ -13,7 +13,7 @@
 
 enum RNNInput {InputData, HiddenState, Weights, RecurrenceWeights, Bias};
 
-OPENVINO_OP(ArmPlugin::pass::ConvertRNNCell, "ConvertRNNCell");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertRNNCell, "ConvertRNNCell");
 ArmPlugin::pass::ConvertRNNCell::ConvertRNNCell() {
     auto rnn_cell = ngraph::pattern::wrap_type<opset::RNNCell>();
     ngraph::matcher_pass_callback callback = [this](ngraph::pattern::Matcher& m) {

--- a/modules/arm_plugin/src/transformations/convert_rnn_cell.hpp
+++ b/modules/arm_plugin/src/transformations/convert_rnn_cell.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertRNNCell: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertRNNCell");
     ConvertRNNCell();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_rnn_cell.hpp
+++ b/modules/arm_plugin/src/transformations/convert_rnn_cell.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertRNNCell: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertRNNCell");
+    OPENVINO_RTTI("ConvertRNNCell");
     ConvertRNNCell();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_round.cpp
+++ b/modules/arm_plugin/src/transformations/convert_round.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ConvertRound, "ConvertRound");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertRound, "ConvertRound");
 ArmPlugin::pass::ConvertRound::ConvertRound() {
     auto round = ngraph::pattern::wrap_type<opset::Round>();
 

--- a/modules/arm_plugin/src/transformations/convert_round.cpp
+++ b/modules/arm_plugin/src/transformations/convert_round.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertRound, "ConvertRound");
+OPENVINO_OP(ArmPlugin::pass::ConvertRound, "ConvertRound");
 ArmPlugin::pass::ConvertRound::ConvertRound() {
     auto round = ngraph::pattern::wrap_type<opset::Round>();
 

--- a/modules/arm_plugin/src/transformations/convert_round.cpp
+++ b/modules/arm_plugin/src/transformations/convert_round.cpp
@@ -8,7 +8,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertRound, "ConvertRound");
 ArmPlugin::pass::ConvertRound::ConvertRound() {
     auto round = ngraph::pattern::wrap_type<opset::Round>();
 

--- a/modules/arm_plugin/src/transformations/convert_round.cpp
+++ b/modules/arm_plugin/src/transformations/convert_round.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertRound, "ConvertRound", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertRound, "ConvertRound");
 ArmPlugin::pass::ConvertRound::ConvertRound() {
     auto round = ngraph::pattern::wrap_type<opset::Round>();
 

--- a/modules/arm_plugin/src/transformations/convert_round.hpp
+++ b/modules/arm_plugin/src/transformations/convert_round.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertRound: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertRound");
+    OPENVINO_RTTI("ConvertRound");
     ConvertRound();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_round.hpp
+++ b/modules/arm_plugin/src/transformations/convert_round.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertRound: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertRound");
     ConvertRound();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_select.cpp
+++ b/modules/arm_plugin/src/transformations/convert_select.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::BroadcastSelect, "BroadcastSelect");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::BroadcastSelect, "BroadcastSelect");
 ArmPlugin::pass::BroadcastSelect::BroadcastSelect() {
     auto select = ngraph::pattern::wrap_type<opset::Select>();
 

--- a/modules/arm_plugin/src/transformations/convert_select.cpp
+++ b/modules/arm_plugin/src/transformations/convert_select.cpp
@@ -10,7 +10,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::BroadcastSelect, "BroadcastSelect");
 ArmPlugin::pass::BroadcastSelect::BroadcastSelect() {
     auto select = ngraph::pattern::wrap_type<opset::Select>();
 

--- a/modules/arm_plugin/src/transformations/convert_select.cpp
+++ b/modules/arm_plugin/src/transformations/convert_select.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::BroadcastSelect, "BroadcastSelect");
+OPENVINO_OP(ArmPlugin::pass::BroadcastSelect, "BroadcastSelect");
 ArmPlugin::pass::BroadcastSelect::BroadcastSelect() {
     auto select = ngraph::pattern::wrap_type<opset::Select>();
 

--- a/modules/arm_plugin/src/transformations/convert_select.cpp
+++ b/modules/arm_plugin/src/transformations/convert_select.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::BroadcastSelect, "BroadcastSelect", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::BroadcastSelect, "BroadcastSelect");
 ArmPlugin::pass::BroadcastSelect::BroadcastSelect() {
     auto select = ngraph::pattern::wrap_type<opset::Select>();
 

--- a/modules/arm_plugin/src/transformations/convert_select.hpp
+++ b/modules/arm_plugin/src/transformations/convert_select.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class BroadcastSelect: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("BroadcastSelect");
     BroadcastSelect();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_select.hpp
+++ b/modules/arm_plugin/src/transformations/convert_select.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class BroadcastSelect: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("BroadcastSelect");
+    OPENVINO_RTTI("BroadcastSelect");
     BroadcastSelect();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_shuffle_channels.cpp
+++ b/modules/arm_plugin/src/transformations/convert_shuffle_channels.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ConvertShuffleChannels, "ConvertShuffleChannels");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertShuffleChannels, "ConvertShuffleChannels");
 ArmPlugin::pass::ConvertShuffleChannels::ConvertShuffleChannels() {
     auto shuffle = ngraph::pattern::wrap_type<opset::ShuffleChannels>();
 

--- a/modules/arm_plugin/src/transformations/convert_shuffle_channels.cpp
+++ b/modules/arm_plugin/src/transformations/convert_shuffle_channels.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertShuffleChannels, "ConvertShuffleChannels");
+OPENVINO_OP(ArmPlugin::pass::ConvertShuffleChannels, "ConvertShuffleChannels");
 ArmPlugin::pass::ConvertShuffleChannels::ConvertShuffleChannels() {
     auto shuffle = ngraph::pattern::wrap_type<opset::ShuffleChannels>();
 

--- a/modules/arm_plugin/src/transformations/convert_shuffle_channels.cpp
+++ b/modules/arm_plugin/src/transformations/convert_shuffle_channels.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertShuffleChannels, "ConvertShuffleChannels", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertShuffleChannels, "ConvertShuffleChannels");
 ArmPlugin::pass::ConvertShuffleChannels::ConvertShuffleChannels() {
     auto shuffle = ngraph::pattern::wrap_type<opset::ShuffleChannels>();
 

--- a/modules/arm_plugin/src/transformations/convert_shuffle_channels.cpp
+++ b/modules/arm_plugin/src/transformations/convert_shuffle_channels.cpp
@@ -10,7 +10,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertShuffleChannels, "ConvertShuffleChannels");
 ArmPlugin::pass::ConvertShuffleChannels::ConvertShuffleChannels() {
     auto shuffle = ngraph::pattern::wrap_type<opset::ShuffleChannels>();
 

--- a/modules/arm_plugin/src/transformations/convert_shuffle_channels.hpp
+++ b/modules/arm_plugin/src/transformations/convert_shuffle_channels.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertShuffleChannels: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertShuffleChannels");
+    OPENVINO_RTTI("ConvertShuffleChannels");
     ConvertShuffleChannels();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_shuffle_channels.hpp
+++ b/modules/arm_plugin/src/transformations/convert_shuffle_channels.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertShuffleChannels: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertShuffleChannels");
     ConvertShuffleChannels();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_sign.cpp
+++ b/modules/arm_plugin/src/transformations/convert_sign.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ConvertSign, "ConvertSign");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSign, "ConvertSign");
 ArmPlugin::pass::ConvertSign::ConvertSign() {
     auto sign = ngraph::pattern::wrap_type<opset::Sign>();
 

--- a/modules/arm_plugin/src/transformations/convert_sign.cpp
+++ b/modules/arm_plugin/src/transformations/convert_sign.cpp
@@ -10,7 +10,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSign, "ConvertSign");
 ArmPlugin::pass::ConvertSign::ConvertSign() {
     auto sign = ngraph::pattern::wrap_type<opset::Sign>();
 

--- a/modules/arm_plugin/src/transformations/convert_sign.cpp
+++ b/modules/arm_plugin/src/transformations/convert_sign.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSign, "ConvertSign");
+OPENVINO_OP(ArmPlugin::pass::ConvertSign, "ConvertSign");
 ArmPlugin::pass::ConvertSign::ConvertSign() {
     auto sign = ngraph::pattern::wrap_type<opset::Sign>();
 

--- a/modules/arm_plugin/src/transformations/convert_sign.cpp
+++ b/modules/arm_plugin/src/transformations/convert_sign.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSign, "ConvertSign", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSign, "ConvertSign");
 ArmPlugin::pass::ConvertSign::ConvertSign() {
     auto sign = ngraph::pattern::wrap_type<opset::Sign>();
 

--- a/modules/arm_plugin/src/transformations/convert_sign.hpp
+++ b/modules/arm_plugin/src/transformations/convert_sign.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertSign: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertSign");
     ConvertSign();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_sign.hpp
+++ b/modules/arm_plugin/src/transformations/convert_sign.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertSign: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertSign");
+    OPENVINO_RTTI("ConvertSign");
     ConvertSign();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_slice_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_slice_arm.cpp
@@ -8,7 +8,6 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include "ngraph/validation_util.hpp"
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSliceToArm, "ConvertSliceToArm");
 ArmPlugin::pass::ConvertSliceToArm::ConvertSliceToArm() {
     auto slice = ngraph::pattern::wrap_type<ngraph::op::v8::Slice>();
 

--- a/modules/arm_plugin/src/transformations/convert_slice_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_slice_arm.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include "ngraph/validation_util.hpp"
 
-OPENVINO_OP(ArmPlugin::pass::ConvertSliceToArm, "ConvertSliceToArm");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSliceToArm, "ConvertSliceToArm");
 ArmPlugin::pass::ConvertSliceToArm::ConvertSliceToArm() {
     auto slice = ngraph::pattern::wrap_type<ngraph::op::v8::Slice>();
 

--- a/modules/arm_plugin/src/transformations/convert_slice_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_slice_arm.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include "ngraph/validation_util.hpp"
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSliceToArm, "ConvertSliceToArm", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSliceToArm, "ConvertSliceToArm");
 ArmPlugin::pass::ConvertSliceToArm::ConvertSliceToArm() {
     auto slice = ngraph::pattern::wrap_type<ngraph::op::v8::Slice>();
 

--- a/modules/arm_plugin/src/transformations/convert_slice_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_slice_arm.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include "ngraph/validation_util.hpp"
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSliceToArm, "ConvertSliceToArm");
+OPENVINO_OP(ArmPlugin::pass::ConvertSliceToArm, "ConvertSliceToArm");
 ArmPlugin::pass::ConvertSliceToArm::ConvertSliceToArm() {
     auto slice = ngraph::pattern::wrap_type<ngraph::op::v8::Slice>();
 

--- a/modules/arm_plugin/src/transformations/convert_slice_arm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_slice_arm.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertSliceToArm: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertSliceToArm");
+    OPENVINO_RTTI("ConvertSliceToArm");
     ConvertSliceToArm();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_slice_arm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_slice_arm.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertSliceToArm: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertSliceToArm");
     ConvertSliceToArm();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_split.cpp
+++ b/modules/arm_plugin/src/transformations/convert_split.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ConvertSplit, "ConvertSplit");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSplit, "ConvertSplit");
 ArmPlugin::pass::ConvertSplit::ConvertSplit() {
     register_matcher(std::make_shared<ngraph::pattern::Matcher>(ngraph::pattern::wrap_type<opset::Split>(), "ConvertSplit"),
         [](ngraph::pattern::Matcher& m) {

--- a/modules/arm_plugin/src/transformations/convert_split.cpp
+++ b/modules/arm_plugin/src/transformations/convert_split.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSplit, "ConvertSplit");
+OPENVINO_OP(ArmPlugin::pass::ConvertSplit, "ConvertSplit");
 ArmPlugin::pass::ConvertSplit::ConvertSplit() {
     register_matcher(std::make_shared<ngraph::pattern::Matcher>(ngraph::pattern::wrap_type<opset::Split>(), "ConvertSplit"),
         [](ngraph::pattern::Matcher& m) {

--- a/modules/arm_plugin/src/transformations/convert_split.cpp
+++ b/modules/arm_plugin/src/transformations/convert_split.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSplit, "ConvertSplit", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSplit, "ConvertSplit");
 ArmPlugin::pass::ConvertSplit::ConvertSplit() {
     register_matcher(std::make_shared<ngraph::pattern::Matcher>(ngraph::pattern::wrap_type<opset::Split>(), "ConvertSplit"),
         [](ngraph::pattern::Matcher& m) {

--- a/modules/arm_plugin/src/transformations/convert_split.cpp
+++ b/modules/arm_plugin/src/transformations/convert_split.cpp
@@ -7,7 +7,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertSplit, "ConvertSplit");
 ArmPlugin::pass::ConvertSplit::ConvertSplit() {
     register_matcher(std::make_shared<ngraph::pattern::Matcher>(ngraph::pattern::wrap_type<opset::Split>(), "ConvertSplit"),
         [](ngraph::pattern::Matcher& m) {

--- a/modules/arm_plugin/src/transformations/convert_split.hpp
+++ b/modules/arm_plugin/src/transformations/convert_split.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertSplit: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertSplit");
     ConvertSplit();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_split.hpp
+++ b/modules/arm_plugin/src/transformations/convert_split.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertSplit: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertSplit");
+    OPENVINO_RTTI("ConvertSplit");
     ConvertSplit();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_strided_slice.cpp
+++ b/modules/arm_plugin/src/transformations/convert_strided_slice.cpp
@@ -12,7 +12,7 @@
 
 using namespace ArmPlugin;
 
-OPENVINO_OP(ArmPlugin::pass::ConvertStridedSlice, "ConvertStridedSlice");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertStridedSlice, "ConvertStridedSlice");
 ArmPlugin::pass::ConvertStridedSlice::ConvertStridedSlice() {
     auto slice  = ngraph::pattern::wrap_type<opset::ArmStridedSlice>();
 

--- a/modules/arm_plugin/src/transformations/convert_strided_slice.cpp
+++ b/modules/arm_plugin/src/transformations/convert_strided_slice.cpp
@@ -12,7 +12,6 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertStridedSlice, "ConvertStridedSlice");
 ArmPlugin::pass::ConvertStridedSlice::ConvertStridedSlice() {
     auto slice  = ngraph::pattern::wrap_type<opset::ArmStridedSlice>();
 

--- a/modules/arm_plugin/src/transformations/convert_strided_slice.cpp
+++ b/modules/arm_plugin/src/transformations/convert_strided_slice.cpp
@@ -12,7 +12,7 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertStridedSlice, "ConvertStridedSlice", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertStridedSlice, "ConvertStridedSlice");
 ArmPlugin::pass::ConvertStridedSlice::ConvertStridedSlice() {
     auto slice  = ngraph::pattern::wrap_type<opset::ArmStridedSlice>();
 

--- a/modules/arm_plugin/src/transformations/convert_strided_slice.cpp
+++ b/modules/arm_plugin/src/transformations/convert_strided_slice.cpp
@@ -12,7 +12,7 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertStridedSlice, "ConvertStridedSlice");
+OPENVINO_OP(ArmPlugin::pass::ConvertStridedSlice, "ConvertStridedSlice");
 ArmPlugin::pass::ConvertStridedSlice::ConvertStridedSlice() {
     auto slice  = ngraph::pattern::wrap_type<opset::ArmStridedSlice>();
 

--- a/modules/arm_plugin/src/transformations/convert_strided_slice.hpp
+++ b/modules/arm_plugin/src/transformations/convert_strided_slice.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertStridedSlice: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertStridedSlice");
     ConvertStridedSlice();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_strided_slice.hpp
+++ b/modules/arm_plugin/src/transformations/convert_strided_slice.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertStridedSlice: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertStridedSlice");
+    OPENVINO_RTTI("ConvertStridedSlice");
     ConvertStridedSlice();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_strided_slice_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_strided_slice_arm.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ConvertStridedSliceToArm, "ConvertStridedSliceToArm");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertStridedSliceToArm, "ConvertStridedSliceToArm");
 ArmPlugin::pass::ConvertStridedSliceToArm::ConvertStridedSliceToArm() {
     auto slice = ngraph::pattern::wrap_type<opset::StridedSlice>();
 

--- a/modules/arm_plugin/src/transformations/convert_strided_slice_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_strided_slice_arm.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertStridedSliceToArm, "ConvertStridedSliceToArm");
+OPENVINO_OP(ArmPlugin::pass::ConvertStridedSliceToArm, "ConvertStridedSliceToArm");
 ArmPlugin::pass::ConvertStridedSliceToArm::ConvertStridedSliceToArm() {
     auto slice = ngraph::pattern::wrap_type<opset::StridedSlice>();
 

--- a/modules/arm_plugin/src/transformations/convert_strided_slice_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_strided_slice_arm.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertStridedSliceToArm, "ConvertStridedSliceToArm", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertStridedSliceToArm, "ConvertStridedSliceToArm");
 ArmPlugin::pass::ConvertStridedSliceToArm::ConvertStridedSliceToArm() {
     auto slice = ngraph::pattern::wrap_type<opset::StridedSlice>();
 

--- a/modules/arm_plugin/src/transformations/convert_strided_slice_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_strided_slice_arm.cpp
@@ -7,7 +7,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertStridedSliceToArm, "ConvertStridedSliceToArm");
 ArmPlugin::pass::ConvertStridedSliceToArm::ConvertStridedSliceToArm() {
     auto slice = ngraph::pattern::wrap_type<opset::StridedSlice>();
 

--- a/modules/arm_plugin/src/transformations/convert_strided_slice_arm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_strided_slice_arm.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertStridedSliceToArm: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertStridedSliceToArm");
     ConvertStridedSliceToArm();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_strided_slice_arm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_strided_slice_arm.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertStridedSliceToArm: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertStridedSliceToArm");
+    OPENVINO_RTTI("ConvertStridedSliceToArm");
     ConvertStridedSliceToArm();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_tile_to_concats.cpp
+++ b/modules/arm_plugin/src/transformations/convert_tile_to_concats.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertTile, "ConvertTile", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertTile, "ConvertTile");
 ArmPlugin::pass::ConvertTile::ConvertTile() {
     auto tile = ngraph::pattern::wrap_type<opset::Tile>();
 

--- a/modules/arm_plugin/src/transformations/convert_tile_to_concats.cpp
+++ b/modules/arm_plugin/src/transformations/convert_tile_to_concats.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertTile, "ConvertTile");
+OPENVINO_OP(ArmPlugin::pass::ConvertTile, "ConvertTile");
 ArmPlugin::pass::ConvertTile::ConvertTile() {
     auto tile = ngraph::pattern::wrap_type<opset::Tile>();
 

--- a/modules/arm_plugin/src/transformations/convert_tile_to_concats.cpp
+++ b/modules/arm_plugin/src/transformations/convert_tile_to_concats.cpp
@@ -10,7 +10,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ConvertTile, "ConvertTile");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertTile, "ConvertTile");
 ArmPlugin::pass::ConvertTile::ConvertTile() {
     auto tile = ngraph::pattern::wrap_type<opset::Tile>();
 

--- a/modules/arm_plugin/src/transformations/convert_tile_to_concats.cpp
+++ b/modules/arm_plugin/src/transformations/convert_tile_to_concats.cpp
@@ -10,7 +10,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertTile, "ConvertTile");
 ArmPlugin::pass::ConvertTile::ConvertTile() {
     auto tile = ngraph::pattern::wrap_type<opset::Tile>();
 

--- a/modules/arm_plugin/src/transformations/convert_tile_to_concats.hpp
+++ b/modules/arm_plugin/src/transformations/convert_tile_to_concats.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertTile: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertTile");
+    OPENVINO_RTTI("ConvertTile");
     ConvertTile();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_tile_to_concats.hpp
+++ b/modules/arm_plugin/src/transformations/convert_tile_to_concats.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertTile: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertTile");
     ConvertTile();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_transpose_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_transpose_arm.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ConvertTranspose, "ConvertTranspose");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertTranspose, "ConvertTranspose");
 ArmPlugin::pass::ConvertTranspose::ConvertTranspose() {
     auto transpose = ngraph::pattern::wrap_type<opset::Transpose>();
 

--- a/modules/arm_plugin/src/transformations/convert_transpose_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_transpose_arm.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertTranspose, "ConvertTranspose", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertTranspose, "ConvertTranspose");
 ArmPlugin::pass::ConvertTranspose::ConvertTranspose() {
     auto transpose = ngraph::pattern::wrap_type<opset::Transpose>();
 

--- a/modules/arm_plugin/src/transformations/convert_transpose_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_transpose_arm.cpp
@@ -7,7 +7,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertTranspose, "ConvertTranspose");
+OPENVINO_OP(ArmPlugin::pass::ConvertTranspose, "ConvertTranspose");
 ArmPlugin::pass::ConvertTranspose::ConvertTranspose() {
     auto transpose = ngraph::pattern::wrap_type<opset::Transpose>();
 

--- a/modules/arm_plugin/src/transformations/convert_transpose_arm.cpp
+++ b/modules/arm_plugin/src/transformations/convert_transpose_arm.cpp
@@ -7,7 +7,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertTranspose, "ConvertTranspose");
 ArmPlugin::pass::ConvertTranspose::ConvertTranspose() {
     auto transpose = ngraph::pattern::wrap_type<opset::Transpose>();
 

--- a/modules/arm_plugin/src/transformations/convert_transpose_arm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_transpose_arm.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertTranspose: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertTranspose");
+    OPENVINO_RTTI("ConvertTranspose");
     ConvertTranspose();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_transpose_arm.hpp
+++ b/modules/arm_plugin/src/transformations/convert_transpose_arm.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertTranspose: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertTranspose");
     ConvertTranspose();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_transpose_mat_mul.cpp
+++ b/modules/arm_plugin/src/transformations/convert_transpose_mat_mul.cpp
@@ -75,7 +75,7 @@ std::shared_ptr<ArmPlugin::opset::Constant> get_reshape_order(const std::shared_
     return {};
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertTransposeMatMul, "ConvertTransposeMatMul");
+OPENVINO_OP(ArmPlugin::pass::ConvertTransposeMatMul, "ConvertTransposeMatMul");
 ArmPlugin::pass::ConvertTransposeMatMul::ConvertTransposeMatMul() {
     auto matmul = std::make_shared<opset::MatMul>(ngraph::pattern::any_input(), ngraph::pattern::any_input());
     matcher_pass_callback callback = [](ngraph::pattern::Matcher& m) {

--- a/modules/arm_plugin/src/transformations/convert_transpose_mat_mul.cpp
+++ b/modules/arm_plugin/src/transformations/convert_transpose_mat_mul.cpp
@@ -75,7 +75,7 @@ std::shared_ptr<ArmPlugin::opset::Constant> get_reshape_order(const std::shared_
     return {};
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertTransposeMatMul, "ConvertTransposeMatMul");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertTransposeMatMul, "ConvertTransposeMatMul");
 ArmPlugin::pass::ConvertTransposeMatMul::ConvertTransposeMatMul() {
     auto matmul = std::make_shared<opset::MatMul>(ngraph::pattern::any_input(), ngraph::pattern::any_input());
     matcher_pass_callback callback = [](ngraph::pattern::Matcher& m) {

--- a/modules/arm_plugin/src/transformations/convert_transpose_mat_mul.cpp
+++ b/modules/arm_plugin/src/transformations/convert_transpose_mat_mul.cpp
@@ -75,7 +75,7 @@ std::shared_ptr<ArmPlugin::opset::Constant> get_reshape_order(const std::shared_
     return {};
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertTransposeMatMul, "ConvertTransposeMatMul", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertTransposeMatMul, "ConvertTransposeMatMul");
 ArmPlugin::pass::ConvertTransposeMatMul::ConvertTransposeMatMul() {
     auto matmul = std::make_shared<opset::MatMul>(ngraph::pattern::any_input(), ngraph::pattern::any_input());
     matcher_pass_callback callback = [](ngraph::pattern::Matcher& m) {

--- a/modules/arm_plugin/src/transformations/convert_transpose_mat_mul.cpp
+++ b/modules/arm_plugin/src/transformations/convert_transpose_mat_mul.cpp
@@ -75,7 +75,6 @@ std::shared_ptr<ArmPlugin::opset::Constant> get_reshape_order(const std::shared_
     return {};
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertTransposeMatMul, "ConvertTransposeMatMul");
 ArmPlugin::pass::ConvertTransposeMatMul::ConvertTransposeMatMul() {
     auto matmul = std::make_shared<opset::MatMul>(ngraph::pattern::any_input(), ngraph::pattern::any_input());
     matcher_pass_callback callback = [](ngraph::pattern::Matcher& m) {

--- a/modules/arm_plugin/src/transformations/convert_transpose_mat_mul.hpp
+++ b/modules/arm_plugin/src/transformations/convert_transpose_mat_mul.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertTransposeMatMul: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertTransposeMatMul");
+    OPENVINO_RTTI("ConvertTransposeMatMul");
     ConvertTransposeMatMul();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/convert_transpose_mat_mul.hpp
+++ b/modules/arm_plugin/src/transformations/convert_transpose_mat_mul.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ConvertTransposeMatMul: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertTransposeMatMul");
     ConvertTransposeMatMul();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/decompose_mish.cpp
+++ b/modules/arm_plugin/src/transformations/decompose_mish.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::DecomposeMish, "DecomposeMish");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::DecomposeMish, "DecomposeMish");
 ArmPlugin::pass::DecomposeMish::DecomposeMish() {
     auto mish = ngraph::pattern::wrap_type<opset::Mish>();
 

--- a/modules/arm_plugin/src/transformations/decompose_mish.cpp
+++ b/modules/arm_plugin/src/transformations/decompose_mish.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::DecomposeMish, "DecomposeMish");
+OPENVINO_OP(ArmPlugin::pass::DecomposeMish, "DecomposeMish");
 ArmPlugin::pass::DecomposeMish::DecomposeMish() {
     auto mish = ngraph::pattern::wrap_type<opset::Mish>();
 

--- a/modules/arm_plugin/src/transformations/decompose_mish.cpp
+++ b/modules/arm_plugin/src/transformations/decompose_mish.cpp
@@ -8,7 +8,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::DecomposeMish, "DecomposeMish");
 ArmPlugin::pass::DecomposeMish::DecomposeMish() {
     auto mish = ngraph::pattern::wrap_type<opset::Mish>();
 

--- a/modules/arm_plugin/src/transformations/decompose_mish.cpp
+++ b/modules/arm_plugin/src/transformations/decompose_mish.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::DecomposeMish, "DecomposeMish", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::DecomposeMish, "DecomposeMish");
 ArmPlugin::pass::DecomposeMish::DecomposeMish() {
     auto mish = ngraph::pattern::wrap_type<opset::Mish>();
 

--- a/modules/arm_plugin/src/transformations/decompose_mish.hpp
+++ b/modules/arm_plugin/src/transformations/decompose_mish.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class DecomposeMish: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("DecomposeMish");
+    OPENVINO_RTTI("DecomposeMish");
     DecomposeMish();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/decompose_mish.hpp
+++ b/modules/arm_plugin/src/transformations/decompose_mish.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class DecomposeMish: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("DecomposeMish");
     DecomposeMish();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/decompose_normalizel2_add.cpp
+++ b/modules/arm_plugin/src/transformations/decompose_normalizel2_add.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::DecomposeNormalizeL2Add, "DecomposeNormalizeL2Add");
+OPENVINO_OP(ArmPlugin::pass::DecomposeNormalizeL2Add, "DecomposeNormalizeL2Add");
 ArmPlugin::pass::DecomposeNormalizeL2Add::DecomposeNormalizeL2Add() {
     auto normalize_l2 = ngraph::pattern::wrap_type<opset::NormalizeL2>();
 

--- a/modules/arm_plugin/src/transformations/decompose_normalizel2_add.cpp
+++ b/modules/arm_plugin/src/transformations/decompose_normalizel2_add.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::DecomposeNormalizeL2Add, "DecomposeNormalizeL2Add");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::DecomposeNormalizeL2Add, "DecomposeNormalizeL2Add");
 ArmPlugin::pass::DecomposeNormalizeL2Add::DecomposeNormalizeL2Add() {
     auto normalize_l2 = ngraph::pattern::wrap_type<opset::NormalizeL2>();
 

--- a/modules/arm_plugin/src/transformations/decompose_normalizel2_add.cpp
+++ b/modules/arm_plugin/src/transformations/decompose_normalizel2_add.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::DecomposeNormalizeL2Add, "DecomposeNormalizeL2Add", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::DecomposeNormalizeL2Add, "DecomposeNormalizeL2Add");
 ArmPlugin::pass::DecomposeNormalizeL2Add::DecomposeNormalizeL2Add() {
     auto normalize_l2 = ngraph::pattern::wrap_type<opset::NormalizeL2>();
 

--- a/modules/arm_plugin/src/transformations/decompose_normalizel2_add.cpp
+++ b/modules/arm_plugin/src/transformations/decompose_normalizel2_add.cpp
@@ -8,7 +8,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::DecomposeNormalizeL2Add, "DecomposeNormalizeL2Add");
 ArmPlugin::pass::DecomposeNormalizeL2Add::DecomposeNormalizeL2Add() {
     auto normalize_l2 = ngraph::pattern::wrap_type<opset::NormalizeL2>();
 

--- a/modules/arm_plugin/src/transformations/decompose_normalizel2_add.hpp
+++ b/modules/arm_plugin/src/transformations/decompose_normalizel2_add.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class DecomposeNormalizeL2Add: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("DecomposeNormalizeL2Add");
+    OPENVINO_RTTI("DecomposeNormalizeL2Add");
     DecomposeNormalizeL2Add();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/decompose_normalizel2_add.hpp
+++ b/modules/arm_plugin/src/transformations/decompose_normalizel2_add.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class DecomposeNormalizeL2Add: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("DecomposeNormalizeL2Add");
     DecomposeNormalizeL2Add();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/decompose_variadic_split.cpp
+++ b/modules/arm_plugin/src/transformations/decompose_variadic_split.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::DecomposeVariadicSplit, "DecomposeVariadicSplit", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::DecomposeVariadicSplit, "DecomposeVariadicSplit");
 ArmPlugin::pass::DecomposeVariadicSplit::DecomposeVariadicSplit() {
     auto split = ngraph::pattern::wrap_type<opset::VariadicSplit>();
 

--- a/modules/arm_plugin/src/transformations/decompose_variadic_split.cpp
+++ b/modules/arm_plugin/src/transformations/decompose_variadic_split.cpp
@@ -8,7 +8,6 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::DecomposeVariadicSplit, "DecomposeVariadicSplit");
 ArmPlugin::pass::DecomposeVariadicSplit::DecomposeVariadicSplit() {
     auto split = ngraph::pattern::wrap_type<opset::VariadicSplit>();
 

--- a/modules/arm_plugin/src/transformations/decompose_variadic_split.cpp
+++ b/modules/arm_plugin/src/transformations/decompose_variadic_split.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::DecomposeVariadicSplit, "DecomposeVariadicSplit");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::DecomposeVariadicSplit, "DecomposeVariadicSplit");
 ArmPlugin::pass::DecomposeVariadicSplit::DecomposeVariadicSplit() {
     auto split = ngraph::pattern::wrap_type<opset::VariadicSplit>();
 

--- a/modules/arm_plugin/src/transformations/decompose_variadic_split.cpp
+++ b/modules/arm_plugin/src/transformations/decompose_variadic_split.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/rt_info.hpp>
 #include <ngraph/pattern/op/wrap_type.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::DecomposeVariadicSplit, "DecomposeVariadicSplit");
+OPENVINO_OP(ArmPlugin::pass::DecomposeVariadicSplit, "DecomposeVariadicSplit");
 ArmPlugin::pass::DecomposeVariadicSplit::DecomposeVariadicSplit() {
     auto split = ngraph::pattern::wrap_type<opset::VariadicSplit>();
 

--- a/modules/arm_plugin/src/transformations/decompose_variadic_split.hpp
+++ b/modules/arm_plugin/src/transformations/decompose_variadic_split.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class DecomposeVariadicSplit: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("DecomposeVariadicSplit");
     DecomposeVariadicSplit();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/decompose_variadic_split.hpp
+++ b/modules/arm_plugin/src/transformations/decompose_variadic_split.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class DecomposeVariadicSplit: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("DecomposeVariadicSplit");
+    OPENVINO_RTTI("DecomposeVariadicSplit");
     DecomposeVariadicSplit();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/finalize_trailing_nodes.cpp
+++ b/modules/arm_plugin/src/transformations/finalize_trailing_nodes.cpp
@@ -10,7 +10,7 @@
 #include "transformations/utils/utils.hpp"
 #include <ngraph/rt_info.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::FinalizeTrailingNodes, "FinalizeTrailingNodes");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::FinalizeTrailingNodes, "FinalizeTrailingNodes");
 bool ArmPlugin::pass::FinalizeTrailingNodes::run_on_model(const std::shared_ptr<ov::Model>& m) {
     // Adding Result node for trailing nodes
     bool is_modified = false;

--- a/modules/arm_plugin/src/transformations/finalize_trailing_nodes.cpp
+++ b/modules/arm_plugin/src/transformations/finalize_trailing_nodes.cpp
@@ -10,7 +10,7 @@
 #include "transformations/utils/utils.hpp"
 #include <ngraph/rt_info.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::FinalizeTrailingNodes, "FinalizeTrailingNodes", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::FinalizeTrailingNodes, "FinalizeTrailingNodes");
 bool ArmPlugin::pass::FinalizeTrailingNodes::run_on_model(const std::shared_ptr<ov::Model>& m) {
     // Adding Result node for trailing nodes
     bool is_modified = false;

--- a/modules/arm_plugin/src/transformations/finalize_trailing_nodes.cpp
+++ b/modules/arm_plugin/src/transformations/finalize_trailing_nodes.cpp
@@ -10,7 +10,6 @@
 #include "transformations/utils/utils.hpp"
 #include <ngraph/rt_info.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::FinalizeTrailingNodes, "FinalizeTrailingNodes");
 bool ArmPlugin::pass::FinalizeTrailingNodes::run_on_model(const std::shared_ptr<ov::Model>& m) {
     // Adding Result node for trailing nodes
     bool is_modified = false;

--- a/modules/arm_plugin/src/transformations/finalize_trailing_nodes.cpp
+++ b/modules/arm_plugin/src/transformations/finalize_trailing_nodes.cpp
@@ -10,7 +10,7 @@
 #include "transformations/utils/utils.hpp"
 #include <ngraph/rt_info.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::FinalizeTrailingNodes, "FinalizeTrailingNodes");
+OPENVINO_OP(ArmPlugin::pass::FinalizeTrailingNodes, "FinalizeTrailingNodes");
 bool ArmPlugin::pass::FinalizeTrailingNodes::run_on_model(const std::shared_ptr<ov::Model>& m) {
     // Adding Result node for trailing nodes
     bool is_modified = false;

--- a/modules/arm_plugin/src/transformations/finalize_trailing_nodes.hpp
+++ b/modules/arm_plugin/src/transformations/finalize_trailing_nodes.hpp
@@ -11,7 +11,7 @@ namespace pass {
 
 class  FinalizeTrailingNodes: public ov::pass::ModelPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("FinalizeTrailingNodes");
     bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/finalize_trailing_nodes.hpp
+++ b/modules/arm_plugin/src/transformations/finalize_trailing_nodes.hpp
@@ -11,7 +11,7 @@ namespace pass {
 
 class  FinalizeTrailingNodes: public ov::pass::ModelPass {
 public:
-    OPENVINO_OP("FinalizeTrailingNodes");
+    OPENVINO_RTTI("FinalizeTrailingNodes");
     bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/matmul_bias_fusion.cpp
+++ b/modules/arm_plugin/src/transformations/matmul_bias_fusion.cpp
@@ -11,7 +11,7 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::MatMulBiasFusion, "MatMulBiasFusion", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::MatMulBiasFusion, "MatMulBiasFusion");
 ArmPlugin::pass::MatMulBiasFusion::MatMulBiasFusion() {
     auto matmul = std::make_shared<opset::MatMul>(ngraph::pattern::any_input(), ngraph::pattern::any_input());
     auto add    = std::make_shared<opset::Add>(matmul, ngraph::pattern::any_input());

--- a/modules/arm_plugin/src/transformations/matmul_bias_fusion.cpp
+++ b/modules/arm_plugin/src/transformations/matmul_bias_fusion.cpp
@@ -11,7 +11,7 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::MatMulBiasFusion, "MatMulBiasFusion");
+OPENVINO_OP(ArmPlugin::pass::MatMulBiasFusion, "MatMulBiasFusion");
 ArmPlugin::pass::MatMulBiasFusion::MatMulBiasFusion() {
     auto matmul = std::make_shared<opset::MatMul>(ngraph::pattern::any_input(), ngraph::pattern::any_input());
     auto add    = std::make_shared<opset::Add>(matmul, ngraph::pattern::any_input());

--- a/modules/arm_plugin/src/transformations/matmul_bias_fusion.cpp
+++ b/modules/arm_plugin/src/transformations/matmul_bias_fusion.cpp
@@ -11,7 +11,6 @@
 
 using namespace ArmPlugin;
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::MatMulBiasFusion, "MatMulBiasFusion");
 ArmPlugin::pass::MatMulBiasFusion::MatMulBiasFusion() {
     auto matmul = std::make_shared<opset::MatMul>(ngraph::pattern::any_input(), ngraph::pattern::any_input());
     auto add    = std::make_shared<opset::Add>(matmul, ngraph::pattern::any_input());

--- a/modules/arm_plugin/src/transformations/matmul_bias_fusion.cpp
+++ b/modules/arm_plugin/src/transformations/matmul_bias_fusion.cpp
@@ -11,7 +11,7 @@
 
 using namespace ArmPlugin;
 
-OPENVINO_OP(ArmPlugin::pass::MatMulBiasFusion, "MatMulBiasFusion");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::MatMulBiasFusion, "MatMulBiasFusion");
 ArmPlugin::pass::MatMulBiasFusion::MatMulBiasFusion() {
     auto matmul = std::make_shared<opset::MatMul>(ngraph::pattern::any_input(), ngraph::pattern::any_input());
     auto add    = std::make_shared<opset::Add>(matmul, ngraph::pattern::any_input());

--- a/modules/arm_plugin/src/transformations/matmul_bias_fusion.hpp
+++ b/modules/arm_plugin/src/transformations/matmul_bias_fusion.hpp
@@ -11,7 +11,7 @@ namespace pass {
 
 class MatMulBiasFusion: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("MatMulBiasFusion");
     MatMulBiasFusion();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/matmul_bias_fusion.hpp
+++ b/modules/arm_plugin/src/transformations/matmul_bias_fusion.hpp
@@ -11,7 +11,7 @@ namespace pass {
 
 class MatMulBiasFusion: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("MatMulBiasFusion");
+    OPENVINO_RTTI("MatMulBiasFusion");
     MatMulBiasFusion();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/normalizel2_max_fusion.cpp
+++ b/modules/arm_plugin/src/transformations/normalizel2_max_fusion.cpp
@@ -9,7 +9,6 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include "transformations/utils/utils.hpp"
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::NormalizeL2Fusion, "NormalizeL2Fusion");
 ArmPlugin::pass::NormalizeL2Fusion::NormalizeL2Fusion() {
     auto input = ngraph::pattern::any_input();
     auto exp = ngraph::pattern::wrap_type<opset::Constant>();

--- a/modules/arm_plugin/src/transformations/normalizel2_max_fusion.cpp
+++ b/modules/arm_plugin/src/transformations/normalizel2_max_fusion.cpp
@@ -9,7 +9,7 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include "transformations/utils/utils.hpp"
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::NormalizeL2Fusion, "NormalizeL2Fusion");
+OPENVINO_OP(ArmPlugin::pass::NormalizeL2Fusion, "NormalizeL2Fusion");
 ArmPlugin::pass::NormalizeL2Fusion::NormalizeL2Fusion() {
     auto input = ngraph::pattern::any_input();
     auto exp = ngraph::pattern::wrap_type<opset::Constant>();

--- a/modules/arm_plugin/src/transformations/normalizel2_max_fusion.cpp
+++ b/modules/arm_plugin/src/transformations/normalizel2_max_fusion.cpp
@@ -9,7 +9,7 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include "transformations/utils/utils.hpp"
 
-OPENVINO_OP(ArmPlugin::pass::NormalizeL2Fusion, "NormalizeL2Fusion");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::NormalizeL2Fusion, "NormalizeL2Fusion");
 ArmPlugin::pass::NormalizeL2Fusion::NormalizeL2Fusion() {
     auto input = ngraph::pattern::any_input();
     auto exp = ngraph::pattern::wrap_type<opset::Constant>();

--- a/modules/arm_plugin/src/transformations/normalizel2_max_fusion.cpp
+++ b/modules/arm_plugin/src/transformations/normalizel2_max_fusion.cpp
@@ -9,7 +9,7 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include "transformations/utils/utils.hpp"
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::NormalizeL2Fusion, "NormalizeL2Fusion", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::NormalizeL2Fusion, "NormalizeL2Fusion");
 ArmPlugin::pass::NormalizeL2Fusion::NormalizeL2Fusion() {
     auto input = ngraph::pattern::any_input();
     auto exp = ngraph::pattern::wrap_type<opset::Constant>();

--- a/modules/arm_plugin/src/transformations/normalizel2_max_fusion.hpp
+++ b/modules/arm_plugin/src/transformations/normalizel2_max_fusion.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class NormalizeL2Fusion: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("NormalizeL2Fusion");
+    OPENVINO_RTTI("NormalizeL2Fusion");
     NormalizeL2Fusion();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/normalizel2_max_fusion.hpp
+++ b/modules/arm_plugin/src/transformations/normalizel2_max_fusion.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class NormalizeL2Fusion: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("NormalizeL2Fusion");
     NormalizeL2Fusion();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/quantize_fusion.cpp
+++ b/modules/arm_plugin/src/transformations/quantize_fusion.cpp
@@ -81,7 +81,7 @@ std::shared_ptr<ngraph::Node> makeTypeRelaxed(const ngraph::Node* node,
 }
 }  // namespace
 
-OPENVINO_OP(ArmPlugin::pass::ConvertQuantize, "ConvertQuantize");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertQuantize, "ConvertQuantize");
 ArmPlugin::pass::ConvertQuantize::ConvertQuantize() {
     auto fakeQuantize = ngraph::pattern::wrap_type<opset::FakeQuantize>({
         ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -145,7 +145,7 @@ ArmPlugin::pass::ConvertQuantize::ConvertQuantize() {
         });
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvolutionQuantizeFusion, "ConvolutionQuantizeFusion");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvolutionQuantizeFusion, "ConvolutionQuantizeFusion");
 ArmPlugin::pass::ConvolutionQuantizeFusion::ConvolutionQuantizeFusion() {
     auto node_pattern = ngraph::pattern::wrap_type<
         opset::ArmConvolution,
@@ -314,7 +314,7 @@ ArmPlugin::pass::ConvolutionQuantizeFusion::ConvolutionQuantizeFusion() {
         });
 }
 
-OPENVINO_OP(ArmPlugin::pass::MeanQuantizeFusion, "MeanQuantizeFusion");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::MeanQuantizeFusion, "MeanQuantizeFusion");
 ArmPlugin::pass::MeanQuantizeFusion::MeanQuantizeFusion() {
     auto node_pattern = ngraph::pattern::wrap_type<
         opset::v1::ArmAvgPool,
@@ -365,7 +365,7 @@ ArmPlugin::pass::MeanQuantizeFusion::MeanQuantizeFusion() {
         });
 }
 
-OPENVINO_OP(ArmPlugin::pass::DequantizeInputFusion, "DequantizeInputFusion");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::DequantizeInputFusion, "DequantizeInputFusion");
 ArmPlugin::pass::DequantizeInputFusion::DequantizeInputFusion() {
     auto scale_pattern = ngraph::pattern::wrap_type<opset::Constant>();
     auto mul_pattern = ngraph::pattern::wrap_type<opset::Multiply>(
@@ -500,7 +500,7 @@ ArmPlugin::pass::DequantizeInputFusion::DequantizeInputFusion() {
         });
 }
 
-OPENVINO_OP(ArmPlugin::pass::AddDequantizeOnInputs, "AddDequantizeOnInputs");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::AddDequantizeOnInputs, "AddDequantizeOnInputs");
 ArmPlugin::pass::AddDequantizeOnInputs::AddDequantizeOnInputs() {
     auto node_pattern = ngraph::pattern::wrap_type<
         opset::ArmConvolution,
@@ -550,7 +550,7 @@ ArmPlugin::pass::AddDequantizeOnInputs::AddDequantizeOnInputs() {
         });
 }
 
-OPENVINO_OP(ArmPlugin::pass::ConvertBiasToI32, "ConvertBiasToI32");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertBiasToI32, "ConvertBiasToI32");
 ArmPlugin::pass::ConvertBiasToI32::ConvertBiasToI32() {
     auto conv = ngraph::pattern::wrap_type<
         opset::ArmConvolution,

--- a/modules/arm_plugin/src/transformations/quantize_fusion.cpp
+++ b/modules/arm_plugin/src/transformations/quantize_fusion.cpp
@@ -81,7 +81,7 @@ std::shared_ptr<ngraph::Node> makeTypeRelaxed(const ngraph::Node* node,
 }
 }  // namespace
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertQuantize, "ConvertQuantize", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertQuantize, "ConvertQuantize");
 ArmPlugin::pass::ConvertQuantize::ConvertQuantize() {
     auto fakeQuantize = ngraph::pattern::wrap_type<opset::FakeQuantize>({
         ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -145,7 +145,7 @@ ArmPlugin::pass::ConvertQuantize::ConvertQuantize() {
         });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvolutionQuantizeFusion, "ConvolutionQuantizeFusion", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvolutionQuantizeFusion, "ConvolutionQuantizeFusion");
 ArmPlugin::pass::ConvolutionQuantizeFusion::ConvolutionQuantizeFusion() {
     auto node_pattern = ngraph::pattern::wrap_type<
         opset::ArmConvolution,
@@ -314,7 +314,7 @@ ArmPlugin::pass::ConvolutionQuantizeFusion::ConvolutionQuantizeFusion() {
         });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::MeanQuantizeFusion, "MeanQuantizeFusion", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::MeanQuantizeFusion, "MeanQuantizeFusion");
 ArmPlugin::pass::MeanQuantizeFusion::MeanQuantizeFusion() {
     auto node_pattern = ngraph::pattern::wrap_type<
         opset::v1::ArmAvgPool,
@@ -365,7 +365,7 @@ ArmPlugin::pass::MeanQuantizeFusion::MeanQuantizeFusion() {
         });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::DequantizeInputFusion, "DequantizeInputFusion", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::DequantizeInputFusion, "DequantizeInputFusion");
 ArmPlugin::pass::DequantizeInputFusion::DequantizeInputFusion() {
     auto scale_pattern = ngraph::pattern::wrap_type<opset::Constant>();
     auto mul_pattern = ngraph::pattern::wrap_type<opset::Multiply>(
@@ -500,7 +500,7 @@ ArmPlugin::pass::DequantizeInputFusion::DequantizeInputFusion() {
         });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::AddDequantizeOnInputs, "AddDequantizeOnInputs", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::AddDequantizeOnInputs, "AddDequantizeOnInputs");
 ArmPlugin::pass::AddDequantizeOnInputs::AddDequantizeOnInputs() {
     auto node_pattern = ngraph::pattern::wrap_type<
         opset::ArmConvolution,
@@ -550,7 +550,7 @@ ArmPlugin::pass::AddDequantizeOnInputs::AddDequantizeOnInputs() {
         });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertBiasToI32, "ConvertBiasToI32", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertBiasToI32, "ConvertBiasToI32");
 ArmPlugin::pass::ConvertBiasToI32::ConvertBiasToI32() {
     auto conv = ngraph::pattern::wrap_type<
         opset::ArmConvolution,

--- a/modules/arm_plugin/src/transformations/quantize_fusion.cpp
+++ b/modules/arm_plugin/src/transformations/quantize_fusion.cpp
@@ -81,7 +81,7 @@ std::shared_ptr<ngraph::Node> makeTypeRelaxed(const ngraph::Node* node,
 }
 }  // namespace
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertQuantize, "ConvertQuantize");
+OPENVINO_OP(ArmPlugin::pass::ConvertQuantize, "ConvertQuantize");
 ArmPlugin::pass::ConvertQuantize::ConvertQuantize() {
     auto fakeQuantize = ngraph::pattern::wrap_type<opset::FakeQuantize>({
         ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -145,7 +145,7 @@ ArmPlugin::pass::ConvertQuantize::ConvertQuantize() {
         });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvolutionQuantizeFusion, "ConvolutionQuantizeFusion");
+OPENVINO_OP(ArmPlugin::pass::ConvolutionQuantizeFusion, "ConvolutionQuantizeFusion");
 ArmPlugin::pass::ConvolutionQuantizeFusion::ConvolutionQuantizeFusion() {
     auto node_pattern = ngraph::pattern::wrap_type<
         opset::ArmConvolution,
@@ -314,7 +314,7 @@ ArmPlugin::pass::ConvolutionQuantizeFusion::ConvolutionQuantizeFusion() {
         });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::MeanQuantizeFusion, "MeanQuantizeFusion");
+OPENVINO_OP(ArmPlugin::pass::MeanQuantizeFusion, "MeanQuantizeFusion");
 ArmPlugin::pass::MeanQuantizeFusion::MeanQuantizeFusion() {
     auto node_pattern = ngraph::pattern::wrap_type<
         opset::v1::ArmAvgPool,
@@ -365,7 +365,7 @@ ArmPlugin::pass::MeanQuantizeFusion::MeanQuantizeFusion() {
         });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::DequantizeInputFusion, "DequantizeInputFusion");
+OPENVINO_OP(ArmPlugin::pass::DequantizeInputFusion, "DequantizeInputFusion");
 ArmPlugin::pass::DequantizeInputFusion::DequantizeInputFusion() {
     auto scale_pattern = ngraph::pattern::wrap_type<opset::Constant>();
     auto mul_pattern = ngraph::pattern::wrap_type<opset::Multiply>(
@@ -500,7 +500,7 @@ ArmPlugin::pass::DequantizeInputFusion::DequantizeInputFusion() {
         });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::AddDequantizeOnInputs, "AddDequantizeOnInputs");
+OPENVINO_OP(ArmPlugin::pass::AddDequantizeOnInputs, "AddDequantizeOnInputs");
 ArmPlugin::pass::AddDequantizeOnInputs::AddDequantizeOnInputs() {
     auto node_pattern = ngraph::pattern::wrap_type<
         opset::ArmConvolution,
@@ -550,7 +550,7 @@ ArmPlugin::pass::AddDequantizeOnInputs::AddDequantizeOnInputs() {
         });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertBiasToI32, "ConvertBiasToI32");
+OPENVINO_OP(ArmPlugin::pass::ConvertBiasToI32, "ConvertBiasToI32");
 ArmPlugin::pass::ConvertBiasToI32::ConvertBiasToI32() {
     auto conv = ngraph::pattern::wrap_type<
         opset::ArmConvolution,

--- a/modules/arm_plugin/src/transformations/quantize_fusion.cpp
+++ b/modules/arm_plugin/src/transformations/quantize_fusion.cpp
@@ -81,7 +81,6 @@ std::shared_ptr<ngraph::Node> makeTypeRelaxed(const ngraph::Node* node,
 }
 }  // namespace
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertQuantize, "ConvertQuantize");
 ArmPlugin::pass::ConvertQuantize::ConvertQuantize() {
     auto fakeQuantize = ngraph::pattern::wrap_type<opset::FakeQuantize>({
         ngraph::pattern::any_input(ngraph::pattern::has_static_shape()),
@@ -145,7 +144,6 @@ ArmPlugin::pass::ConvertQuantize::ConvertQuantize() {
         });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvolutionQuantizeFusion, "ConvolutionQuantizeFusion");
 ArmPlugin::pass::ConvolutionQuantizeFusion::ConvolutionQuantizeFusion() {
     auto node_pattern = ngraph::pattern::wrap_type<
         opset::ArmConvolution,
@@ -314,7 +312,6 @@ ArmPlugin::pass::ConvolutionQuantizeFusion::ConvolutionQuantizeFusion() {
         });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::MeanQuantizeFusion, "MeanQuantizeFusion");
 ArmPlugin::pass::MeanQuantizeFusion::MeanQuantizeFusion() {
     auto node_pattern = ngraph::pattern::wrap_type<
         opset::v1::ArmAvgPool,
@@ -365,7 +362,6 @@ ArmPlugin::pass::MeanQuantizeFusion::MeanQuantizeFusion() {
         });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::DequantizeInputFusion, "DequantizeInputFusion");
 ArmPlugin::pass::DequantizeInputFusion::DequantizeInputFusion() {
     auto scale_pattern = ngraph::pattern::wrap_type<opset::Constant>();
     auto mul_pattern = ngraph::pattern::wrap_type<opset::Multiply>(
@@ -500,7 +496,6 @@ ArmPlugin::pass::DequantizeInputFusion::DequantizeInputFusion() {
         });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::AddDequantizeOnInputs, "AddDequantizeOnInputs");
 ArmPlugin::pass::AddDequantizeOnInputs::AddDequantizeOnInputs() {
     auto node_pattern = ngraph::pattern::wrap_type<
         opset::ArmConvolution,
@@ -550,7 +545,6 @@ ArmPlugin::pass::AddDequantizeOnInputs::AddDequantizeOnInputs() {
         });
 }
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ConvertBiasToI32, "ConvertBiasToI32");
 ArmPlugin::pass::ConvertBiasToI32::ConvertBiasToI32() {
     auto conv = ngraph::pattern::wrap_type<
         opset::ArmConvolution,

--- a/modules/arm_plugin/src/transformations/quantize_fusion.hpp
+++ b/modules/arm_plugin/src/transformations/quantize_fusion.hpp
@@ -11,37 +11,37 @@ namespace pass {
 
 class ConvertQuantize: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertQuantize");
     ConvertQuantize();
 };
 
 class ConvolutionQuantizeFusion : public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvolutionQuantizeFusion");
     ConvolutionQuantizeFusion();
 };
 
 class MeanQuantizeFusion : public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("MeanQuantizeFusion");
     MeanQuantizeFusion();
 };
 
 class DequantizeInputFusion : public ngraph::pass::MatcherPass{
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("DequantizeInputFusion");
     DequantizeInputFusion();
 };
 
 class AddDequantizeOnInputs: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("AddDequantizeOnInputs");
     AddDequantizeOnInputs();
 };
 
 class ConvertBiasToI32: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ConvertBiasToI32");
     ConvertBiasToI32();
 };
 

--- a/modules/arm_plugin/src/transformations/quantize_fusion.hpp
+++ b/modules/arm_plugin/src/transformations/quantize_fusion.hpp
@@ -11,37 +11,37 @@ namespace pass {
 
 class ConvertQuantize: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertQuantize");
+    OPENVINO_RTTI("ConvertQuantize");
     ConvertQuantize();
 };
 
 class ConvolutionQuantizeFusion : public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvolutionQuantizeFusion");
+    OPENVINO_RTTI("ConvolutionQuantizeFusion");
     ConvolutionQuantizeFusion();
 };
 
 class MeanQuantizeFusion : public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("MeanQuantizeFusion");
+    OPENVINO_RTTI("MeanQuantizeFusion");
     MeanQuantizeFusion();
 };
 
 class DequantizeInputFusion : public ngraph::pass::MatcherPass{
 public:
-    OPENVINO_OP("DequantizeInputFusion");
+    OPENVINO_RTTI("DequantizeInputFusion");
     DequantizeInputFusion();
 };
 
 class AddDequantizeOnInputs: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("AddDequantizeOnInputs");
+    OPENVINO_RTTI("AddDequantizeOnInputs");
     AddDequantizeOnInputs();
 };
 
 class ConvertBiasToI32: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ConvertBiasToI32");
+    OPENVINO_RTTI("ConvertBiasToI32");
     ConvertBiasToI32();
 };
 

--- a/modules/arm_plugin/src/transformations/replace_power_by_mul.cpp
+++ b/modules/arm_plugin/src/transformations/replace_power_by_mul.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ReplacePowerByMul, "ReplacePowerByMul", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ReplacePowerByMul, "ReplacePowerByMul");
 ArmPlugin::pass::ReplacePowerByMul::ReplacePowerByMul() {
     auto constant_pattern = ngraph::pattern::wrap_type<opset::Constant>();
     auto power_pattern = ngraph::pattern::wrap_type<opset::Power>({

--- a/modules/arm_plugin/src/transformations/replace_power_by_mul.cpp
+++ b/modules/arm_plugin/src/transformations/replace_power_by_mul.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
 
-OPENVINO_OP(ArmPlugin::pass::ReplacePowerByMul, "ReplacePowerByMul");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ReplacePowerByMul, "ReplacePowerByMul");
 ArmPlugin::pass::ReplacePowerByMul::ReplacePowerByMul() {
     auto constant_pattern = ngraph::pattern::wrap_type<opset::Constant>();
     auto power_pattern = ngraph::pattern::wrap_type<opset::Power>({

--- a/modules/arm_plugin/src/transformations/replace_power_by_mul.cpp
+++ b/modules/arm_plugin/src/transformations/replace_power_by_mul.cpp
@@ -8,7 +8,6 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ReplacePowerByMul, "ReplacePowerByMul");
 ArmPlugin::pass::ReplacePowerByMul::ReplacePowerByMul() {
     auto constant_pattern = ngraph::pattern::wrap_type<opset::Constant>();
     auto power_pattern = ngraph::pattern::wrap_type<opset::Power>({

--- a/modules/arm_plugin/src/transformations/replace_power_by_mul.cpp
+++ b/modules/arm_plugin/src/transformations/replace_power_by_mul.cpp
@@ -8,7 +8,7 @@
 #include <ngraph/pattern/op/wrap_type.hpp>
 #include <ngraph/rt_info.hpp>
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::ReplacePowerByMul, "ReplacePowerByMul");
+OPENVINO_OP(ArmPlugin::pass::ReplacePowerByMul, "ReplacePowerByMul");
 ArmPlugin::pass::ReplacePowerByMul::ReplacePowerByMul() {
     auto constant_pattern = ngraph::pattern::wrap_type<opset::Constant>();
     auto power_pattern = ngraph::pattern::wrap_type<opset::Power>({

--- a/modules/arm_plugin/src/transformations/replace_power_by_mul.hpp
+++ b/modules/arm_plugin/src/transformations/replace_power_by_mul.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ReplacePowerByMul: public ngraph::pass::MatcherPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("ReplacePowerByMul");
     ReplacePowerByMul();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/replace_power_by_mul.hpp
+++ b/modules/arm_plugin/src/transformations/replace_power_by_mul.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class ReplacePowerByMul: public ngraph::pass::MatcherPass {
 public:
-    OPENVINO_OP("ReplacePowerByMul");
+    OPENVINO_RTTI("ReplacePowerByMul");
     ReplacePowerByMul();
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/store_result_name.cpp
+++ b/modules/arm_plugin/src/transformations/store_result_name.cpp
@@ -6,7 +6,7 @@
 #include "store_result_name.hpp"
 #include "transformations/utils/utils.hpp"
 
-OPENVINO_OP(ArmPlugin::pass::StoreResultName, "StoreResultName");
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::StoreResultName, "StoreResultName");
 bool ArmPlugin::pass::StoreResultName::run_on_model(const std::shared_ptr<ov::Model>& m) {
     for (auto&& node : m->get_results()) {
         IE_ASSERT(node->inputs().size() == 1);

--- a/modules/arm_plugin/src/transformations/store_result_name.cpp
+++ b/modules/arm_plugin/src/transformations/store_result_name.cpp
@@ -6,7 +6,7 @@
 #include "store_result_name.hpp"
 #include "transformations/utils/utils.hpp"
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::StoreResultName, "StoreResultName", 0);
+NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::StoreResultName, "StoreResultName");
 bool ArmPlugin::pass::StoreResultName::run_on_model(const std::shared_ptr<ov::Model>& m) {
     for (auto&& node : m->get_results()) {
         IE_ASSERT(node->inputs().size() == 1);

--- a/modules/arm_plugin/src/transformations/store_result_name.cpp
+++ b/modules/arm_plugin/src/transformations/store_result_name.cpp
@@ -6,7 +6,6 @@
 #include "store_result_name.hpp"
 #include "transformations/utils/utils.hpp"
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::StoreResultName, "StoreResultName");
 bool ArmPlugin::pass::StoreResultName::run_on_model(const std::shared_ptr<ov::Model>& m) {
     for (auto&& node : m->get_results()) {
         IE_ASSERT(node->inputs().size() == 1);

--- a/modules/arm_plugin/src/transformations/store_result_name.cpp
+++ b/modules/arm_plugin/src/transformations/store_result_name.cpp
@@ -6,7 +6,7 @@
 #include "store_result_name.hpp"
 #include "transformations/utils/utils.hpp"
 
-NGRAPH_RTTI_DEFINITION(ArmPlugin::pass::StoreResultName, "StoreResultName");
+OPENVINO_OP(ArmPlugin::pass::StoreResultName, "StoreResultName");
 bool ArmPlugin::pass::StoreResultName::run_on_model(const std::shared_ptr<ov::Model>& m) {
     for (auto&& node : m->get_results()) {
         IE_ASSERT(node->inputs().size() == 1);

--- a/modules/arm_plugin/src/transformations/store_result_name.hpp
+++ b/modules/arm_plugin/src/transformations/store_result_name.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class StoreResultName : public ov::pass::ModelPass {
 public:
-    OPENVINO_OP("StoreResultName");
+    OPENVINO_RTTI("StoreResultName");
     bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
 };
 }  // namespace pass

--- a/modules/arm_plugin/src/transformations/store_result_name.hpp
+++ b/modules/arm_plugin/src/transformations/store_result_name.hpp
@@ -10,7 +10,7 @@ namespace pass {
 
 class StoreResultName : public ov::pass::ModelPass {
 public:
-    NGRAPH_RTTI_DECLARATION;
+    OPENVINO_OP("StoreResultName");
     bool run_on_model(const std::shared_ptr<ov::Model>& m) override;
 };
 }  // namespace pass

--- a/modules/nvidia_plugin/tests/unit/nodes/result_stub_node.hpp
+++ b/modules/nvidia_plugin/tests/unit/nodes/result_stub_node.hpp
@@ -11,7 +11,7 @@
 struct ResultStubNode : ov::op::v0::Result {
     using ov::op::v0::Result::Result;
 
-    inline static constexpr type_info_t type_info{"Result"};
+    inline static constexpr type_info_t type_info{"Result", "opset0"};
     const type_info_t& get_type_info() const override { return type_info; }
 
     std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& inputs) const override {

--- a/modules/nvidia_plugin/tests/unit/nodes/result_stub_node.hpp
+++ b/modules/nvidia_plugin/tests/unit/nodes/result_stub_node.hpp
@@ -11,7 +11,7 @@
 struct ResultStubNode : ov::op::v0::Result {
     using ov::op::v0::Result::Result;
 
-    inline static constexpr type_info_t type_info{"Result", 0ul};
+    inline static constexpr type_info_t type_info{"Result"};
     const type_info_t& get_type_info() const override { return type_info; }
 
     std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& inputs) const override {

--- a/modules/nvidia_plugin/tests/unit/nodes/result_stub_node.hpp
+++ b/modules/nvidia_plugin/tests/unit/nodes/result_stub_node.hpp
@@ -11,7 +11,7 @@
 struct ResultStubNode : ov::op::v0::Result {
     using ov::op::v0::Result::Result;
 
-    inline static constexpr type_info_t type_info{"Result", "opset0"};
+    inline static constexpr type_info_t type_info{"Result"};
     const type_info_t& get_type_info() const override { return type_info; }
 
     std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& inputs) const override {

--- a/modules/nvidia_plugin/tests/unit/test_networks.hpp
+++ b/modules/nvidia_plugin/tests/unit/test_networks.hpp
@@ -27,7 +27,7 @@ inline std::shared_ptr<ngraph::Function> CreateMatMulTestNetwork() {
 
 class SuperDummyOp : public ov::op::Op {
 public:
-    inline static constexpr type_info_t type_info{"SuperOperation", "opset0"};
+    inline static constexpr type_info_t type_info{"SuperOperation"};
     const type_info_t& get_type_info() const override { return type_info; }
 
     std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override {

--- a/modules/nvidia_plugin/tests/unit/test_networks.hpp
+++ b/modules/nvidia_plugin/tests/unit/test_networks.hpp
@@ -27,7 +27,7 @@ inline std::shared_ptr<ngraph::Function> CreateMatMulTestNetwork() {
 
 class SuperDummyOp : public ov::op::Op {
 public:
-    inline static constexpr type_info_t type_info{"SuperOperation", 0ul};
+    inline static constexpr type_info_t type_info{"SuperOperation"};
     const type_info_t& get_type_info() const override { return type_info; }
 
     std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override {

--- a/modules/nvidia_plugin/tests/unit/test_networks.hpp
+++ b/modules/nvidia_plugin/tests/unit/test_networks.hpp
@@ -27,7 +27,7 @@ inline std::shared_ptr<ngraph::Function> CreateMatMulTestNetwork() {
 
 class SuperDummyOp : public ov::op::Op {
 public:
-    inline static constexpr type_info_t type_info{"SuperOperation"};
+    inline static constexpr type_info_t type_info{"SuperOperation", "opset0"};
     const type_info_t& get_type_info() const override { return type_info; }
 
     std::shared_ptr<ov::Node> clone_with_new_inputs(const ov::OutputVector& new_args) const override {


### PR DESCRIPTION
Fix error in NGRAPH_RTTI_DEFINITION, caused by deprecated `version`