### PR TITLE
[NVIDIA] Switch inference precision to f16 by default

### DIFF
--- a/modules/nvidia_plugin/src/cuda_config.cpp
+++ b/modules/nvidia_plugin/src/cuda_config.cpp
@@ -169,7 +169,7 @@ Configuration::Configuration(const ov::AnyMap& config, const Configuration& defa
         } else if (ov::hint::inference_precision == key) {
             auto element_type = value.as<ov::element::Type>();
             const std::set<ov::element::Type> supported_types = {
-                ov::element::undefined, ov::element::f16, ov::element::f32,
+                ov::element::f16, ov::element::f32,
             };
             if (supported_types.count(element_type) == 0) {
                 throw_ov_exception(fmt::format("Inference precision {} is not supported by plugin", value.as<std::string>()));

--- a/modules/nvidia_plugin/src/cuda_plugin.cpp
+++ b/modules/nvidia_plugin/src/cuda_plugin.cpp
@@ -30,9 +30,7 @@ Plugin::Plugin() {
         device_thread_pool_[std::to_string(i)] = std::make_shared<CudaThreadPool>(device, num_concurrent_streams);
         configs_.insert({std::to_string(i),
             Configuration({ov::device::id(i),
-                            // TODO uncomment next line to switch default precision
-                            // ov::hint::inference_precision(isHalfSupported(device) ? ov::element::f16 : ov::element::f32)})});
-                            ov::hint::inference_precision(ov::element::undefined)})});
+                            ov::hint::inference_precision(isHalfSupported(device) ? ov::element::f16 : ov::element::f32)})});
     }
 }
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/infer_request/infer_request.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/infer_request/infer_request.cpp
@@ -346,7 +346,7 @@ TEST_F(smoke_InferenceRequestTest, ParameterResult) {
     InferenceEngine::Core ie{};
     InferenceEngine::Blob::Ptr a{};
     auto testNet = ie.ReadNetwork(model10, a);
-    auto execNet = ie.LoadNetwork(testNet, "NVIDIA");
+    auto execNet = ie.LoadNetwork(testNet, "NVIDIA", {{ "INFERENCE_PRECISION_HINT", "f32"}});
     InferenceEngine::InferRequest request{execNet.CreateInferRequest()};
 
     const InferenceEngine::ConstInputsDataMap inputsInfo{execNet.GetInputsInfo()};

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_executable_network/properties.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_executable_network/properties.cpp
@@ -67,7 +67,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_AutoBatch_BehaviorTests,
 
 const std::vector<ov::AnyMap> default_properties = {
     {ov::num_streams(1)},
-    {ov::hint::inference_precision(ov::element::undefined)},
     {ov::hint::num_requests(0)},
     {ov::hint::performance_mode(ov::hint::PerformanceMode::LATENCY)},
     {ov::hint::execution_mode(ov::hint::ExecutionMode::PERFORMANCE)},
@@ -85,7 +84,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
 const std::vector<ov::AnyMap> properties = {
     {ov::num_streams(8)},
     {ov::num_streams(ov::streams::AUTO)},
-    {ov::hint::inference_precision(ov::element::undefined)},
     {ov::hint::inference_precision(ov::element::f32)},
     {ov::hint::inference_precision(ov::element::f16)},
     {ov::hint::performance_mode(ov::hint::PerformanceMode::THROUGHPUT)},

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
@@ -64,7 +64,6 @@ INSTANTIATE_TEST_SUITE_P(DISABLED_smoke_AutoBatch_BehaviorTests,
 
 const std::vector<ov::AnyMap> default_properties = {
     {ov::num_streams(1)},
-    {ov::hint::inference_precision(ov::element::undefined)},
     {ov::hint::num_requests(0)},
     {ov::hint::performance_mode(ov::hint::PerformanceMode::LATENCY)},
     {ov::hint::execution_mode(ov::hint::ExecutionMode::PERFORMANCE)},
@@ -81,7 +80,6 @@ INSTANTIATE_TEST_SUITE_P(smoke_BehaviorTests,
 const std::vector<ov::AnyMap> properties = {
     {ov::num_streams(8)},
     {ov::num_streams(ov::streams::AUTO)},
-    {ov::hint::inference_precision(ov::element::undefined)},
     {ov::hint::inference_precision(ov::element::f32)},
     {ov::hint::inference_precision(ov::element::f16)},
     {ov::hint::performance_mode(ov::hint::PerformanceMode::THROUGHPUT)},


### PR DESCRIPTION
### Details:
 - *Switch inference precision to f16 dy default*
 - *Remove WA with pre-processing for ConvertPrecision since transformation was extended with new parameter which allow keep precision of inputs/outputs*

### Tickets:
 - *105052*
