### PR TITLE
[NVIDIA] CUDA Graph API C++ wrappers

### DIFF
--- a/modules/nvidia_plugin/src/cuda/event.hpp
+++ b/modules/nvidia_plugin/src/cuda/event.hpp
@@ -11,8 +11,8 @@ namespace CUDA {
 class Event : public Handle<cudaEvent_t> {
 public:
     Event() : Handle((static_cast<__host__ cudaError_t (*)(cudaEvent_t* event)>(cudaEventCreate)), cudaEventDestroy) {}
-    auto& record(const Stream& stream) {
-        throwIfError(cudaEventRecord(get(), stream.get()));
+    auto& record(const Stream& stream, unsigned int flags = cudaEventRecordDefault) {
+        throwIfError(cudaEventRecordWithFlags(get(), stream.get(), flags));
         return *this;
     }
     auto&& record(const cudaStream_t& stream) {

--- a/modules/nvidia_plugin/src/cuda/graph.cpp
+++ b/modules/nvidia_plugin/src/cuda/graph.cpp
@@ -1,0 +1,89 @@
+// Copyright (C) 2021-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "graph.hpp"
+#include <ie_common.h>
+#include <fmt/format.h>
+
+namespace CUDA {
+
+Graph::Graph(unsigned int flags) :
+        Graph { createNativeWithFlags(flags) } {
+}
+
+Graph::Graph(cudaGraph_t graph) :
+        Handle { createFromNative, cudaGraphDestroy, graph } {
+}
+
+cudaError_t Graph::createFromNative(cudaGraph_t *pGraph, const cudaGraph_t anotherGraph) {
+    *pGraph = anotherGraph;
+    return cudaSuccess;
+}
+
+cudaGraph_t Graph::createNativeWithFlags(unsigned int flags) {
+    cudaGraph_t g;
+    throwIfError(cudaGraphCreate(&g, flags));
+    return g;
+}
+
+// clang-format off
+GraphExec::GraphExec(const Graph &g)
+#if !defined(NDEBUG) || defined(_DEBUG)
+try
+#endif
+:
+Handle(cudaGraphInstantiate, cudaGraphExecDestroy, g.get(), static_cast<cudaGraphNode_t*>(nullptr),
+#if !defined(NDEBUG) || defined(_DEBUG)
+       errorMsg_, kErrorStringLen)
+#else
+       static_cast<char*>(nullptr), static_cast<size_t>(0ul))
+#endif
+{
+}
+#if !defined(NDEBUG) || defined(_DEBUG)
+catch (std::exception &e) {
+    throw InferenceEngine::GeneralError { fmt::format("{}: {}", e.what(), errorMsg_) };
+}
+#endif
+// clang-format on
+
+cudaGraphExecUpdateResult GraphExec::update(const Graph &g) {
+    cudaGraphExecUpdateResult res;
+    throwIfError(cudaGraphExecUpdate(get(), g.get(), nullptr, &res));
+    return res;
+}
+
+void GraphExec::launch(const Stream &stream) {
+    throwIfError(cudaGraphLaunch(get(), stream.get()));
+}
+
+GraphCapture::GraphCaptureScope::GraphCaptureScope(GraphCapture &graphCapture) :
+        graphCapture_ { graphCapture } {
+    throwIfError(cudaStreamBeginCapture(graphCapture_.stream_.get(), cudaStreamCaptureModeGlobal));
+}
+
+GraphCapture::GraphCaptureScope::~GraphCaptureScope() {
+    graphCapture_.capturedError_ = cudaStreamEndCapture(graphCapture_.stream_.get(), &graphCapture_.cudaGraph_);
+}
+
+GraphCapture::GraphCapture(const Stream &capturedStream) :
+        stream_ { capturedStream } {
+}
+
+GraphCapture::GraphCaptureScope GraphCapture::getScope() {
+    graph_.reset();
+    cudaGraph_ = nullptr;
+    capturedError_ = cudaSuccess;
+    return GraphCapture::GraphCaptureScope { *this };
+}
+
+const Graph& GraphCapture::getGraph() {
+    throwIfError(capturedError_);
+    if (!graph_ && cudaGraph_ != nullptr) {
+        graph_ = std::make_optional<Graph>( Graph{ cudaGraph_ });
+    }
+    return graph_.value();
+}
+
+} // namespace CUDA

--- a/modules/nvidia_plugin/src/cuda/graph.hpp
+++ b/modules/nvidia_plugin/src/cuda/graph.hpp
@@ -1,0 +1,74 @@
+// Copyright (C) 2021-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "runtime.hpp"
+#include <optional>
+
+namespace CUDA {
+
+class GraphCapture;
+
+class Graph: public Handle<cudaGraph_t> {
+public:
+    Graph(unsigned int flags);
+
+    friend GraphCapture;
+
+private:
+    Graph(cudaGraph_t graph);
+
+    static cudaError_t createFromNative(cudaGraph_t *pGraph, cudaGraph_t anotherGraph);
+
+    static cudaGraph_t createNativeWithFlags(unsigned int flags);
+};
+
+
+class GraphExec: public Handle<cudaGraphExec_t> {
+public:
+    GraphExec(const Graph& g);
+
+    cudaGraphExecUpdateResult update(const Graph& g);
+
+    void launch(const Stream& stream);
+
+#if !defined(NDEBUG) || defined(_DEBUG)
+private:
+    static constexpr std::size_t kErrorStringLen = 1024;
+    char errorMsg_[kErrorStringLen];
+#endif
+};
+
+
+class GraphCapture {
+public:
+    class GraphCaptureScope {
+    public:
+        GraphCaptureScope(GraphCapture& graphCapture);
+
+        GraphCaptureScope(const GraphCaptureScope&) = delete;
+
+        GraphCaptureScope& operator=(const GraphCaptureScope&) = delete;
+
+        ~GraphCaptureScope();
+
+    private:
+        GraphCapture& graphCapture_;
+    };
+
+    GraphCapture(const Stream& capturedStream);
+
+    [[nodiscard]] GraphCaptureScope getScope();
+
+    [[nodiscard]] const Graph& getGraph();
+
+private:
+    Stream stream_;
+    cudaGraph_t cudaGraph_ {};
+    cudaError_t capturedError_ {cudaSuccess};
+    std::optional<Graph> graph_ {};
+};
+
+}// namespace CUDA

--- a/modules/nvidia_plugin/tests/unit/cuda/wrappers/graph.cpp
+++ b/modules/nvidia_plugin/tests/unit/cuda/wrappers/graph.cpp
@@ -1,0 +1,151 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include "graph.cuh"
+#include <cuda/graph.hpp>
+#include <cuda/event.hpp>
+#include <ie_common.h>
+#include <array>
+#include <gsl/gsl_util>
+
+using namespace testing;
+
+namespace {
+
+class CudaGraphCaptureCppWrappersTest : public Test {
+protected:
+    std::array<int, 8> a{0, 1, 2,  3,  4,  5,  6,  7};
+    std::array<int, 8> b{8, 9, 10, 11, 12, 13, 14, 15};
+    std::array<int, 8> result{};
+    std::size_t buffer_size{sizeof(decltype(a)::value_type) * a.size()};
+    CUDA::Stream stream{};
+    CUDA::Allocation devA = stream.malloc(buffer_size);
+    CUDA::Allocation devB = stream.malloc(buffer_size);
+    CUDA::Allocation devResult = stream.malloc(buffer_size);
+};
+
+TEST_F(CudaGraphCaptureCppWrappersTest, Capture) {
+    CUDA::GraphCapture capture{stream};
+    {
+        auto scope = capture.getScope();
+        stream.upload(devA, a.data(), buffer_size);
+        stream.upload(devB, b.data(), buffer_size);
+        enqueueVecAdd(stream, dim3{}, dim3{gsl::narrow<unsigned>(a.size())}, static_cast<int*>(devA.get()),
+                      static_cast<int*>(devB.get()),
+                      static_cast<int*>(devResult.get()), a.size());
+        stream.download(result.data(), devResult, buffer_size);
+    }
+    CUDA::GraphExec exec{capture.getGraph()};
+    stream.synchronize();
+    ASSERT_THAT(result, ElementsAre(0, 0, 0, 0, 0, 0, 0, 0));
+    exec.launch(stream);
+    stream.synchronize();
+    ASSERT_THAT(result, ElementsAre(8, 10, 12, 14, 16, 18, 20, 22));
+}
+
+TEST_F(CudaGraphCaptureCppWrappersTest, UpdateGraph) {
+    CUDA::GraphCapture capture{stream};
+    CUDA::Allocation dummyAllocation = stream.malloc(buffer_size);
+    {
+        auto scope = capture.getScope();
+        stream.upload(dummyAllocation, reinterpret_cast<void*>(0xffffl), buffer_size);
+        stream.upload(dummyAllocation, reinterpret_cast<void*>(0xffffl), buffer_size);
+        enqueueVecAdd(stream,
+                      dim3{},
+                      dim3{gsl::narrow<unsigned>(a.size())},
+                      static_cast<int*>(dummyAllocation.get()),
+                      static_cast<int*>(dummyAllocation.get()),
+                      static_cast<int*>(dummyAllocation.get()), 0);
+        stream.download(reinterpret_cast<void*>(0xffffl), dummyAllocation, buffer_size);
+    }
+    CUDA::GraphExec exec{capture.getGraph()};
+    CUDA::GraphCapture captureUpdate{stream};
+    {
+        auto scope = captureUpdate.getScope();
+        stream.upload(devA, a.data(), buffer_size);
+        stream.upload(devB, b.data(), buffer_size);
+        enqueueVecAdd(stream,
+                      dim3{},
+                      dim3{gsl::narrow<unsigned>(a.size())},
+                      static_cast<int*>(devA.get()),
+                      static_cast<int*>(devB.get()),
+                      static_cast<int*>(devResult.get()), a.size());
+        stream.download(result.data(), devResult, buffer_size);
+    }
+    exec.update(captureUpdate.getGraph());
+    exec.launch(stream);
+    stream.synchronize();
+    ASSERT_THAT(result, ElementsAre(8, 10, 12, 14, 16, 18, 20, 22));
+}
+
+TEST_F(CudaGraphCaptureCppWrappersTest, EventCapture) {
+    CUDA::Event event0{};
+    CUDA::Event event1{};
+    CUDA::GraphCapture capture{stream};
+    {
+        auto scope = capture.getScope();
+        event0.record(stream, cudaEventRecordExternal);
+        stream.upload(devA, a.data(), buffer_size);
+        stream.upload(devB, b.data(), buffer_size);
+        enqueueVecAdd(stream,
+                      dim3{},
+                      dim3{gsl::narrow<unsigned>(a.size())},
+                      static_cast<int*>(devA.get()),
+                      static_cast<int*>(devB.get()),
+                      static_cast<int*>(devResult.get()), a.size());
+        stream.download(result.data(), devResult, buffer_size);
+        event1.record(stream, cudaEventRecordExternal);
+    }
+    CUDA::GraphExec exec{capture.getGraph()};
+    exec.launch(stream);
+    stream.synchronize();
+    EXPECT_GT(event1.elapsedSince(event0), 0);
+}
+
+TEST_F(CudaGraphCaptureCppWrappersTest, EventUpdate) {
+    CUDA::Event event0{};
+    CUDA::Event event1{};
+    CUDA::GraphCapture capture0{stream};
+    {
+        auto scope = capture0.getScope();
+        event0.record(stream, cudaEventRecordExternal);
+        stream.upload(devA, a.data(), buffer_size);
+        stream.upload(devB, b.data(), buffer_size);
+        enqueueVecAdd(stream,
+                      dim3{},
+                      dim3{gsl::narrow<unsigned>(a.size())},
+                      static_cast<int*>(devA.get()),
+                      static_cast<int*>(devB.get()),
+                      static_cast<int*>(devResult.get()), a.size());
+        stream.download(result.data(), devResult, buffer_size);
+        event1.record(stream, cudaEventRecordExternal);
+    }
+    CUDA::GraphExec exec{capture0.getGraph()};
+    CUDA::Event event2{};
+    CUDA::Event event3{};
+    CUDA::GraphCapture capture1{stream};
+    {
+        auto scope = capture1.getScope();
+        event2.record(stream, cudaEventRecordExternal);
+        stream.upload(devA, a.data(), buffer_size);
+        stream.upload(devB, b.data(), buffer_size);
+        enqueueVecAdd(stream,
+                      dim3{},
+                      dim3{gsl::narrow<unsigned>(a.size())},
+                      static_cast<int*>(devA.get()),
+                      static_cast<int*>(devB.get()),
+                      static_cast<int*>(devResult.get()), a.size());
+        stream.download(result.data(), devResult, buffer_size);
+        event3.record(stream, cudaEventRecordExternal);
+    }
+    exec.update(capture1.getGraph());
+    exec.launch(stream);
+    stream.synchronize();
+    EXPECT_GT(event3.elapsedSince(event2), 0);
+    EXPECT_THROW(event1.elapsedSince(event0), InferenceEngine::GeneralError);
+}
+
+} // annonymous namespace

--- a/modules/nvidia_plugin/tests/unit/cuda/wrappers/graph.cu
+++ b/modules/nvidia_plugin/tests/unit/cuda/wrappers/graph.cu
@@ -1,0 +1,17 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "graph.cuh"
+
+__global__ void VecAdd(int* A, int* B, int* C, int N)
+{
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+    if (i < N)
+        C[i] = A[i] + B[i];
+}
+
+void enqueueVecAdd(const CUDA::Stream s, dim3 gridDim, dim3 blockDim,
+                   int* devA, int* devB, int* devC, int N) {
+    s.run(gridDim, blockDim, VecAdd, devA, devB, devC, N);
+}

--- a/modules/nvidia_plugin/tests/unit/cuda/wrappers/graph.cuh
+++ b/modules/nvidia_plugin/tests/unit/cuda/wrappers/graph.cuh
@@ -1,0 +1,10 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cuda/runtime.hpp>
+
+void enqueueVecAdd(const CUDA::Stream s, dim3 gridDim, dim3 blockDim,
+                   int* devA, int* devB, int* devC, int N);


### PR DESCRIPTION
### Details:
 - *cudaGraph_t C++ wrapper*
 - *cudaGraphExec_t C++ wrapper*
 - *GraphCapture C++ wrapper*
 - *GraphCaptureScope C++ wrapper*
 - *New CUDA::Event constructor which allows events creation with flags*
 - *Tests which cover CUDA Graph API C++ wrappers functionality*

### Tickets:
 - *[CVS-108536](https://jira.devtools.intel.com/browse/CVS-108536)*
