### PR TITLE
[ARM] [CUDA] Interpolate - Cleanup of deprecated symbols usage

### DIFF
--- a/modules/arm_plugin/tests/functional/shared_tests_instances/single_layer_tests/interpolation.cpp
+++ b/modules/arm_plugin/tests/functional/shared_tests_instances/single_layer_tests/interpolation.cpp
@@ -21,38 +21,38 @@ const std::vector<std::vector<size_t>> inShapes = {
 };
 
 const  std::vector<ngraph::op::v4::Interpolate::InterpolateMode> modesWithoutNearest = {
-        ngraph::op::v4::Interpolate::InterpolateMode::linear,
-        ngraph::op::v4::Interpolate::InterpolateMode::linear_onnx,
-        ngraph::op::v4::Interpolate::InterpolateMode::cubic,
+        ngraph::op::v4::Interpolate::InterpolateMode::LINEAR,
+        ngraph::op::v4::Interpolate::InterpolateMode::LINEAR_ONNX,
+        ngraph::op::v4::Interpolate::InterpolateMode::CUBIC,
 };
 
 const  std::vector<ngraph::op::v4::Interpolate::InterpolateMode> nearestMode = {
-        ngraph::op::v4::Interpolate::InterpolateMode::nearest,
+        ngraph::op::v4::Interpolate::InterpolateMode::NEAREST,
 };
 
 const std::vector<ngraph::op::v4::Interpolate::CoordinateTransformMode> coordinateTransformModes = {
-        ngraph::op::v4::Interpolate::CoordinateTransformMode::tf_half_pixel_for_nn,
-        ngraph::op::v4::Interpolate::CoordinateTransformMode::pytorch_half_pixel,
-        ngraph::op::v4::Interpolate::CoordinateTransformMode::half_pixel,
-        ngraph::op::v4::Interpolate::CoordinateTransformMode::asymmetric,
-        ngraph::op::v4::Interpolate::CoordinateTransformMode::align_corners,
+        ngraph::op::v4::Interpolate::CoordinateTransformMode::TF_HALF_PIXEL_FOR_NN,
+        ngraph::op::v4::Interpolate::CoordinateTransformMode::PYTORCH_HALF_PIXEL,
+        ngraph::op::v4::Interpolate::CoordinateTransformMode::HALF_PIXEL,
+        ngraph::op::v4::Interpolate::CoordinateTransformMode::ASYMMETRIC,
+        ngraph::op::v4::Interpolate::CoordinateTransformMode::ALIGN_CORNERS,
 };
 
 const std::vector<ngraph::op::v4::Interpolate::ShapeCalcMode> shapeCalculationMode = {
-        ngraph::op::v4::Interpolate::ShapeCalcMode::sizes,
-        ngraph::op::v4::Interpolate::ShapeCalcMode::scales,
+        ngraph::op::v4::Interpolate::ShapeCalcMode::SIZES,
+        ngraph::op::v4::Interpolate::ShapeCalcMode::SCALES,
 };
 
 const std::vector<ngraph::op::v4::Interpolate::NearestMode> nearestModes = {
-        ngraph::op::v4::Interpolate::NearestMode::simple,
-        ngraph::op::v4::Interpolate::NearestMode::round_prefer_floor,
-        ngraph::op::v4::Interpolate::NearestMode::floor,
-        ngraph::op::v4::Interpolate::NearestMode::ceil,
-        ngraph::op::v4::Interpolate::NearestMode::round_prefer_ceil,
+        ngraph::op::v4::Interpolate::NearestMode::SIMPLE,
+        ngraph::op::v4::Interpolate::NearestMode::ROUND_PREFER_FLOOR,
+        ngraph::op::v4::Interpolate::NearestMode::FLOOR,
+        ngraph::op::v4::Interpolate::NearestMode::CEIL,
+        ngraph::op::v4::Interpolate::NearestMode::ROUND_PREFER_CEIL,
 };
 
 const std::vector<ngraph::op::v4::Interpolate::NearestMode> defaultNearestMode = {
-        ngraph::op::v4::Interpolate::NearestMode::round_prefer_floor,
+        ngraph::op::v4::Interpolate::NearestMode::ROUND_PREFER_FLOOR,
 };
 
 const std::vector<std::vector<size_t>> pads = {

--- a/modules/nvidia_plugin/src/ops/interpolate.cpp
+++ b/modules/nvidia_plugin/src/ops/interpolate.cpp
@@ -30,7 +30,7 @@ static OperationBase::Ptr interpolateFactory(const CreationContext& context,
     std::stringstream exception_msg;
 
     switch (node->get_attrs().mode) {
-        case InterpolateMode::nearest:
+        case InterpolateMode::NEAREST:
             try {
                 return std::make_shared<InterpolateNearestOp>(
                     context, *node, IndexCollection{inputIds}, IndexCollection{outputIds});
@@ -38,7 +38,7 @@ static OperationBase::Ptr interpolateFactory(const CreationContext& context,
                 exception_msg << "failed to create InterpolateNearestOp: " << e.what() << "\n";
             }
             break;
-        case InterpolateMode::linear:
+        case InterpolateMode::LINEAR:
             try {
                 return std::make_shared<InterpolateLinearOp>(
                     context, *node, IndexCollection{inputIds}, IndexCollection{outputIds});
@@ -46,7 +46,7 @@ static OperationBase::Ptr interpolateFactory(const CreationContext& context,
                 exception_msg << "failed to create InterpolateLinearOp: " << e.what() << "\n";
             }
             break;
-        case InterpolateMode::cubic:
+        case InterpolateMode::CUBIC:
             try {
                 return std::make_shared<InterpolateCubicOp>(
                     context, *node, IndexCollection{inputIds}, IndexCollection{outputIds});

--- a/modules/nvidia_plugin/src/ops/interpolate_components/interpolate_components.cpp
+++ b/modules/nvidia_plugin/src/ops/interpolate_components/interpolate_components.cpp
@@ -15,7 +15,7 @@ namespace ov::nvidia_gpu::Interpolate::Details {
 void getAxesAndScales(const ov::op::v4::Interpolate& node, std::vector<size_t>& axes, std::vector<float>& scales) {
     axes = ngraph::get_constant_from_source(node.input_value(3))->cast_vector<size_t>();
     switch (node.get_attrs().shape_calculation_mode) {
-        case ov::op::v4::Interpolate::ShapeCalcMode::sizes: {
+        case ov::op::v4::Interpolate::ShapeCalcMode::SIZES: {
             const auto& input_shape = node.get_input_shape(0);
             const auto& output_shape = node.get_output_shape(0);
             scales.resize(axes.size());
@@ -24,7 +24,7 @@ void getAxesAndScales(const ov::op::v4::Interpolate& node, std::vector<size_t>& 
                 scales[i] = static_cast<float>(output_shape[axe]) / static_cast<float>(input_shape[axe]);
             }
         } break;
-        case ov::op::v4::Interpolate::ShapeCalcMode::scales:
+        case ov::op::v4::Interpolate::ShapeCalcMode::SCALES:
             scales = ngraph::get_constant_from_source(node.input_value(2))->cast_vector<float>();
             OPENVINO_ASSERT(axes.size() == scales.size());
             break;

--- a/modules/nvidia_plugin/src/ops/interpolate_cubic.cpp
+++ b/modules/nvidia_plugin/src/ops/interpolate_cubic.cpp
@@ -39,7 +39,7 @@ InterpolateCubicOp::InterpolateCubicOp(const CreationContext& context,
                                        IndexCollection&& inputIds,
                                        IndexCollection&& outputIds)
     : OperationBase(context, node, std::move(inputIds), std::move(outputIds)) {
-    OPENVINO_ASSERT(node.get_attrs().mode == ov::op::v4::Interpolate::InterpolateMode::cubic, "Node name: ", GetName());
+    OPENVINO_ASSERT(node.get_attrs().mode == ov::op::v4::Interpolate::InterpolateMode::CUBIC, "Node name: ", GetName());
     checkLimitations(node);
 
     std::vector<size_t> axes;

--- a/modules/nvidia_plugin/src/ops/interpolate_linear.cpp
+++ b/modules/nvidia_plugin/src/ops/interpolate_linear.cpp
@@ -40,7 +40,7 @@ InterpolateLinearOp::InterpolateLinearOp(const CreationContext& context,
                                          IndexCollection&& outputIds)
     : OperationBase(context, node, std::move(inputIds), std::move(outputIds)) {
     OPENVINO_ASSERT(
-        node.get_attrs().mode == ov::op::v4::Interpolate::InterpolateMode::linear, "Node name: ", GetName());
+        node.get_attrs().mode == ov::op::v4::Interpolate::InterpolateMode::LINEAR, "Node name: ", GetName());
     checkLimitations(node);
 
     std::vector<size_t> axes;

--- a/modules/nvidia_plugin/src/ops/interpolate_nearest.cpp
+++ b/modules/nvidia_plugin/src/ops/interpolate_nearest.cpp
@@ -35,7 +35,7 @@ std::vector<float> getScalesVector(const ov::nvidia_gpu::InterpolateNearestOp::N
     for (size_t i = 0; i < axis.size(); ++i) {
         using ShapeCalcMode = ov::op::v4::Interpolate::ShapeCalcMode;
         const auto idx = axis[i];
-        if (node.get_attrs().shape_calculation_mode == ShapeCalcMode::scales) {
+        if (node.get_attrs().shape_calculation_mode == ShapeCalcMode::SCALES) {
             result_scales[idx] = scales[i];
         } else {
             float scale = output_shape[idx] == input_shape[idx]
@@ -50,8 +50,8 @@ std::vector<float> getScalesVector(const ov::nvidia_gpu::InterpolateNearestOp::N
 bool canApplyUpscaleOptimizing(const InterpolateNearestOp::NodeOp& node, const std::vector<float>& scales) {
     using CoordinateTransformMode = ov::op::v4::Interpolate::CoordinateTransformMode;
     switch (node.get_attrs().coordinate_transformation_mode) {
-        case CoordinateTransformMode::asymmetric:
-        case CoordinateTransformMode::tf_half_pixel_for_nn:
+        case CoordinateTransformMode::ASYMMETRIC:
+        case CoordinateTransformMode::TF_HALF_PIXEL_FOR_NN:
             break;
         default:
             return false;
@@ -59,8 +59,8 @@ bool canApplyUpscaleOptimizing(const InterpolateNearestOp::NodeOp& node, const s
 
     using NearestMode = ov::op::v4::Interpolate::NearestMode;
     switch (node.get_attrs().nearest_mode) {
-        case NearestMode::simple:
-        case NearestMode::floor:
+        case NearestMode::SIMPLE:
+        case NearestMode::FLOOR:
             break;
         default:
             return false;
@@ -118,7 +118,7 @@ InterpolateNearestOp::InterpolateNearestOp(const CreationContext& context,
       out_shape_{node.get_output_shape(0)},
       can_use_upscale_optimizing_{canApplyUpscaleOptimizing(node, scales_)} {
     OPENVINO_ASSERT(
-        node.get_attrs().mode == ov::op::v4::Interpolate::InterpolateMode::nearest, "Node name: ", GetName());
+        node.get_attrs().mode == ov::op::v4::Interpolate::InterpolateMode::NEAREST, "Node name: ", GetName());
     checkLimitations(node);
 
     const auto& prop = context.device().props();

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/interpolate.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/interpolate.cpp
@@ -57,23 +57,23 @@ const std::vector<std::vector<size_t>> yolov5From40To80Shape = {
     {1, 128, 80, 80},
 };
 
-const std::vector<CoordinateTransformMode> coordinateTransformModes = {CoordinateTransformMode::half_pixel,
-                                                                       CoordinateTransformMode::pytorch_half_pixel,
-                                                                       CoordinateTransformMode::asymmetric,
-                                                                       CoordinateTransformMode::tf_half_pixel_for_nn,
-                                                                       CoordinateTransformMode::align_corners};
+const std::vector<CoordinateTransformMode> coordinateTransformModes = {CoordinateTransformMode::HALF_PIXEL,
+                                                                       CoordinateTransformMode::PYTORCH_HALF_PIXEL,
+                                                                       CoordinateTransformMode::ASYMMETRIC,
+                                                                       CoordinateTransformMode::TF_HALF_PIXEL_FOR_NN,
+                                                                       CoordinateTransformMode::ALIGN_CORNERS};
 
 const std::vector<ShapeCalcMode> shapeCalculationMode = {
-    ShapeCalcMode::sizes,
-    ShapeCalcMode::scales,
+    ShapeCalcMode::SIZES,
+    ShapeCalcMode::SCALES,
 };
 
 const std::vector<NearestMode> nearestModes = {
-    NearestMode::round_prefer_floor,
-    NearestMode::round_prefer_ceil,
-    NearestMode::floor,
-    NearestMode::ceil,
-    NearestMode::simple,
+    NearestMode::ROUND_PREFER_FLOOR,
+    NearestMode::ROUND_PREFER_CEIL,
+    NearestMode::FLOOR,
+    NearestMode::CEIL,
+    NearestMode::SIMPLE,
 };
 
 const std::vector<std::vector<size_t>> pads = {
@@ -258,15 +258,15 @@ const std::vector<InferenceEngine::Precision> linearNetPrecisions = {
     InferenceEngine::Precision::FP16,
     InferenceEngine::Precision::FP32,
 };
-const std::vector<ShapeCalcMode> linearShapeCalculationMode = {ShapeCalcMode::sizes, ShapeCalcMode::scales};
+const std::vector<ShapeCalcMode> linearShapeCalculationMode = {ShapeCalcMode::SIZES, ShapeCalcMode::SCALES};
 const std::vector<CoordinateTransformMode> linearCoordinateTransformModes = {
-    CoordinateTransformMode::half_pixel,
-    CoordinateTransformMode::pytorch_half_pixel,
-    CoordinateTransformMode::asymmetric,
-    CoordinateTransformMode::tf_half_pixel_for_nn,
-    CoordinateTransformMode::align_corners,
+    CoordinateTransformMode::HALF_PIXEL,
+    CoordinateTransformMode::PYTORCH_HALF_PIXEL,
+    CoordinateTransformMode::ASYMMETRIC,
+    CoordinateTransformMode::TF_HALF_PIXEL_FOR_NN,
+    CoordinateTransformMode::ALIGN_CORNERS,
 };
-const std::vector<NearestMode> linearNearestModes = {NearestMode::simple};
+const std::vector<NearestMode> linearNearestModes = {NearestMode::SIMPLE};
 const std::vector<bool> linearAntialias = {true, false};
 
 const std::vector<std::vector<int64_t>> linearTest2DAxes = {{2, 3}};
@@ -330,16 +330,16 @@ const std::vector<InferenceEngine::Precision> cubicNetPrecisions = {
     InferenceEngine::Precision::FP32,
 };
 const std::vector<double> cubeCoeffs = {-0.75f, -0.6f};
-const std::vector<ShapeCalcMode> cubicShapeCalculationMode = {ShapeCalcMode::sizes, ShapeCalcMode::scales};
+const std::vector<ShapeCalcMode> cubicShapeCalculationMode = {ShapeCalcMode::SIZES, ShapeCalcMode::SCALES};
 const std::vector<CoordinateTransformMode> cubicCoordinateTransformModes = {
-    CoordinateTransformMode::half_pixel,
-    CoordinateTransformMode::pytorch_half_pixel,
-    CoordinateTransformMode::asymmetric,
-    CoordinateTransformMode::tf_half_pixel_for_nn,
-    CoordinateTransformMode::align_corners,
+    CoordinateTransformMode::HALF_PIXEL,
+    CoordinateTransformMode::PYTORCH_HALF_PIXEL,
+    CoordinateTransformMode::ASYMMETRIC,
+    CoordinateTransformMode::TF_HALF_PIXEL_FOR_NN,
+    CoordinateTransformMode::ALIGN_CORNERS,
 };
 const std::vector<NearestMode> cubicNearestModes = {
-    NearestMode::simple  // Cubic interpolation algo doesn't use it.
+    NearestMode::SIMPLE  // Cubic interpolation algo doesn't use it.
 };
 const std::vector<bool> cubicAntialias = {false};  // Cubic interpolation algo doesn't use it.
 
@@ -425,7 +425,7 @@ INSTANTIATE_TEST_CASE_P(CUDAInterpolate_Nearest_Benchmark,
                         nearestBenchmarkParams,
                         InterpolateLayerTest::getTestCaseName);
 
-const std::vector<InterpolateMode> benchmarkInterpolateModes = {InterpolateMode::linear, InterpolateMode::cubic};
+const std::vector<InterpolateMode> benchmarkInterpolateModes = {InterpolateMode::LINEAR, InterpolateMode::CUBIC};
 const std::vector<InferenceEngine::Precision> benchmarkPrecisions = {
     InferenceEngine::Precision::FP16,
     InferenceEngine::Precision::FP32,
@@ -433,9 +433,9 @@ const std::vector<InferenceEngine::Precision> benchmarkPrecisions = {
 const std::vector<std::vector<float>> benchmarkScales = {{0.5f, 0.5f, 0.5f}, {1.5f, 1.5f, 1.5f}};
 const auto benchmarkParams =
     ::testing::Combine(::testing::Combine(::testing::ValuesIn(benchmarkInterpolateModes),
-                                          ::testing::Values(ShapeCalcMode::scales),
-                                          ::testing::Values(CoordinateTransformMode::half_pixel),
-                                          ::testing::Values(NearestMode::simple),
+                                          ::testing::Values(ShapeCalcMode::SCALES),
+                                          ::testing::Values(CoordinateTransformMode::HALF_PIXEL),
+                                          ::testing::Values(NearestMode::SIMPLE),
                                           ::testing::Values(true),  // antialias
                                           ::testing::ValuesIn(pads),
                                           ::testing::ValuesIn(pads),


### PR DESCRIPTION
This PR is required to fix the build errors which started popping up after the changes introduced by this PR https://github.com/openvinotoolkit/openvino/pull/16162

The deprecated enum values are going to be removed and thus all usages need to be adjusted.