### PR TITLE
[NVIDIA] Add IsCudaGraphCompatible() to all operations

### DIFF
--- a/modules/nvidia_plugin/src/cuda_operation_base.hpp
+++ b/modules/nvidia_plugin/src/cuda_operation_base.hpp
@@ -42,6 +42,7 @@ public:
                          Inputs inputTensors,
                          Outputs outputTensors,
                          const Workbuffers& workbuffers) const = 0;
+    virtual bool IsCudaGraphCompatible() const = 0;
     virtual void InitSharedImmutableWorkbuffers(const Buffers&) = 0;
     virtual WorkbufferRequest GetWorkBufferRequest() const = 0;
     virtual const WorkbufferIds& GetWorkbufferIds() const = 0;
@@ -75,6 +76,8 @@ public:
                   const ov::Node& node,
                   IndexCollection&& inputIds,
                   IndexCollection&& outputIds);
+
+    bool IsCudaGraphCompatible() const override { return false; }
 
     WorkbufferRequest GetWorkBufferRequest() const override {
         return {};  // Most operators do not need workbuffers

--- a/modules/nvidia_plugin/src/ops/activation_forward_cudnn_base.cpp
+++ b/modules/nvidia_plugin/src/ops/activation_forward_cudnn_base.cpp
@@ -59,5 +59,7 @@ void ActivationForwardCuDnnOpBase::Execute(const InferenceRequestContext& contex
                                                              outputTensors[0].get());
 }
 
+bool ActivationForwardCuDnnOpBase::IsCudaGraphCompatible() const { return true; }
+
 }  // namespace nvidia_gpu
 }  // namespace ov

--- a/modules/nvidia_plugin/src/ops/activation_forward_cudnn_base.hpp
+++ b/modules/nvidia_plugin/src/ops/activation_forward_cudnn_base.hpp
@@ -25,10 +25,13 @@ public:
                                  const ov::Node& node,
                                  IndexCollection&& inputIds,
                                  IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers&) const override;
+
+    bool IsCudaGraphCompatible() const override;
 
 protected:
     std::unique_ptr<CUDA::DnnActivationDescriptor> op_desc_;

--- a/modules/nvidia_plugin/src/ops/avgpool.cpp
+++ b/modules/nvidia_plugin/src/ops/avgpool.cpp
@@ -30,6 +30,8 @@ void AvgPoolOp::Execute(const InferenceRequestContext& context,
                   outputs[PoolingImpl::output_index].get());
 }
 
+bool AvgPoolOp::IsCudaGraphCompatible() const { return true; }
+
 OPERATION_REGISTER(AvgPoolOp, AvgPool);
 
 }  // namespace nvidia_gpu

--- a/modules/nvidia_plugin/src/ops/avgpool.hpp
+++ b/modules/nvidia_plugin/src/ops/avgpool.hpp
@@ -17,10 +17,13 @@ public:
                        const std::shared_ptr<ov::Node>& node,
                        IndexCollection&& inputIds,
                        IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
+
+    bool IsCudaGraphCompatible() const override;
 
 private:
     PoolingImpl impl_;

--- a/modules/nvidia_plugin/src/ops/broadcast.cpp
+++ b/modules/nvidia_plugin/src/ops/broadcast.cpp
@@ -65,6 +65,8 @@ void BroadcastOp::Execute(const InferenceRequestContext& context,
     (*kernel_)(stream, inputs[0].get(), broadcast_params_->mapper(workbuffers.immutable_buffers), outputs[0].get());
 }
 
+bool BroadcastOp::IsCudaGraphCompatible() const { return true; }
+
 WorkbufferRequest BroadcastOp::GetWorkBufferRequest() const { return {immutable_buffer_sizes_, {}}; }
 
 void BroadcastOp::InitSharedImmutableWorkbuffers(const Buffers& buffers) {

--- a/modules/nvidia_plugin/src/ops/broadcast.hpp
+++ b/modules/nvidia_plugin/src/ops/broadcast.hpp
@@ -27,6 +27,8 @@ public:
     WorkbufferRequest GetWorkBufferRequest() const override;
     void InitSharedImmutableWorkbuffers(const Buffers& buffers) override;
 
+    bool IsCudaGraphCompatible() const override;
+
 private:
     std::vector<WorkbufferRequest::size_in_bytes_t> immutable_buffer_sizes_;
     std::unique_ptr<NumpyBroadcastParams> broadcast_params_;

--- a/modules/nvidia_plugin/src/ops/clamp_cuda.cpp
+++ b/modules/nvidia_plugin/src/ops/clamp_cuda.cpp
@@ -51,5 +51,7 @@ void ClampCudaOp::Execute(const InferenceRequestContext& context,
     (*kernel_)(context.getThreadContext().stream().get(), inputTensors[0].get(), outputTensors[0].get());
 }
 
+bool ClampCudaOp::IsCudaGraphCompatible() const { return true; }
+
 }  // namespace nvidia_gpu
 }  // namespace ov

--- a/modules/nvidia_plugin/src/ops/clamp_cuda.hpp
+++ b/modules/nvidia_plugin/src/ops/clamp_cuda.hpp
@@ -26,6 +26,8 @@ public:
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
 
+    bool IsCudaGraphCompatible() const override;
+
 private:
     std::optional<kernel::Clamp> kernel_;
 };

--- a/modules/nvidia_plugin/src/ops/clamp_cudnn.cpp
+++ b/modules/nvidia_plugin/src/ops/clamp_cudnn.cpp
@@ -97,6 +97,8 @@ void ClampCuDnnOp::Execute(const InferenceRequestContext& context,
                                                     outputTensors[0].get());
 }
 
+bool ClampCuDnnOp::IsCudaGraphCompatible() const { return true; }
+
 void ClampCuDnnOp::InitSharedImmutableWorkbuffers(const Buffers& buffers) {
     switch (data_type_) {
         case CUDNN_DATA_FLOAT:

--- a/modules/nvidia_plugin/src/ops/clamp_cudnn.hpp
+++ b/modules/nvidia_plugin/src/ops/clamp_cudnn.hpp
@@ -33,6 +33,7 @@ public:
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
 
+    bool IsCudaGraphCompatible() const override;
     void InitSharedImmutableWorkbuffers(const Buffers& buffers) override;
     WorkbufferRequest GetWorkBufferRequest() const override;
 

--- a/modules/nvidia_plugin/src/ops/comparison.cpp
+++ b/modules/nvidia_plugin/src/ops/comparison.cpp
@@ -84,6 +84,8 @@ Comparison::Comparison(const CreationContext& context,
                                  threads_per_block};
 }
 
+bool Comparison::IsCudaGraphCompatible() const { return true; }
+
 void Comparison::Execute(const InferenceRequestContext& context,
                          Inputs inputs,
                          Outputs outputs,

--- a/modules/nvidia_plugin/src/ops/comparison.hpp
+++ b/modules/nvidia_plugin/src/ops/comparison.hpp
@@ -18,6 +18,8 @@ public:
                IndexCollection&& outputIds,
                kernel::Comparison::Op_t operation_type);
 
+    bool IsCudaGraphCompatible() const override;
+
 private:
     void calculateOffsets();
     void Execute(const InferenceRequestContext& context,

--- a/modules/nvidia_plugin/src/ops/concat.cpp
+++ b/modules/nvidia_plugin/src/ops/concat.cpp
@@ -95,6 +95,8 @@ void ConcatOp::Execute(const InferenceRequestContext& context,
                       outputs[0].get());
 }
 
+bool ConcatOp::IsCudaGraphCompatible() const { return false; }
+
 OPERATION_REGISTER(ConcatOp, Concat);
 }  // namespace nvidia_gpu
 }  // namespace ov

--- a/modules/nvidia_plugin/src/ops/concat.hpp
+++ b/modules/nvidia_plugin/src/ops/concat.hpp
@@ -28,6 +28,8 @@ public:
     WorkbufferRequest GetWorkBufferRequest() const override;
     void InitSharedImmutableWorkbuffers(const Buffers&) override;
 
+    bool IsCudaGraphCompatible() const override;
+
 private:
     size_t immutableWbSize() const { return concat_kernel_.value().immutableWbSize(); }
     size_t mutableWbSize() const { return concat_kernel_.value().mutableWbSize(); }

--- a/modules/nvidia_plugin/src/ops/convert.cpp
+++ b/modules/nvidia_plugin/src/ops/convert.cpp
@@ -55,6 +55,8 @@ void ConvertOp::Execute(const InferenceRequestContext& context,
     (*convert_kernel_)(stream.get(), outputs[0].get(), inputs[0].get());
 }
 
