### PR TITLE
[NVIDIA] Skip LoadNetworkToDefaultDeviceNoThrow test

### DIFF
--- a/modules/nvidia_plugin/tests/functional/skip_tests_config.cpp
+++ b/modules/nvidia_plugin/tests/functional/skip_tests_config.cpp
@@ -119,6 +119,8 @@ std::vector<std::string> disabledTestPatterns() {
         R"(.*smoke_Auto_BehaviorTests*.*)",
         R"(.*smoke_Multi_BehaviorTests*.*)",
         R"(.*HETERO(W|w)ithMULTI*.*)",
+         // 106454, 106628
+        R"(.*.*LoadNetworkToDefaultDeviceNoThrow.*)",
     };
 
 #ifdef _WIN32


### PR DESCRIPTION
### Details:
 - *Skip LoadNetworkToDefaultDeviceNoThrow test to enable NVIDIA CI*
 
### Tickets:
 - *106454*
 - *106628*

Depends on https://github.com/openvinotoolkit/openvino/pull/16507