+bool ConvertOp::IsCudaGraphCompatible() const { return true; }
+
 OPERATION_REGISTER(ConvertOp, Convert);
 
 }  // namespace nvidia_gpu

--- a/modules/nvidia_plugin/src/ops/convert.hpp
+++ b/modules/nvidia_plugin/src/ops/convert.hpp
@@ -18,10 +18,14 @@ public:
               const std::shared_ptr<ov::Node>& node,
               IndexCollection&& inputIds,
               IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
+
+    bool IsCudaGraphCompatible() const override;
+
     using Type_t = ov::element::Type_t;
     using convert_t = void (*)(
         const CUDA::Stream&, size_t, CUDA::DevicePointer<void*>, CUDA::DevicePointer<const void*>, unsigned, unsigned);

--- a/modules/nvidia_plugin/src/ops/convert_color_i420.hpp
+++ b/modules/nvidia_plugin/src/ops/convert_color_i420.hpp
@@ -91,6 +91,8 @@ public:
         }
     }
 
+    bool IsCudaGraphCompatible() const override { return true; }
+
 private:
     std::optional<TKernel> kernel_;
 };

--- a/modules/nvidia_plugin/src/ops/convert_color_nv12.hpp
+++ b/modules/nvidia_plugin/src/ops/convert_color_nv12.hpp
@@ -90,6 +90,8 @@ public:
         }
     }
 
+    bool IsCudaGraphCompatible() const override { return true; }
+
 private:
     std::optional<TKernel> kernel_;
 };

--- a/modules/nvidia_plugin/src/ops/convolution_backprop_data.cpp
+++ b/modules/nvidia_plugin/src/ops/convolution_backprop_data.cpp
@@ -42,6 +42,11 @@ void ConvBackpropDataOp<T>::Execute(const InferenceRequestContext& context,
                                                 outputs[ConvBackpropDataOp::ArgIndices::dinput].get()));
 }
 
+template <typename T>
+bool ConvBackpropDataOp<T>::IsCudaGraphCompatible() const {
+    return true;
+}
+
 OPERATION_REGISTER(ConvolutionBackpropDataOp, ConvolutionBackpropData);
 OPERATION_REGISTER(GroupConvolutionBackpropDataOp, GroupConvolutionBackpropData);
 

--- a/modules/nvidia_plugin/src/ops/convolution_backprop_data.hpp
+++ b/modules/nvidia_plugin/src/ops/convolution_backprop_data.hpp
@@ -32,6 +32,8 @@ public:
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
 
+    bool IsCudaGraphCompatible() const override;
+
     void InitSharedImmutableWorkbuffers(const IOperationExec::Buffers&) override;
     WorkbufferRequest GetWorkBufferRequest() const override;
 

--- a/modules/nvidia_plugin/src/ops/convolution_cudnn.cpp
+++ b/modules/nvidia_plugin/src/ops/convolution_cudnn.cpp
@@ -44,6 +44,8 @@ void ConvolutionCuDnn::Execute(const InferenceRequestContext& context,
     throwIfError(status);
 }
 
+bool ConvolutionCuDnn::IsCudaGraphCompatible() const { return true; }
+
 WorkbufferRequest ConvolutionCuDnn::GetWorkBufferRequest() const {
     if (descs_.Algo().memory != 0)
         return {{}, {descs_.Algo().memory}};

--- a/modules/nvidia_plugin/src/ops/convolution_cudnn.hpp
+++ b/modules/nvidia_plugin/src/ops/convolution_cudnn.hpp
@@ -26,7 +26,10 @@ public:
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers&) const override;
+
     WorkbufferRequest GetWorkBufferRequest() const override;
+
+    bool IsCudaGraphCompatible() const override;
 
 private:
     Convolution::Details::ConvolutionDescriptorsCuDnn descs_;

--- a/modules/nvidia_plugin/src/ops/convolution_cudnn_be.cpp
+++ b/modules/nvidia_plugin/src/ops/convolution_cudnn_be.cpp
@@ -148,6 +148,8 @@ void ConvolutionCuDnnBE::Execute(const InferenceRequestContext& context,
     throwIfError(::cudnnBackendExecute(context.getThreadContext().dnnHandle().get(), plan->get(), variantPack->get()));
 }
 
+bool ConvolutionCuDnnBE::IsCudaGraphCompatible() const { return false; }
+
 std::shared_ptr<CUDA::DnnBETensorDescriptor> ConvolutionCuDnnBE::MakeTensorDescriptor(int64_t id,
                                                                                       cudnnDataType_t element_type,
                                                                                       const ov::Shape& shape) {

--- a/modules/nvidia_plugin/src/ops/convolution_cudnn_be.hpp
+++ b/modules/nvidia_plugin/src/ops/convolution_cudnn_be.hpp
@@ -32,6 +32,9 @@ public:
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
+
+    bool IsCudaGraphCompatible() const override;
+
     WorkbufferRequest GetWorkBufferRequest() const override;
 
 private:

--- a/modules/nvidia_plugin/src/ops/cudnn_tensor_op_base.cpp
+++ b/modules/nvidia_plugin/src/ops/cudnn_tensor_op_base.cpp
@@ -166,6 +166,8 @@ void CuDnnTensorOpBase::Execute(const InferenceRequestContext& context,
                                                     outputTensors[0].get());
 }
 
+bool CuDnnTensorOpBase::IsCudaGraphCompatible() const { return true; }
+
 CuDnnTensorOpBase::IoParams::IoParams(const ov::Node& node, const Type& io_type, int index)
     : type_(convertDataType<cudnnDataType_t>(io_type == Type::INPUT ? node.get_input_element_type(index)
                                                                     : node.get_output_element_type(index))),

--- a/modules/nvidia_plugin/src/ops/cudnn_tensor_op_base.hpp
+++ b/modules/nvidia_plugin/src/ops/cudnn_tensor_op_base.hpp
@@ -24,6 +24,8 @@ public:
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
 
+    bool IsCudaGraphCompatible() const override;
+
 private:
     struct IoParams {
         const cudnnDataType_t type_;

--- a/modules/nvidia_plugin/src/ops/detection_output.cpp
+++ b/modules/nvidia_plugin/src/ops/detection_output.cpp
@@ -102,6 +102,8 @@ void DetectionOutputOp::Execute(const InferenceRequestContext& context,
     }
 }
 
+bool DetectionOutputOp::IsCudaGraphCompatible() const { return true; }
+
 void DetectionOutputOp::InitSharedImmutableWorkbuffers(const Buffers& buffers) {
     kernel_.value().initSharedImmutableWorkbuffers(buffers);
 }

--- a/modules/nvidia_plugin/src/ops/detection_output.hpp
+++ b/modules/nvidia_plugin/src/ops/detection_output.hpp
@@ -19,10 +19,13 @@ public:
                       const NodeOp& node,
                       IndexCollection&& inputIds,
                       IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
+
+    bool IsCudaGraphCompatible() const override;
 
     void InitSharedImmutableWorkbuffers(const Buffers& buffers) override;
     WorkbufferRequest GetWorkBufferRequest() const override;

--- a/modules/nvidia_plugin/src/ops/elementwise_binary.hpp
+++ b/modules/nvidia_plugin/src/ops/elementwise_binary.hpp
@@ -59,6 +59,8 @@ public:
                    static_cast<void*>(outputTensors[0].get()));
     }
 
+    bool IsCudaGraphCompatible() const override { return true; }
+
     void InitSharedImmutableWorkbuffers(const IOperationExec::Buffers& buffers) override {
         in0_broadcast_params_->initWorkbuffers(buffers);
         in1_broadcast_params_->initWorkbuffers(buffers);

--- a/modules/nvidia_plugin/src/ops/fake_quantize.cpp
+++ b/modules/nvidia_plugin/src/ops/fake_quantize.cpp
@@ -45,6 +45,8 @@ FakeQuantizeOp::FakeQuantizeOp(const CreationContext &context,
         convertDataType<ov::nvidia_gpu::kernel::Type_t>(element_type), output_size, max_threads_per_block, levels};
 }
 
+bool FakeQuantizeOp::IsCudaGraphCompatible() const { return true; }
+
 void FakeQuantizeOp::Execute(const InferenceRequestContext &context,
                              Inputs inputTensors,
                              Outputs outputTensors,

--- a/modules/nvidia_plugin/src/ops/fake_quantize.hpp
+++ b/modules/nvidia_plugin/src/ops/fake_quantize.hpp
@@ -20,6 +20,8 @@ public:
                    IndexCollection&& inputIds,
                    IndexCollection&& outputIds);
 
+    bool IsCudaGraphCompatible() const override;
+
 private:
     void Execute(const InferenceRequestContext& context,
                  Inputs inputTensors,

--- a/modules/nvidia_plugin/src/ops/floor.cpp
+++ b/modules/nvidia_plugin/src/ops/floor.cpp
@@ -42,6 +42,8 @@ void FloorOp::Execute(const InferenceRequestContext& context,
     (*kernel_)(stream.get(), inputTensors[0].get(), outputTensors[0].get());
 }
 
+bool FloorOp::IsCudaGraphCompatible() const { return true; }
+
 OPERATION_REGISTER(FloorOp, Floor);
 
 }  // namespace nvidia_gpu

--- a/modules/nvidia_plugin/src/ops/floor.hpp
+++ b/modules/nvidia_plugin/src/ops/floor.hpp
@@ -23,6 +23,8 @@ public:
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
 
+    bool IsCudaGraphCompatible() const override;
+
 private:
     std::optional<kernel::Floor> kernel_;
 };

--- a/modules/nvidia_plugin/src/ops/fully_connected.cpp
+++ b/modules/nvidia_plugin/src/ops/fully_connected.cpp
@@ -54,6 +54,8 @@ void FullyConnectedOp::Execute(const InferenceRequestContext& context,
     matmul_op_.Execute(context, inputs.first(inputs.size() - 1), outputs, workbuffers);
 }
 
+bool FullyConnectedOp::IsCudaGraphCompatible() const { return true; }
+
 OPERATION_REGISTER(FullyConnectedOp, FullyConnected);
 }  // namespace nvidia_gpu
 }  // namespace ov

--- a/modules/nvidia_plugin/src/ops/fully_connected.hpp
+++ b/modules/nvidia_plugin/src/ops/fully_connected.hpp
@@ -26,6 +26,8 @@ public:
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
 
+    bool IsCudaGraphCompatible() const override;
+
 private:
     MatMulOp matmul_op_;
     size_t bias_size_ = 0;

--- a/modules/nvidia_plugin/src/ops/fused_convolution_backprop_data.cpp
+++ b/modules/nvidia_plugin/src/ops/fused_convolution_backprop_data.cpp
@@ -77,6 +77,8 @@ void FusedConvolutionBackpropDataOp::Execute(const InferenceRequestContext& cont
                                                 outputs[ArgIndices3Ins::dinput].get()));
 }
 
+bool FusedConvolutionBackpropDataOp::IsCudaGraphCompatible() const { return true; }
+
 void FusedConvolutionBackpropDataOp::InitSharedImmutableWorkbuffers(const IOperationExec::Buffers& buffers) {
     OPENVINO_ASSERT(buffers.size() == 1, "Node name: ", GetName());
     const size_t repeat = conv_in_bytes_ / add_in_bytes_;

--- a/modules/nvidia_plugin/src/ops/fused_convolution_backprop_data.hpp
+++ b/modules/nvidia_plugin/src/ops/fused_convolution_backprop_data.hpp
@@ -25,6 +25,8 @@ public:
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers&) const override;
+
+    bool IsCudaGraphCompatible() const override;
     void InitSharedImmutableWorkbuffers(const IOperationExec::Buffers& buffers) override;
     WorkbufferRequest GetWorkBufferRequest() const override;
 

--- a/modules/nvidia_plugin/src/ops/fused_convolution_cudnn.cpp
+++ b/modules/nvidia_plugin/src/ops/fused_convolution_cudnn.cpp
@@ -95,6 +95,8 @@ void FusedConvolutionCuDnn::Execute(const InferenceRequestContext& context,
                                                 outputs[ArgIndices::output].get()));
 }
 
+bool FusedConvolutionCuDnn::IsCudaGraphCompatible() const { return true; }
+
 WorkbufferRequest FusedConvolutionCuDnn::GetWorkBufferRequest() const {
     if (conv_descs_->Algo().memory != 0)
         return {{}, {conv_descs_->Algo().memory}};

--- a/modules/nvidia_plugin/src/ops/fused_convolution_cudnn.hpp
+++ b/modules/nvidia_plugin/src/ops/fused_convolution_cudnn.hpp
@@ -34,6 +34,8 @@ public:
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers&) const override;
+
+    bool IsCudaGraphCompatible() const override;
     void InitSharedImmutableWorkbuffers(const IOperationExec::Buffers&) override {}
     WorkbufferRequest GetWorkBufferRequest() const override;
 

--- a/modules/nvidia_plugin/src/ops/fused_convolution_cudnn_be.cpp
+++ b/modules/nvidia_plugin/src/ops/fused_convolution_cudnn_be.cpp
@@ -327,6 +327,8 @@ void FusedConvolutionCuDnnBE::Execute(const InferenceRequestContext& context,
     throwIfError(::cudnnBackendExecute(context.getThreadContext().dnnHandle().get(), plan->get(), variantPack->get()));
 }
 
+bool FusedConvolutionCuDnnBE::IsCudaGraphCompatible() const { return false; }
+
 std::shared_ptr<CUDA::DnnBETensorDescriptor> FusedConvolutionCuDnnBE::MakeTensorDescriptor(
     int64_t id,
     cudnnDataType_t element_type,

--- a/modules/nvidia_plugin/src/ops/fused_convolution_cudnn_be.hpp
+++ b/modules/nvidia_plugin/src/ops/fused_convolution_cudnn_be.hpp
@@ -33,6 +33,8 @@ public:
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
+
+    bool IsCudaGraphCompatible() const override;
     WorkbufferRequest GetWorkBufferRequest() const override;
 
 private:

--- a/modules/nvidia_plugin/src/ops/fused_convolution_cudnn_decomposed.cpp
+++ b/modules/nvidia_plugin/src/ops/fused_convolution_cudnn_decomposed.cpp
@@ -85,6 +85,8 @@ void FusedConvolutionCuDnnDecomposed::Execute(const InferenceRequestContext& con
     }
 }
 
+bool FusedConvolutionCuDnnDecomposed::IsCudaGraphCompatible() const { return true; }
+
 WorkbufferRequest FusedConvolutionCuDnnDecomposed::GetWorkBufferRequest() const {
     if (conv_descs_->Algo().memory != 0) {
         return {{}, {conv_descs_->Algo().memory}};

--- a/modules/nvidia_plugin/src/ops/fused_convolution_cudnn_decomposed.hpp
+++ b/modules/nvidia_plugin/src/ops/fused_convolution_cudnn_decomposed.hpp
@@ -36,6 +36,8 @@ public:
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers&) const override;
+
+    bool IsCudaGraphCompatible() const override;
     void InitSharedImmutableWorkbuffers(const IOperationExec::Buffers&) override {}
     WorkbufferRequest GetWorkBufferRequest() const override;
 

--- a/modules/nvidia_plugin/src/ops/gather.cpp
+++ b/modules/nvidia_plugin/src/ops/gather.cpp
@@ -182,6 +182,8 @@ void GatherOp::Execute(const InferenceRequestContext& context,
                       outputs[0].get());
 }
 
+bool GatherOp::IsCudaGraphCompatible() const { return true; }
+
 OPERATION_REGISTER(GatherOp, Gather);
 }  // namespace nvidia_gpu
 }  // namespace ov

--- a/modules/nvidia_plugin/src/ops/gather.hpp
+++ b/modules/nvidia_plugin/src/ops/gather.hpp
@@ -16,10 +16,13 @@ public:
              const ov::Node& node,
              IndexCollection&& inputIds,
              IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
+
+    bool IsCudaGraphCompatible() const override;
 
 private:
     std::optional<kernel::Gather> gather_kernel_;

--- a/modules/nvidia_plugin/src/ops/group_convolution.cpp
+++ b/modules/nvidia_plugin/src/ops/group_convolution.cpp
@@ -25,6 +25,8 @@ void GroupConvolutionOp::Execute(const InferenceRequestContext &context,
     convolution_.Execute(context, inputTensors, outputTensors, buffers);
 }
 
+bool GroupConvolutionOp::IsCudaGraphCompatible() const { return true; }
+
 WorkbufferRequest GroupConvolutionOp::GetWorkBufferRequest() const { return convolution_.GetWorkBufferRequest(); }
 
 OPERATION_REGISTER(GroupConvolutionOp, GroupConvolution);

--- a/modules/nvidia_plugin/src/ops/group_convolution.hpp
+++ b/modules/nvidia_plugin/src/ops/group_convolution.hpp
@@ -26,6 +26,8 @@ public:
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers&) const override final;
+
+    bool IsCudaGraphCompatible() const override;
     WorkbufferRequest GetWorkBufferRequest() const override final;
 
 private:

--- a/modules/nvidia_plugin/src/ops/gru_cell.cpp
+++ b/modules/nvidia_plugin/src/ops/gru_cell.cpp
@@ -61,6 +61,8 @@ void GRUCellOp::Execute(const InferenceRequestContext& context,
                                                       nullptr);
 }
 
+bool GRUCellOp::IsCudaGraphCompatible() const { return true; }
+
 void GRUCellOp::InitSharedImmutableWorkbuffers(const IOperationExec::Buffers& buffers) {
     OPENVINO_ASSERT(buffers.size() == 1 || buffers.size() == 2, "Node name: ", GetName());
 

--- a/modules/nvidia_plugin/src/ops/gru_cell.hpp
+++ b/modules/nvidia_plugin/src/ops/gru_cell.hpp
@@ -26,6 +26,8 @@ public:
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers&) const override;
+
+    bool IsCudaGraphCompatible() const override;
     void InitSharedImmutableWorkbuffers(const IOperationExec::Buffers&) override;
     WorkbufferRequest GetWorkBufferRequest() const override;
 

--- a/modules/nvidia_plugin/src/ops/gru_sequence.cpp
+++ b/modules/nvidia_plugin/src/ops/gru_sequence.cpp
@@ -18,7 +18,8 @@ GRUSequenceOp::GRUSequenceOp(const CreationContext& context,
                              IndexCollection&& outputIds)
     : OperationCuDnn(context, node, std::move(inputIds), std::move(outputIds)),
       params_{node},
-      descs_{context, params_, config()} {
+      descs_{context, params_, config()},
+      is_cuda_graph_compatible_{RNN::Details::isRNNSequenceCudaGraphCompatible(context.device())} {
     ib_seq_lengths_.addRequest(immut_sizes_, descs_.seqLengthArraySizeBytes());
     ib_weight_space_.addRequest(immut_sizes_, descs_.weightSpaceSize());
 
@@ -69,6 +70,8 @@ void GRUSequenceOp::Execute(const InferenceRequestContext& context,
                          0,
                          nullptr);
 }
+
+bool GRUSequenceOp::IsCudaGraphCompatible() const { return is_cuda_graph_compatible_; }
 
 void GRUSequenceOp::InitSharedImmutableWorkbuffers(const IOperationExec::Buffers& buffers) {
     descs_.initDevSeqLengthArray(CUDA::DevicePointer<void*>{ib_seq_lengths_.requiredPtr(buffers)});

--- a/modules/nvidia_plugin/src/ops/gru_sequence.hpp
+++ b/modules/nvidia_plugin/src/ops/gru_sequence.hpp
@@ -32,6 +32,8 @@ public:
                  Outputs outputTensors,
                  const Workbuffers&) const override;
 
+    bool IsCudaGraphCompatible() const override;
+
 private:
     static Config config();
     void InitSharedImmutableWorkbuffers(const IOperationExec::Buffers&) override;
@@ -47,6 +49,8 @@ private:
     WorkbufferDesc ib_seq_lengths_;
     WorkbufferDesc ib_weight_space_;
     WorkbufferDesc mb_work_space_;
+
+    bool is_cuda_graph_compatible_;
 };
 
 }  // namespace nvidia_gpu

--- a/modules/nvidia_plugin/src/ops/interpolate_cubic.cpp
+++ b/modules/nvidia_plugin/src/ops/interpolate_cubic.cpp
@@ -68,6 +68,8 @@ void InterpolateCubicOp::Execute(const InferenceRequestContext& context,
     (*interpolate_)(context.getThreadContext().stream().get(), inputs[0].get(), outputs[0].get());
 }
 
+bool InterpolateCubicOp::IsCudaGraphCompatible() const { return true; }
+
 WorkbufferRequest InterpolateCubicOp::GetWorkBufferRequest() const {
     return {interpolate_->immutableWorkbufferSizes(), {}};
 }

--- a/modules/nvidia_plugin/src/ops/interpolate_cubic.hpp
+++ b/modules/nvidia_plugin/src/ops/interpolate_cubic.hpp
@@ -14,15 +14,18 @@ namespace nvidia_gpu {
 class InterpolateCubicOp : public OperationBase {
 public:
     using NodeOp = ov::op::v4::Interpolate;
+
     InterpolateCubicOp(const CreationContext& context,
                        const NodeOp& stridedSliceOp,
                        IndexCollection&& inputIds,
                        IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputs,
                  Outputs outputs,
                  const Workbuffers& workbuffers) const override;
 
+    bool IsCudaGraphCompatible() const override;
     WorkbufferRequest GetWorkBufferRequest() const override;
     void InitSharedImmutableWorkbuffers(const Buffers& buffers) override;
 

--- a/modules/nvidia_plugin/src/ops/interpolate_linear.cpp
+++ b/modules/nvidia_plugin/src/ops/interpolate_linear.cpp
@@ -69,6 +69,8 @@ void InterpolateLinearOp::Execute(const InferenceRequestContext& context,
     (*interpolate_)(context.getThreadContext().stream().get(), inputs[0].get(), outputs[0].get());
 }
 
+bool InterpolateLinearOp::IsCudaGraphCompatible() const { return true; }
+
 WorkbufferRequest InterpolateLinearOp::GetWorkBufferRequest() const {
     return {interpolate_->immutableWorkbufferSizes(), {}};
 }

--- a/modules/nvidia_plugin/src/ops/interpolate_linear.hpp
+++ b/modules/nvidia_plugin/src/ops/interpolate_linear.hpp
@@ -14,15 +14,18 @@ namespace nvidia_gpu {
 class InterpolateLinearOp : public OperationBase {
 public:
     using NodeOp = ov::op::v4::Interpolate;
+
     InterpolateLinearOp(const CreationContext& context,
                         const NodeOp& stridedSliceOp,
                         IndexCollection&& inputIds,
                         IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputs,
                  Outputs outputs,
                  const Workbuffers& workbuffers) const override;
 
+    bool IsCudaGraphCompatible() const override;
     WorkbufferRequest GetWorkBufferRequest() const override;
     void InitSharedImmutableWorkbuffers(const Buffers& buffers) override;
 

--- a/modules/nvidia_plugin/src/ops/interpolate_nearest.cpp
+++ b/modules/nvidia_plugin/src/ops/interpolate_nearest.cpp
@@ -154,6 +154,8 @@ void InterpolateNearestOp::Execute(const InferenceRequestContext& context,
                     dst);
 }
 
+bool InterpolateNearestOp::IsCudaGraphCompatible() const { return true; }
+
 template <typename T>
 static auto size_in_bytes(const std::vector<T>& v) noexcept {
     return sizeof(T) * v.size();

--- a/modules/nvidia_plugin/src/ops/interpolate_nearest.hpp
+++ b/modules/nvidia_plugin/src/ops/interpolate_nearest.hpp
@@ -15,15 +15,18 @@ namespace nvidia_gpu {
 class InterpolateNearestOp : public OperationBase {
 public:
     using NodeOp = ov::op::v4::Interpolate;
+
     InterpolateNearestOp(const CreationContext& context,
                          const NodeOp& stridedSliceOp,
                          IndexCollection&& inputIds,
                          IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputs,
                  Outputs outputs,
                  const Workbuffers& workbuffers) const override;
 
+    bool IsCudaGraphCompatible() const override;
     WorkbufferRequest GetWorkBufferRequest() const override;
     void InitSharedImmutableWorkbuffers(const Buffers& buffers) override;
 

--- a/modules/nvidia_plugin/src/ops/logical_not.cpp
+++ b/modules/nvidia_plugin/src/ops/logical_not.cpp
@@ -35,6 +35,8 @@ void LogicalNotOp::Execute(const InferenceRequestContext& context,
     throwIfError(cudaPeekAtLastError());
 }
 
+bool LogicalNotOp::IsCudaGraphCompatible() const { return true; }
+
 OPERATION_REGISTER(LogicalNotOp, LogicalNot);
 
 }  // namespace nvidia_gpu

--- a/modules/nvidia_plugin/src/ops/logical_not.hpp
+++ b/modules/nvidia_plugin/src/ops/logical_not.hpp
@@ -15,10 +15,13 @@ public:
                           const std::shared_ptr<ov::Node>& node,
                           IndexCollection&& inputIds,
                           IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
+
+    bool IsCudaGraphCompatible() const override;
 
 private:
     kernel::LogicalNot kernel_;

--- a/modules/nvidia_plugin/src/ops/lstm_cell.cpp
+++ b/modules/nvidia_plugin/src/ops/lstm_cell.cpp
@@ -57,6 +57,8 @@ void LSTMCellOp::Execute(const InferenceRequestContext& context,
                                                       nullptr);
 }
 
+bool LSTMCellOp::IsCudaGraphCompatible() const { return true; }
+
 void LSTMCellOp::InitSharedImmutableWorkbuffers(const IOperationExec::Buffers& buffers) {
     OPENVINO_ASSERT(buffers.size() == 1 || buffers.size() == 2, "Node name: ", GetName());
 

--- a/modules/nvidia_plugin/src/ops/lstm_cell.hpp
+++ b/modules/nvidia_plugin/src/ops/lstm_cell.hpp
@@ -26,6 +26,8 @@ public:
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers&) const override;
+
+    bool IsCudaGraphCompatible() const override;
     void InitSharedImmutableWorkbuffers(const IOperationExec::Buffers&) override;
     WorkbufferRequest GetWorkBufferRequest() const override;
 

--- a/modules/nvidia_plugin/src/ops/lstm_sequence_base.hpp
+++ b/modules/nvidia_plugin/src/ops/lstm_sequence_base.hpp
@@ -31,6 +31,7 @@ public:
                  Outputs outputTensors,
                  const Workbuffers&) const override;
 
+    bool IsCudaGraphCompatible() const override;
     void InitSharedImmutableWorkbuffers(const IOperationExec::Buffers&) override;
     WorkbufferRequest GetWorkBufferRequest() const override;
 
@@ -57,6 +58,9 @@ protected:
     OutputTensorAdapterPtr y_adapter;
     OutputTensorAdapterPtr hy_adapter;
     OutputTensorAdapterPtr cy_adapter;
+
+private:
+    bool is_cuda_graph_compatible_;
 };
 
 }  // namespace nvidia_gpu

--- a/modules/nvidia_plugin/src/ops/matmul.cpp
+++ b/modules/nvidia_plugin/src/ops/matmul.cpp
@@ -226,6 +226,8 @@ void MatMulOp::Execute(const InferenceRequestContext& context,
                                             CUBLAS_GEMM_DEFAULT));
 }
 
+bool MatMulOp::IsCudaGraphCompatible() const { return true; }
+
 OPERATION_REGISTER(MatMulOp, MatMul);
 }  // namespace nvidia_gpu
 }  // namespace ov

--- a/modules/nvidia_plugin/src/ops/matmul.hpp
+++ b/modules/nvidia_plugin/src/ops/matmul.hpp
@@ -18,15 +18,19 @@ namespace nvidia_gpu {
 class MatMulOp : public OperationCuBlas {
 public:
     using NodeOp = ov::op::v0::MatMul;
+
     template <typename TOperation>
     MatMulOp(const CreationContext& context,
              const TOperation& node,
              IndexCollection&& inputIds,
              IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
+
+    bool IsCudaGraphCompatible() const override;
 
     int GetBatchCount() const { return batch_count_; }
 

--- a/modules/nvidia_plugin/src/ops/maxpool.cpp
+++ b/modules/nvidia_plugin/src/ops/maxpool.cpp
@@ -30,6 +30,8 @@ void MaxPoolOp::Execute(const InferenceRequestContext& context,
                   outputs[PoolingImpl::output_index].get());
 }
 
+bool MaxPoolOp::IsCudaGraphCompatible() const { return true; }
+
 OPERATION_REGISTER(MaxPoolOp, MaxPool);
 
 }  // namespace nvidia_gpu

--- a/modules/nvidia_plugin/src/ops/maxpool.hpp
+++ b/modules/nvidia_plugin/src/ops/maxpool.hpp
@@ -17,10 +17,13 @@ public:
                        const std::shared_ptr<ov::Node>& node,
                        IndexCollection&& inputIds,
                        IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
+
+    bool IsCudaGraphCompatible() const override;
 
 private:
     PoolingImpl impl_;

--- a/modules/nvidia_plugin/src/ops/mvn.cpp
+++ b/modules/nvidia_plugin/src/ops/mvn.cpp
@@ -99,6 +99,8 @@ void MvnOp::Execute(const InferenceRequestContext& context,
                        {tensor_desc_, outputTensors[0]});
 }
 
+bool MvnOp::IsCudaGraphCompatible() const { return true; }
+
 void MvnOp::Context::reduceMean(ConstTensor input, Tensor output) {
     context.getThreadContext().dnnHandle().reduceTensor(op.reduce_mean_desc_,
                                                         op.getReduceWorkspaceBuffer(workbuffers),

--- a/modules/nvidia_plugin/src/ops/mvn.hpp
+++ b/modules/nvidia_plugin/src/ops/mvn.hpp
@@ -26,6 +26,7 @@ public:
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
 
+    bool IsCudaGraphCompatible() const override;
     WorkbufferRequest GetWorkBufferRequest() const override;
 
 private:

--- a/modules/nvidia_plugin/src/ops/nop_op.hpp
+++ b/modules/nvidia_plugin/src/ops/nop_op.hpp
@@ -38,6 +38,8 @@ public:
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override {}
+
+    bool IsCudaGraphCompatible() const override { return true; }
 };
 
 }  // namespace nvidia_gpu

--- a/modules/nvidia_plugin/src/ops/pad.cpp
+++ b/modules/nvidia_plugin/src/ops/pad.cpp
@@ -58,6 +58,8 @@ void PadOp::Execute(const InferenceRequestContext& context,
             inputTensors[InputIndex::kPadValue].get());
 }
 
+bool PadOp::IsCudaGraphCompatible() const { return true; }
+
 WorkbufferRequest PadOp::GetWorkBufferRequest() const {
     auto rank = src_shape_.size();
     return {{rank * sizeof(std::size_t), rank * sizeof(std::size_t)}, {}};

--- a/modules/nvidia_plugin/src/ops/pad.hpp
+++ b/modules/nvidia_plugin/src/ops/pad.hpp
@@ -17,10 +17,13 @@ public:
                    const ov::op::v1::Pad& node,
                    IndexCollection&& inputIds,
                    IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
+
+    bool IsCudaGraphCompatible() const override;
     WorkbufferRequest GetWorkBufferRequest() const override;
     void InitSharedImmutableWorkbuffers(const Buffers&) override;
 

--- a/modules/nvidia_plugin/src/ops/parameter.cpp
+++ b/modules/nvidia_plugin/src/ops/parameter.cpp
@@ -31,6 +31,8 @@ void ParameterOp::Execute(const InferenceRequestContext& context,
     context.getThreadContext().stream().upload(outputs[0], tensor->data(), tensor->get_byte_size());
 }
 
+bool ParameterOp::IsCudaGraphCompatible() const { return true; }
+
 std::string ParameterOp::GetInputTensorName(const ov::Node& node) { return node.get_friendly_name(); }
 
 OPERATION_REGISTER(ParameterOp, Parameter);

--- a/modules/nvidia_plugin/src/ops/parameter.hpp
+++ b/modules/nvidia_plugin/src/ops/parameter.hpp
@@ -16,10 +16,13 @@ public:
                 const ov::Node& node,
                 IndexCollection&& inputIds,
                 IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
+
+    bool IsCudaGraphCompatible() const override;
     static std::string GetInputTensorName(const ov::Node& node);
 
 private:

--- a/modules/nvidia_plugin/src/ops/range.cpp
+++ b/modules/nvidia_plugin/src/ops/range.cpp
@@ -64,6 +64,8 @@ void RangeOp::Execute(const InferenceRequestContext& context,
                   outputs[OUTPUT_INDX].get());
 }
 
+bool RangeOp::IsCudaGraphCompatible() const { return true; }
+
 OPERATION_REGISTER(RangeOp, Range);
 }  // namespace nvidia_gpu
 }  // namespace ov

--- a/modules/nvidia_plugin/src/ops/range.hpp
+++ b/modules/nvidia_plugin/src/ops/range.hpp
@@ -26,6 +26,8 @@ public:
                  Outputs outputs,
                  const Workbuffers& workbuffers) const override;
 
+    bool IsCudaGraphCompatible() const override;
+
 private:
     size_t output_size_;
     std::optional<kernel::RangeKernelOp> kernel_op_;

--- a/modules/nvidia_plugin/src/ops/reduce_sum.cpp
+++ b/modules/nvidia_plugin/src/ops/reduce_sum.cpp
@@ -58,6 +58,8 @@ void ReduceSumOp::Execute(const InferenceRequestContext& context,
                                                         outputTensors[0]);
 }
 
+bool ReduceSumOp::IsCudaGraphCompatible() const { return true; }
+
 OPERATION_REGISTER(ReduceSumOp, ReduceSum);
 }  // namespace nvidia_gpu
 }  // namespace ov

--- a/modules/nvidia_plugin/src/ops/reduce_sum.hpp
+++ b/modules/nvidia_plugin/src/ops/reduce_sum.hpp
@@ -21,6 +21,7 @@ public:
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
 
+    bool IsCudaGraphCompatible() const override;
     WorkbufferRequest GetWorkBufferRequest() const override;
 
 private:

--- a/modules/nvidia_plugin/src/ops/result.cpp
+++ b/modules/nvidia_plugin/src/ops/result.cpp
@@ -44,6 +44,8 @@ void ResultOp::Execute(const InferenceRequestContext& context,
     context.getThreadContext().stream().download(tensor->data(), inputs[0], tensor->get_byte_size());
 }
 
+bool ResultOp::IsCudaGraphCompatible() const { return true; }
+
 std::optional<std::string> ResultOp::GetFusedOutputTensorName(const ov::Node::RTMap& rtInfo,
                                                               const std::string& resultName) {
     if (auto found = rtInfo.find(RtInfo::CUDA_FUSED_NAMES_MAPPING); found != rtInfo.end()) {

--- a/modules/nvidia_plugin/src/ops/result.hpp
+++ b/modules/nvidia_plugin/src/ops/result.hpp
@@ -18,10 +18,14 @@ public:
              const NodeOp& node,
              IndexCollection&& inputIds,
              IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
+
+    bool IsCudaGraphCompatible() const override;
+
     static std::vector<std::string> GetOutputTensorName(const ov::op::v0::Result& node);
 
 private:

--- a/modules/nvidia_plugin/src/ops/rnn_components/rnn_sequence_components.cpp
+++ b/modules/nvidia_plugin/src/ops/rnn_components/rnn_sequence_components.cpp
@@ -9,6 +9,16 @@
 
 namespace ov::nvidia_gpu::RNN::Details {
 
+bool isRNNSequenceCudaGraphCompatible(const CUDA::Device& device) {
+    const auto computeCompatabilityVersion = 10 * device.props().major + device.props().minor;
+    const auto isDeviceSupported = computeCompatabilityVersion > 61;
+
+    const auto cudnnVersion = ::cudnnGetVersion();
+    const auto isCudnnSupported = cudnnVersion != 8500 && cudnnVersion != 8600;
+
+    return isDeviceSupported || isCudnnSupported;
+}
+
 inline bool isTypeSupported(cudaDataType_t type) {
     switch (type) {
         case CUDA_R_16F:

--- a/modules/nvidia_plugin/src/ops/rnn_components/rnn_sequence_components.hpp
+++ b/modules/nvidia_plugin/src/ops/rnn_components/rnn_sequence_components.hpp
@@ -11,6 +11,14 @@
 namespace ov::nvidia_gpu::RNN::Details {
 
 /**
+ * Checks if LSTM/GRU Sequence is supported by the combination of cuDNN runtime and device compute capability
+ * cuDNN v8.5.0/v8.6.0 on GTX1080 (compute capabiltiy 6.1) doesn't work properly with stream capturing
+ * @param device CUDA device to check
+ * @returns true if the combination supported and false if it isn't
+ */
+bool isRNNSequenceCudaGraphCompatible(const CUDA::Device& device);
+
+/**
  * Base class for `TransposeInputTensorAdapter` and `TransposeOutputTensorAdapter`
  *
  * TODO: Consider to refactor using `TransposeOp` using aggregation or by creating

--- a/modules/nvidia_plugin/src/ops/round.cpp
+++ b/modules/nvidia_plugin/src/ops/round.cpp
@@ -48,6 +48,8 @@ void RoundOp::Execute(const InferenceRequestContext& context,
     (*kernel_)(context.getThreadContext().stream().get(), inputTensors[0].get(), outputTensors[0].get());
 }
 
+bool RoundOp::IsCudaGraphCompatible() const { return true; }
+
 OPERATION_REGISTER(RoundOp, Round);
 
 }  // namespace nvidia_gpu

--- a/modules/nvidia_plugin/src/ops/round.hpp
+++ b/modules/nvidia_plugin/src/ops/round.hpp
@@ -25,6 +25,8 @@ public:
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
 
+    bool IsCudaGraphCompatible() const override;
+
 private:
     std::optional<kernel::Round> kernel_;
 };

--- a/modules/nvidia_plugin/src/ops/scatter_nd_update.cpp
+++ b/modules/nvidia_plugin/src/ops/scatter_nd_update.cpp
@@ -100,6 +100,8 @@ void ScatterNDUpdateOp::Execute(const InferenceRequestContext& context,
                outputs[0].get());
 }
 
+bool ScatterNDUpdateOp::IsCudaGraphCompatible() const { return true; }
+
 template <typename T>
 static auto size_in_bytes(const std::vector<T>& v) noexcept {
     return sizeof(T) * v.size();

--- a/modules/nvidia_plugin/src/ops/scatter_nd_update.hpp
+++ b/modules/nvidia_plugin/src/ops/scatter_nd_update.hpp
@@ -16,11 +16,13 @@ public:
                       const ov::Node& node,
                       IndexCollection&& inputIds,
                       IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputs,
                  Outputs outputs,
                  const Workbuffers& workbuffers) const override;
 
+    bool IsCudaGraphCompatible() const override;
     WorkbufferRequest GetWorkBufferRequest() const override;
     void InitSharedImmutableWorkbuffers(const Buffers& buffers) override;
 

--- a/modules/nvidia_plugin/src/ops/select.cpp
+++ b/modules/nvidia_plugin/src/ops/select.cpp
@@ -90,6 +90,8 @@ void SelectOp::Execute(const InferenceRequestContext& context,
         outputs[0].get());
 }
 
+bool SelectOp::IsCudaGraphCompatible() const { return true; }
+
 WorkbufferRequest SelectOp::GetWorkBufferRequest() const {
     return {std::vector<WorkbufferRequest::size_in_bytes_t>(SIZES + 1, kOffsetBufferSize), {}};
 }

--- a/modules/nvidia_plugin/src/ops/select.hpp
+++ b/modules/nvidia_plugin/src/ops/select.hpp
@@ -26,6 +26,7 @@ public:
                  Outputs outputs,
                  const Workbuffers& workbuffers) const override;
 
+    bool IsCudaGraphCompatible() const override;
     WorkbufferRequest GetWorkBufferRequest() const override;
 
     void InitSharedImmutableWorkbuffers(const Buffers& buffers) override;

--- a/modules/nvidia_plugin/src/ops/softmax.cpp
+++ b/modules/nvidia_plugin/src/ops/softmax.cpp
@@ -192,6 +192,8 @@ void SoftmaxOp::Execute(const InferenceRequestContext& context,
                                      outputs[0].get()));
 }
 
+bool SoftmaxOp::IsCudaGraphCompatible() const { return true; }
+
 OPERATION_REGISTER(SoftmaxOp, Softmax);
 }  // namespace nvidia_gpu
 }  // namespace ov

--- a/modules/nvidia_plugin/src/ops/softmax.hpp
+++ b/modules/nvidia_plugin/src/ops/softmax.hpp
@@ -16,14 +16,18 @@ namespace nvidia_gpu {
 class SoftmaxOp : public OperationCuDnn {
 public:
     using NodeOp = ov::op::v1::Softmax;
+
     SoftmaxOp(const CreationContext& context,
               const NodeOp& node,
               IndexCollection&& inputIds,
               IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
+
+    bool IsCudaGraphCompatible() const override;
 
 private:
     void mapRankAxis(const ov::Shape& shape, int axis);

--- a/modules/nvidia_plugin/src/ops/split.cpp
+++ b/modules/nvidia_plugin/src/ops/split.cpp
@@ -89,6 +89,8 @@ void SplitOp::Execute(const InferenceRequestContext& context,
     (*split_kernel_)(stream.get(), reinterpret_cast<const void*>(in.get()), reinterpret_cast<void**>(outputPtrs.get()));
 }
 
+bool SplitOp::IsCudaGraphCompatible() const { return true; }
+
 OPERATION_REGISTER(SplitOp, Split);
 }  // namespace nvidia_gpu
 }  // namespace ov

--- a/modules/nvidia_plugin/src/ops/split.hpp
+++ b/modules/nvidia_plugin/src/ops/split.hpp
@@ -20,10 +20,14 @@ public:
             const ov::Node& node,
             IndexCollection&& inputIds,
             IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
+
+    bool IsCudaGraphCompatible() const override;
+
     WorkbufferRequest GetWorkBufferRequest() const override;
 
 private:

--- a/modules/nvidia_plugin/src/ops/strided_slice.cpp
+++ b/modules/nvidia_plugin/src/ops/strided_slice.cpp
@@ -103,6 +103,8 @@ void StridedSliceOp::Execute(const InferenceRequestContext& context,
                   outputs[0].get());
 }
 
+bool StridedSliceOp::IsCudaGraphCompatible() const { return true; }
+
 WorkbufferRequest StridedSliceOp::GetWorkBufferRequest() const {
     return {{size_bytes(src_matrix_sizes_),
              size_bytes(dst_matrix_sizes_),

--- a/modules/nvidia_plugin/src/ops/strided_slice.hpp
+++ b/modules/nvidia_plugin/src/ops/strided_slice.hpp
@@ -16,14 +16,18 @@ namespace nvidia_gpu {
 class StridedSliceOp : public OperationBase {
 public:
     using NodeOp = ov::op::v1::StridedSlice;
+
     StridedSliceOp(const CreationContext& context,
                    const NodeOp& stridedSliceOp,
                    IndexCollection&& inputIds,
                    IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputs,
                  Outputs outputs,
                  const Workbuffers& workbuffers) const override;
+
+    bool IsCudaGraphCompatible() const override;
     WorkbufferRequest GetWorkBufferRequest() const override;
     void InitSharedImmutableWorkbuffers(const Buffers& buffers) override;
 
@@ -33,19 +37,23 @@ private:
                      Inputs inputs,
                      Outputs outputs,
                      const Workbuffers& workbuffers) const;
+
     template <typename T>
     void callStridedSliceKernel(const InferenceRequestContext& context,
                                 const Inputs inputs,
                                 Outputs outputs,
                                 const Workbuffers& workbuffers) const;
+
     template <typename T>
     void callReverseAxesKernel(const InferenceRequestContext& context, Outputs outputs) const;
+
     template <typename T>
     void callReverseAxesKernel(const InferenceRequestContext& context,
                                const std::vector<size_t>& matrixShapes,
                                const std::vector<int64_t>& matrixSizes,
                                const ov::AxisSet& reverseAxes,
                                CUDA::DevicePointer<void*> buffer) const;
+
     void uploadDataToWorkbuffer(CUDA::DevicePointer<void*> buffer, const std::vector<int64_t>& data);
 
     std::vector<int64_t> getNodeConstantValues(const ov::Node* node) const;

--- a/modules/nvidia_plugin/src/ops/subgraph.cpp
+++ b/modules/nvidia_plugin/src/ops/subgraph.cpp
@@ -143,5 +143,14 @@ void SubGraph::Execute(const InferenceRequestContext& context, Inputs, Outputs, 
     }
 }
 
+bool SubGraph::IsCudaGraphCompatible() const {
+    for (const auto& op : exec_sequence_) {
+        if (!op->IsCudaGraphCompatible()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 }  // namespace nvidia_gpu
 }  // namespace ov

--- a/modules/nvidia_plugin/src/ops/subgraph.hpp
+++ b/modules/nvidia_plugin/src/ops/subgraph.hpp
@@ -21,6 +21,9 @@ public:
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
+
+    bool IsCudaGraphCompatible() const override;
+
     const MemoryManager& memoryManager() const { return *memory_manager_; }
 
     const std::vector<OperationBase::Ptr>& getParams() const;

--- a/modules/nvidia_plugin/src/ops/swish.cpp
+++ b/modules/nvidia_plugin/src/ops/swish.cpp
@@ -69,6 +69,8 @@ void SwishOp::Execute(const InferenceRequestContext& context,
     (*kernel_)(stream.get(), inputTensors[0].get(), outputTensors[0].get());
 }
 
+bool SwishOp::IsCudaGraphCompatible() const { return true; }
+
 OPERATION_REGISTER(SwishOp, Swish);
 }  // namespace nvidia_gpu
 }  // namespace ov

--- a/modules/nvidia_plugin/src/ops/swish.hpp
+++ b/modules/nvidia_plugin/src/ops/swish.hpp
@@ -24,6 +24,8 @@ public:
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
 
+    bool IsCudaGraphCompatible() const override;
+
 private:
     std::optional<kernel::Swish> kernel_;
 };

--- a/modules/nvidia_plugin/src/ops/topk.cpp
+++ b/modules/nvidia_plugin/src/ops/topk.cpp
@@ -169,6 +169,8 @@ void TopKOp::Execute(const InferenceRequestContext& context,
                static_cast<const void*>(kernel_param.get()));
 }
 
+bool TopKOp::IsCudaGraphCompatible() const { return true; }
+
 void TopKOp::InitSharedImmutableWorkbuffers(const Buffers& buffers) {
     OPENVINO_ASSERT(buffers.size() == 1, "Node name: ", GetName());
     size_t buffer_offset = 0;

--- a/modules/nvidia_plugin/src/ops/topk.hpp
+++ b/modules/nvidia_plugin/src/ops/topk.hpp
@@ -19,11 +19,13 @@ public:
                     const ov::Node& node,
                     IndexCollection&& inputIds,
                     IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
 
+    bool IsCudaGraphCompatible() const override;
     void InitSharedImmutableWorkbuffers(const Buffers&) override;
     WorkbufferRequest GetWorkBufferRequest() const override;
 

--- a/modules/nvidia_plugin/src/ops/transpose.cpp
+++ b/modules/nvidia_plugin/src/ops/transpose.cpp
@@ -113,6 +113,8 @@ void TransposeOp::Execute(const InferenceRequestContext& context,
                                      context.getThreadContext().stream().get()));
 }
 
+bool TransposeOp::IsCudaGraphCompatible() const { return true; }
+
 std::vector<std::int64_t> TransposeOp::extractInputExtents(const ov::Node& node) {
     std::vector<std::int64_t> result;
     auto inputShape = node.input(0).get_shape();

--- a/modules/nvidia_plugin/src/ops/transpose.hpp
+++ b/modules/nvidia_plugin/src/ops/transpose.hpp
@@ -18,10 +18,13 @@ public:
                 const std::shared_ptr<ov::Node>& node,
                 IndexCollection&& inputIds,
                 IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
+
+    bool IsCudaGraphCompatible() const override;
 
 private:
     using ExtentsMap = std::unordered_map<int, std::int64_t>;

--- a/modules/nvidia_plugin/src/ops/variadic_split.cpp
+++ b/modules/nvidia_plugin/src/ops/variadic_split.cpp
@@ -199,6 +199,8 @@ void VariadicSplitOp::Execute(const InferenceRequestContext& context,
                               static_cast<const void*>(axis_offset_sizes.get()));
 }
 
+bool VariadicSplitOp::IsCudaGraphCompatible() const { return false; }
+
 OPERATION_REGISTER(VariadicSplitOp, VariadicSplit);
 }  // namespace nvidia_gpu
 }  // namespace ov

--- a/modules/nvidia_plugin/src/ops/variadic_split.hpp
+++ b/modules/nvidia_plugin/src/ops/variadic_split.hpp
@@ -22,10 +22,13 @@ public:
                     const ov::Node& node,
                     IndexCollection&& inputIds,
                     IndexCollection&& outputIds);
+
     void Execute(const InferenceRequestContext& context,
                  Inputs inputTensors,
                  Outputs outputTensors,
                  const Workbuffers& workbuffers) const override;
+
+    bool IsCudaGraphCompatible() const override;
 
 private:
     enum { kOutputPtrsMWBIdx = 0, kNumberOfMWBIdx };

--- a/modules/nvidia_plugin/tests/unit/is_cuda_graph_compatible.cpp
+++ b/modules/nvidia_plugin/tests/unit/is_cuda_graph_compatible.cpp
@@ -1,0 +1,221 @@
+// Copyright (C) 2021-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <cuda_runtime.h>
+#include <gtest/gtest.h>
+
+#include <cuda/graph.hpp>
+#include <cuda_executable_network.hpp>
+#include <cuda_operation_registry.hpp>
+#include <cuda_profiler.hpp>
+#include <openvino/op/parameter.hpp>
+#include <openvino/op/relu.hpp>
+#include <random>
+
+#include "ngraph_functions/utils/ngraph_helpers.hpp"
+
+namespace {
+
+using namespace ov::nvidia_gpu;
+using DevPtr = CUDA::DevicePointer<void*>;
+using CDevPtr = CUDA::DevicePointer<const void*>;
+
+struct IsCudaGraphCompatibleTest : testing::Test {
+    template <typename T, typename C>
+    static void generate(C& c) {
+        std::random_device randDevice;
+        std::mt19937 randEngine{randDevice()};
+        std::uniform_int_distribution<int> dist{std::numeric_limits<int>::min(), std::numeric_limits<int>::max()};
+        auto gen_input = [&dist, &randEngine]() {
+            return static_cast<T>(10.f * dist(randEngine) / static_cast<float>(std::numeric_limits<int>::max()));
+        };
+        std::generate(c.begin(), c.end(), gen_input);
+    }
+
+    static bool checkAndRun(const OperationBase::Ptr& operation,
+                            InferenceRequestContext& context,
+                            OperationBase::Inputs inputs,
+                            OperationBase::Outputs outputs,
+                            const Workbuffers& workbuffers) {
+        auto& stream = context.getThreadContext().stream();
+        if (operation->IsCudaGraphCompatible()) {
+            stream.synchronize();
+            CUDA::GraphCapture capture{stream};
+            {
+                auto scope = capture.getScope();
+                operation->Execute(context, inputs, outputs, workbuffers);
+            }
+            CUDA::GraphExec exec{capture.getGraph()};
+            stream.synchronize();
+            std::cout << "--- Operation compatible. Running with CudaGraph ---\n";
+            exec.launch(stream);
+            return true;
+        }
+        std::cout << "--- Operation isn't compatible. Running without CudaGraph ---\n";
+        operation->Execute(context, inputs, outputs, workbuffers);
+        return false;
+    }
+};
+
+struct ReluIsCudaGraphCompatibleTest : IsCudaGraphCompatibleTest {
+    void run() {
+        using ElementType = float;
+
+        ov::Shape shape{1, 2, 3, 4};
+
+        // Prepare environment
+        auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::from<ElementType>(), shape);
+        auto node = std::make_shared<ov::op::v0::Relu>(param);
+
+        CUDA::Device device{};
+        constexpr bool optimizeOption = false;
+        CreationContext creationContext{device, optimizeOption};
+        auto operation = OperationRegistry::getInstance().createOperation(
+            creationContext, node, std::array{TensorID{0}}, std::array{TensorID{0}});
+
+        const auto inSize = ov::shape_size(shape);
+        const auto inSizeBytes = inSize * sizeof(ElementType);
+        const auto outSize = ov::shape_size(shape);
+        const auto outSizeBytes = outSize * sizeof(ElementType);
+
+        ThreadContext threadContext{device};
+        auto& stream = threadContext.stream();
+        CUDA::Allocation inAlloc = stream.malloc(inSizeBytes);
+        CUDA::Allocation outAlloc = stream.malloc(outSizeBytes);
+        std::vector<CDevPtr> inputs{inAlloc};
+        std::vector<DevPtr> outputs{outAlloc};
+
+        CancellationToken token{};
+        ExecGraph graph{creationContext, {}};
+        Profiler profiler{false, graph};
+        std::vector<std::shared_ptr<ngraph::runtime::Tensor>> emptyTensor;
+        std::map<std::string, std::size_t> emptyMapping;
+        InferenceRequestContext context{
+            emptyTensor, emptyMapping, emptyTensor, emptyMapping, threadContext, token, profiler};
+
+        // Generate input
+        std::vector<ElementType> input(inSize);
+        generate<ElementType>(input);
+
+        // Upload input
+        stream.upload(inAlloc, input.data(), inSizeBytes);
+
+        Workbuffers workbuffers{};
+
+        // Run with or without CudaGraph usage
+        bool isCompatible = checkAndRun(operation, context, inputs, outputs, workbuffers);
+        ASSERT_TRUE(isCompatible);
+
+        // Download output
+        std::vector<ElementType> output(outSize);
+        stream.download(output.data(), outAlloc, outSizeBytes);
+        stream.synchronize();
+
+        // Calculate reference output
+        std::vector<ElementType> refOutput(outSize);
+        ASSERT_EQ(input.size(), refOutput.size());
+        std::transform(input.cbegin(), input.cend(), refOutput.begin(), [](ElementType el) { return el > 0 ? el : 0; });
+
+        // Validate result
+        ASSERT_EQ(output.size(), refOutput.size());
+        ASSERT_TRUE(std::equal(output.cbegin(), output.cend(), refOutput.cbegin()));
+    }
+};
+
+TEST_F(ReluIsCudaGraphCompatibleTest, Compatibile) { run(); }
+
+struct ConcatIsCudaGraphCompatibleTest : IsCudaGraphCompatibleTest {
+    void run() {
+        using ElementType = float;
+
+        // Prepare environment
+        ov::Shape shape1{1, 2, 3, 4};
+        ov::Shape shape2{2, 2, 3, 4};
+        std::vector<std::shared_ptr<ov::op::v0::Parameter>> params{
+            std::make_shared<ov::op::v0::Parameter>(ov::element::from<ElementType>(), shape1),
+            std::make_shared<ov::op::v0::Parameter>(ov::element::from<ElementType>(), shape2)};
+        auto paramOuts =
+            ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(params));
+
+        constexpr int64_t axis = 0;
+        auto node = std::make_shared<ov::op::v0::Concat>(paramOuts, axis);
+
+        CUDA::Device device{};
+        constexpr bool optimizeOption = false;
+        CreationContext creationContext{device, optimizeOption};
+        auto operation = OperationRegistry::getInstance().createOperation(
+            creationContext, node, std::array{TensorID{0}, TensorID{0}}, std::array{TensorID{0}});
+
+        const auto inSize1 = ov::shape_size(shape1);
+        const auto inSizeBytes1 = inSize1 * sizeof(ElementType);
+        const auto inSize2 = ov::shape_size(shape2);
+        const auto inSizeBytes2 = inSize2 * sizeof(ElementType);
+
+        const auto& outputShape = node->get_output_shape(0);
+        const auto outSize = ov::shape_size(outputShape);
+        const auto outSizeBytes = outSize * sizeof(ElementType);
+
+        ThreadContext threadContext{device};
+        auto& stream = threadContext.stream();
+        CUDA::Allocation inAlloc1 = stream.malloc(inSizeBytes1);
+        CUDA::Allocation inAlloc2 = stream.malloc(inSizeBytes2);
+        CUDA::Allocation outAlloc = stream.malloc(outSizeBytes);
+        std::vector<CDevPtr> inputs{inAlloc1, inAlloc2};
+        std::vector<DevPtr> outputs{outAlloc};
+
+        CancellationToken token{};
+        ExecGraph graph{creationContext, {}};
+        Profiler profiler{false, graph};
+        std::vector<std::shared_ptr<ngraph::runtime::Tensor>> emptyTensor;
+        std::map<std::string, std::size_t> emptyMapping;
+        InferenceRequestContext context{
+            emptyTensor, emptyMapping, emptyTensor, emptyMapping, threadContext, token, profiler};
+
+        // Generate inputs
+        std::vector<ElementType> input1(inSize1);
+        std::vector<ElementType> input2(inSize2);
+        generate<ElementType>(input1);
+        generate<ElementType>(input2);
+
+        // Upload inputs
+        stream.upload(inAlloc1, input1.data(), inSizeBytes1);
+        stream.upload(inAlloc2, input2.data(), inSizeBytes2);
+
+        WorkbufferRequest wbRequest{operation->GetWorkBufferRequest()};
+
+        ASSERT_EQ(wbRequest.immutable_sizes.size(), 1);
+        ASSERT_EQ(wbRequest.mutable_sizes.size(), 1);
+
+        auto immutAlloc = stream.malloc(wbRequest.immutable_sizes[0]);
+        auto mutAlloc = stream.malloc(wbRequest.mutable_sizes[0]);
+        auto immutPtr = DevPtr{immutAlloc};
+        auto mutPtr = DevPtr{mutAlloc};
+
+        operation->InitSharedImmutableWorkbuffers({immutPtr});
+        Workbuffers workbuffers{{immutPtr.cast<const void*>()}, {mutPtr}};
+
+        // Run with or without CudaGraph usage
+        bool isCompatible = checkAndRun(operation, context, inputs, outputs, workbuffers);
+        ASSERT_FALSE(isCompatible);
+
+        // Download output
+        std::vector<ElementType> output(outSize);
+        stream.download(output.data(), outAlloc, outSizeBytes);
+        stream.synchronize();
+
+        // Calculate reference output
+        std::vector<ElementType> refOutput(outSize);
+        ASSERT_EQ(input1.size() + input2.size(), refOutput.size());
+        std::copy(input1.cbegin(), input1.cend(), refOutput.begin());
+        std::copy(input2.cbegin(), input2.cend(), refOutput.begin() + input1.size());
+
+        // Validate result
+        ASSERT_EQ(output.size(), refOutput.size());
+        ASSERT_TRUE(std::equal(output.cbegin(), output.cend(), refOutput.cbegin()));
+    }
+};
+
+TEST_F(ConcatIsCudaGraphCompatibleTest, NotCompatible) { run(); }
+
+}  // namespace


### PR DESCRIPTION
### Details:
- *Add virtual `IsCudaGraphCompatible()` function to `IOperationExec` interface, default `false` value for it in `OperationBase` class and actual values (`true` for the vast majorty) for all inherited operations.*
### Ticket:
- CVS-108535