### PR TITLE
[DRAFT] [JAVA_API] Add Java API 2.0 JNI wrappers

### DIFF
--- a/modules/java_api/src/main/cpp/compiled_model.cpp
+++ b/modules/java_api/src/main/cpp/compiled_model.cpp
@@ -22,6 +22,60 @@ JNIEXPORT jlong JNICALL Java_org_intel_openvino_CompiledModel_CreateInferRequest
     return 0;
 }
 
+JNIEXPORT jobject JNICALL Java_org_intel_openvino_CompiledModel_GetInputs(JNIEnv * env, jobject obj, jlong modelAddr) {
+    JNI_METHOD("GetInputs",
+        CompiledModel *compiled_model = (CompiledModel *) modelAddr;
+        const std::vector<ov::Output<const ov::Node>>& inputs_vec = compiled_model->inputs();
+
+        jclass arrayClass = env->FindClass("java/util/ArrayList");
+        jmethodID arrayInit = env->GetMethodID(arrayClass, "<init>", "()V");
+        jobject arrayObj = env->NewObject(arrayClass, arrayInit);
+        jmethodID arrayAdd = env->GetMethodID(arrayClass, "add", "(Ljava/lang/Object;)Z");
+
+        jclass outputClass = env->FindClass("org/intel/openvino/Output");
+        jmethodID outputConstructor = env->GetMethodID(outputClass,"<init>","(J)V");
+
+        Output<const Node> *input;
+        for (const auto &item : inputs_vec) {
+            input = new Output<const Node>;
+            *input = item;
+
+            jobject inputObj = env->NewObject(outputClass, outputConstructor, (jlong)(input));
+            env->CallObjectMethod(arrayObj, arrayAdd, inputObj);
+        }
+
+        return arrayObj;
+    )
+    return 0;
+}
+
+JNIEXPORT jobject JNICALL Java_org_intel_openvino_CompiledModel_GetOutputs(JNIEnv * env, jobject obj, jlong modelAddr) {
+    JNI_METHOD("GetOutputs",
+        CompiledModel *compiled_model = (CompiledModel *) modelAddr;
+        const std::vector<ov::Output<const ov::Node>>& outputs_vec = compiled_model->outputs();
+
+        jclass arrayClass = env->FindClass("java/util/ArrayList");
+        jmethodID arrayInit = env->GetMethodID(arrayClass, "<init>", "()V");
+        jobject arrayObj = env->NewObject(arrayClass, arrayInit);
+        jmethodID arrayAdd = env->GetMethodID(arrayClass, "add", "(Ljava/lang/Object;)Z");
+
+        jclass outputClass = env->FindClass("org/intel/openvino/Output");
+        jmethodID outputConstructor = env->GetMethodID(outputClass,"<init>","(J)V");
+
+        Output<const Node> *output;
+        for (const auto &item : outputs_vec) {
+            output = new Output<const Node>;
+            *output = item;
+
+            jobject outputObj = env->NewObject(outputClass, outputConstructor, (jlong)(output));
+            env->CallObjectMethod(arrayObj, arrayAdd, outputObj);
+        }
+
+        return arrayObj;
+    )
+    return 0;
+}
+
 JNIEXPORT void JNICALL Java_org_intel_openvino_CompiledModel_delete(JNIEnv *, jobject, jlong addr)
 {
     CompiledModel *compiled_model = (CompiledModel *)addr;

--- a/modules/java_api/src/main/cpp/core.cpp
+++ b/modules/java_api/src/main/cpp/core.cpp
@@ -124,6 +124,25 @@ JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_CompileModel3(JNIEnv *env, 
     return 0;
 }
 
+JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_CompileModel4(JNIEnv *env, jobject obj, jlong coreAddr, jlong netAddr, jstring device, jobject props)
+{
+    JNI_METHOD("CompileModel4",
+        std::string n_device = jstringToString(env, device);
+        std::shared_ptr<Model> *model = reinterpret_cast<std::shared_ptr<Model> *>(netAddr);
+        AnyMap map;
+        for (const auto& it : javaMapToMap(env, props)) {
+            map[it.first] = it.second;
+        }
+
+        Core *core = (Core *)coreAddr;
+        CompiledModel *compiled_model = new CompiledModel();
+        *compiled_model = core->compile_model(*model, n_device, map);
+
+        return (jlong)compiled_model;
+    )
+    return 0;
+}
+
 JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_GetProperty(JNIEnv *env, jobject obj, jlong coreAddr, jstring device, jstring name)
 {
     JNI_METHOD("GetProperty",

--- a/modules/java_api/src/main/cpp/core.cpp
+++ b/modules/java_api/src/main/cpp/core.cpp
@@ -76,6 +76,54 @@ JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_CompileModel(JNIEnv *env, j
     return 0;
 }
 
+JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_CompileModel1(JNIEnv *env, jobject obj, jlong coreAddr, jstring path)
+{
+    JNI_METHOD("CompileModel1",
+        std::string n_path = jstringToString(env, path);
+
+        Core *core = (Core *)coreAddr;
+        CompiledModel *compiled_model = new CompiledModel();
+        *compiled_model = core->compile_model(n_path);
+
+        return (jlong)compiled_model;
+    )
+    return 0;
+}
+
+JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_CompileModel2(JNIEnv *env, jobject obj, jlong coreAddr, jstring path, jstring device)
+{
+    JNI_METHOD("CompileModel2",
+        std::string n_device = jstringToString(env, device);
+        std::string n_path = jstringToString(env, path);
+
+        Core *core = (Core *)coreAddr;
+        CompiledModel *compiled_model = new CompiledModel();
+        *compiled_model = core->compile_model(n_path, n_device);
+
+        return (jlong)compiled_model;
+    )
+    return 0;
+}
+
+JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_CompileModel3(JNIEnv *env, jobject obj, jlong coreAddr, jstring path, jstring device, jobject props)
+{
+    JNI_METHOD("CompileModel3",
+        std::string n_device = jstringToString(env, device);
+        std::string n_path = jstringToString(env, path);
+        AnyMap map;
+        for (const auto& it : javaMapToMap(env, props)) {
+            map[it.first] = it.second;
+        }
+
+        Core *core = (Core *)coreAddr;
+        CompiledModel *compiled_model = new CompiledModel();
+        *compiled_model = core->compile_model(n_path, n_device, map);
+
+        return (jlong)compiled_model;
+    )
+    return 0;
+}
+
 JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_GetProperty(JNIEnv *env, jobject obj, jlong coreAddr, jstring device, jstring name)
 {
     JNI_METHOD("GetProperty",
@@ -102,6 +150,26 @@ JNIEXPORT void JNICALL Java_org_intel_openvino_Core_SetProperty(JNIEnv *env, job
         }
         core->set_property(n_device, map);
     )
+}
+
+JNIEXPORT jobject JNICALL Java_org_intel_openvino_Core_GetAvailableDevices(JNIEnv *env, jobject obj, jlong coreAddr) {
+    JNI_METHOD("GetAvailableDevices",
+        Core *core = (Core *)coreAddr;
+        const std::vector<std::string>& devices_vec = core->get_available_devices();
+
+        jclass arrayClass = env->FindClass("java/util/ArrayList");
+        jmethodID arrayInit = env->GetMethodID(arrayClass, "<init>", "()V");
+        jobject arrayObj = env->NewObject(arrayClass, arrayInit);
+        jmethodID arrayAdd = env->GetMethodID(arrayClass, "add", "(Ljava/lang/Object;)Z");
+
+        for (const std::string &item : devices_vec) {
+            jstring device = env->NewStringUTF(item.c_str());
+            env->CallObjectMethod(arrayObj, arrayAdd, device);
+        }
+
+        return arrayObj;
+    )
+    return 0;
 }
 
 JNIEXPORT void JNICALL Java_org_intel_openvino_Core_delete(JNIEnv *, jobject, jlong addr)

--- a/modules/java_api/src/main/cpp/infer_request.cpp
+++ b/modules/java_api/src/main/cpp/infer_request.cpp
@@ -75,6 +75,17 @@ JNIEXPORT jlong JNICALL Java_org_intel_openvino_InferRequest_GetTensor(JNIEnv *e
     return 0;
 }
 
+JNIEXPORT void JNICALL Java_org_intel_openvino_InferRequest_SetTensor(JNIEnv *env, jobject obj, jlong addr, jstring tensorName, jlong tensorAddr)
+{
+    JNI_METHOD("SetTensor",
+        InferRequest *infer_request = (InferRequest *)addr;
+
+        std::string c_tensorName= jstringToString(env, tensorName);
+        const Tensor *tensor = (Tensor *)tensorAddr;
+        infer_request->set_tensor(c_tensorName, *tensor);
+    )
+}
+
 JNIEXPORT void JNICALL Java_org_intel_openvino_InferRequest_delete(JNIEnv *env, jobject obj, jlong addr)
 {
     jclass cls = env->GetObjectClass(obj);

--- a/modules/java_api/src/main/cpp/openvino.cpp
+++ b/modules/java_api/src/main/cpp/openvino.cpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2020-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+#include <jni.h> // JNI header provided by JDK
+#include "openvino/openvino.hpp"
+#include "openvino/core/graph_util.hpp"
+
+#include "openvino_java.hpp"
+#include "jni_common.hpp"
+
+using namespace ov;
+
+JNIEXPORT void JNICALL Java_org_intel_openvino_Openvino_SaveModel(JNIEnv *env, jobject, jlong modelAddr, jstring output_model, jboolean compress_to_fp16) {
+    JNI_METHOD("SaveModel",
+        std::shared_ptr<const Model> *model = reinterpret_cast<std::shared_ptr<const Model> *>(modelAddr);
+        const std::string n_output_model = jstringToString(env, output_model);
+        ov::save_model(*model, n_output_model, compress_to_fp16);
+    )
+
+}
+
+JNIEXPORT void JNICALL Java_org_intel_openvino_Openvino_serialize(JNIEnv *env, jobject obj, jlong modelAddr, jstring xmlPath, jstring binPath)
+{
+    JNI_METHOD("serialize",
+        std::string xml_path = jstringToString(env, xmlPath);
+        std::string bin_path = jstringToString(env, binPath);
+        std::shared_ptr<const Model> *model = reinterpret_cast<std::shared_ptr<const Model> *>(modelAddr);
+
+        serialize(*model, xml_path, bin_path);
+    )
+}

--- a/modules/java_api/src/main/cpp/openvino_java.hpp
+++ b/modules/java_api/src/main/cpp/openvino_java.hpp
@@ -133,8 +133,12 @@ extern "C"
     JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_ReadModel(JNIEnv *, jobject, jlong, jstring);
     JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_ReadModel1(JNIEnv *, jobject, jlong, jstring, jstring);
     JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_CompileModel(JNIEnv *, jobject, jlong, jlong, jstring);
+    JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_CompileModel1(JNIEnv *, jobject, jlong, jstring);
+    JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_CompileModel2(JNIEnv *, jobject, jlong, jstring, jstring);
+    JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_CompileModel3(JNIEnv *, jobject, jlong, jstring, jstring, jobject);
     JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_GetProperty(JNIEnv *, jobject, jlong, jstring, jstring);
     JNIEXPORT void JNICALL Java_org_intel_openvino_Core_SetProperty(JNIEnv *, jobject, jlong, jstring, jobject);
+    JNIEXPORT jobject JNICALL Java_org_intel_openvino_Core_GetAvailableDevices(JNIEnv *, jobject, jlong);
     JNIEXPORT void JNICALL Java_org_intel_openvino_Core_delete(JNIEnv *, jobject, jlong);
 
     // ov::Any
@@ -152,6 +156,8 @@ extern "C"
     // ov::CompiledModel
     JNIEXPORT jlong JNICALL Java_org_intel_openvino_CompiledModel_CreateInferRequest(JNIEnv *, jobject, jlong);
     JNIEXPORT void JNICALL Java_org_intel_openvino_CompiledModel_delete(JNIEnv *, jobject, jlong);
+    JNIEXPORT jobject JNICALL Java_org_intel_openvino_CompiledModel_GetInputs(JNIEnv *, jobject, jlong);
+    JNIEXPORT jobject JNICALL Java_org_intel_openvino_CompiledModel_GetOutputs(JNIEnv *, jobject, jlong);
 
     // ov::InferRequest
     JNIEXPORT void JNICALL Java_org_intel_openvino_InferRequest_Infer(JNIEnv *, jobject, jlong);
@@ -161,14 +167,17 @@ extern "C"
     JNIEXPORT void JNICALL Java_org_intel_openvino_InferRequest_SetOutputTensor(JNIEnv *, jobject, jlong, jlong);
     JNIEXPORT jlong JNICALL Java_org_intel_openvino_InferRequest_GetOutputTensor(JNIEnv *, jobject, jlong);
     JNIEXPORT jlong JNICALL Java_org_intel_openvino_InferRequest_GetTensor(JNIEnv *, jobject, jlong, jstring);
+    JNIEXPORT void JNICALL Java_org_intel_openvino_InferRequest_SetTensor(JNIEnv *, jobject, jlong, jstring, jlong);
     JNIEXPORT void JNICALL Java_org_intel_openvino_InferRequest_delete(JNIEnv *, jobject, jlong);
 
     // ov::Tensor
     JNIEXPORT jlong JNICALL Java_org_intel_openvino_Tensor_TensorCArray(JNIEnv *, jobject, jint, jintArray, jlong);
     JNIEXPORT jlong JNICALL Java_org_intel_openvino_Tensor_TensorFloat(JNIEnv *, jobject, jintArray, jfloatArray);
+    JNIEXPORT jlong JNICALL Java_org_intel_openvino_Tensor_TensorInt(JNIEnv *, jobject, jintArray, jintArray);
     JNIEXPORT jint JNICALL Java_org_intel_openvino_Tensor_GetSize(JNIEnv *, jobject, jlong);
     JNIEXPORT jintArray JNICALL Java_org_intel_openvino_Tensor_GetShape(JNIEnv *, jobject, jlong);
     JNIEXPORT jfloatArray JNICALL Java_org_intel_openvino_Tensor_asFloat(JNIEnv *, jobject, jlong);
+    JNIEXPORT jintArray JNICALL Java_org_intel_openvino_Tensor_asInt(JNIEnv *, jobject, jlong);
     JNIEXPORT void JNICALL Java_org_intel_openvino_Tensor_delete(JNIEnv *, jobject, jlong);
 
     // ov::PrePostProcessor
@@ -216,6 +225,7 @@ extern "C"
     // ov::Output<ov::Node>
     JNIEXPORT jstring JNICALL Java_org_intel_openvino_Output_GetAnyName(JNIEnv *, jobject, jlong);
     JNIEXPORT jintArray JNICALL Java_org_intel_openvino_Output_GetShape(JNIEnv *, jobject, jlong);
+    JNIEXPORT int JNICALL Java_org_intel_openvino_Output_GetElementType(JNIEnv *, jobject, jlong);
     JNIEXPORT void JNICALL Java_org_intel_openvino_Output_delete(JNIEnv *, jobject, jlong);
 
 #ifdef __cplusplus

--- a/modules/java_api/src/main/cpp/openvino_java.hpp
+++ b/modules/java_api/src/main/cpp/openvino_java.hpp
@@ -127,6 +127,10 @@ extern "C"
 
     /* -------------------------------------- API 2.0 ------------------------------------------*/
 
+    //ov
+    JNIEXPORT void JNICALL Java_org_intel_openvino_Openvino_SaveModel(JNIEnv *, jobject, jlong, jstring, jboolean);
+    JNIEXPORT void JNICALL Java_org_intel_openvino_Openvino_serialize(JNIEnv *, jobject, jlong, jstring, jstring);
+
     // ov::Core
     JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_GetCore(JNIEnv *, jobject);
     JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_GetCore1(JNIEnv *, jobject, jstring);
@@ -136,6 +140,7 @@ extern "C"
     JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_CompileModel1(JNIEnv *, jobject, jlong, jstring);
     JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_CompileModel2(JNIEnv *, jobject, jlong, jstring, jstring);
     JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_CompileModel3(JNIEnv *, jobject, jlong, jstring, jstring, jobject);
+    JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_CompileModel4(JNIEnv *, jobject, jlong, jlong, jstring, jobject);
     JNIEXPORT jlong JNICALL Java_org_intel_openvino_Core_GetProperty(JNIEnv *, jobject, jlong, jstring, jstring);
     JNIEXPORT void JNICALL Java_org_intel_openvino_Core_SetProperty(JNIEnv *, jobject, jlong, jstring, jobject);
     JNIEXPORT jobject JNICALL Java_org_intel_openvino_Core_GetAvailableDevices(JNIEnv *, jobject, jlong);

--- a/modules/java_api/src/main/cpp/output.cpp
+++ b/modules/java_api/src/main/cpp/output.cpp
@@ -36,6 +36,17 @@ JNIEXPORT jintArray JNICALL Java_org_intel_openvino_Output_GetShape(JNIEnv *env,
     return 0;
 }
 
+JNIEXPORT int JNICALL Java_org_intel_openvino_Output_GetElementType(JNIEnv *env, jobject obj, jlong addr) {
+    JNI_METHOD("GetElementType",
+        Output<Node> *output = (Output<Node> *)addr;
+
+        element::Type_t t_type = output->get_element_type();
+        jint type = static_cast<jint>(t_type);
+        return type;
+    )
+    return 0;
+}
+
 JNIEXPORT void JNICALL Java_org_intel_openvino_Output_delete(JNIEnv *, jobject, jlong addr)
 {
     Output<Node> *obj = (Output<Node> *)addr;

--- a/modules/java_api/src/main/cpp/tensor.cpp
+++ b/modules/java_api/src/main/cpp/tensor.cpp
@@ -55,6 +55,20 @@ JNIEXPORT jlong JNICALL Java_org_intel_openvino_Tensor_TensorFloat(JNIEnv *env, 
     return 0;
 }
 
+JNIEXPORT jlong JNICALL Java_org_intel_openvino_Tensor_TensorInt(JNIEnv *env, jobject, jintArray shape, jintArray data)
+{
+    JNI_METHOD(
+        "TensorInt",
+        Shape input_shape = jintArrayToVector(env, shape);
+        Tensor *ov_tensor = new Tensor(element::i32, input_shape);
+
+        env->GetIntArrayRegion(data, 0, ov_tensor->get_size(), (jint*)ov_tensor->data());
+
+        return (jlong)ov_tensor;
+    );
+    return 0;
+}
+
 JNIEXPORT jint JNICALL Java_org_intel_openvino_Tensor_GetSize(JNIEnv *env, jobject, jlong addr)
 {
     JNI_METHOD(
@@ -104,6 +118,29 @@ JNIEXPORT jfloatArray JNICALL Java_org_intel_openvino_Tensor_asFloat(JNIEnv *env
             arr[i] = data[i];
 
         env->ReleaseFloatArrayElements(result, arr, 0);
+        return result;
+    )
+    return 0;
+}
+
+JNIEXPORT jintArray JNICALL Java_org_intel_openvino_Tensor_asInt(JNIEnv *env, jobject, jlong addr)
+{
+    JNI_METHOD(
+        "asInt",
+        Tensor *ov_tensor = (Tensor *)addr;
+
+        size_t size = ov_tensor->get_size();
+        const int *data = ov_tensor->data<const int>();
+
+        jintArray result = env->NewIntArray(size);
+        if (!result) {
+            throw std::runtime_error("Out of memory!");
+        } jint *arr = env->GetIntArrayElements(result, nullptr);
+
+        for (size_t i = 0; i < size; ++i)
+            arr[i] = data[i];
+
+        env->ReleaseIntArrayElements(result, arr, 0);
         return result;
     )
     return 0;

--- a/modules/java_api/src/main/java/org/intel/openvino/CompiledModel.java
+++ b/modules/java_api/src/main/java/org/intel/openvino/CompiledModel.java
@@ -3,6 +3,8 @@
 
 package org.intel.openvino;
 
+import java.util.List;
+
 /**
  * This class represents a compiled model.
  *
@@ -25,8 +27,32 @@ public class CompiledModel extends Wrapper {
         return new InferRequest(CreateInferRequest(nativeObj));
     }
 
+    /**
+     * Gets all inputs of a compiled model. They contain information about input tensors such as
+     * tensor shape, names, and element type.
+     *
+     * @return List of model inputs.
+     */
+    public List<Output> inputs() {
+        return GetInputs(nativeObj);
+    }
+
+    /**
+     * Gets all outputs of a compiled model. They contain information about output tensors such as
+     * tensor shape, name, and element type.
+     *
+     * @return List of model outputs.
+     */
+    public List<Output> outputs() {
+        return GetOutputs(nativeObj);
+    }
+
     /*----------------------------------- native methods -----------------------------------*/
     private static native long CreateInferRequest(long addr);
+
+    private static native List<Output> GetInputs(long addr);
+
+    private static native List<Output> GetOutputs(long addr);
 
     @Override
     protected native void delete(long nativeObj);

--- a/modules/java_api/src/main/java/org/intel/openvino/Core.java
+++ b/modules/java_api/src/main/java/org/intel/openvino/Core.java
@@ -3,6 +3,7 @@
 
 package org.intel.openvino;
 
+import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -56,6 +57,48 @@ public class Core extends Wrapper {
     }
 
     /**
+     * Reads and loads a compiled model from the IR/ONNX/PDPD file to the default OpenVINO device
+     * selected by the AUTO plugin.
+     *
+     * @param path Path to a model.
+     * @return A compiled model.
+     */
+    public CompiledModel compile_model(final String path) {
+        return new CompiledModel(CompileModel1(nativeObj, path));
+    }
+
+    /**
+     * Reads and loads a compiled model from the IR/ONNX/PDPD file.
+     *
+     * <p>This can be more efficient, especially when caching is enabled and a cached model is
+     * available, than using the read_model followed by compile_model flow.
+     *
+     * @param path Path to a model.
+     * @param device Name of a device to load a model to.
+     * @return A compiled model.
+     */
+    public CompiledModel compile_model(final String path, final String device) {
+        return new CompiledModel(CompileModel2(nativeObj, path, device));
+    }
+
+    /**
+     * Reads and loads a compiled model from the IR/ONNX/PDPD file.
+     *
+     * <p>This can be more efficient, especially when caching is enabled and a cached model is
+     * available, than using the read_model followed by compile_model flow.
+     *
+     * @param path Path to a model.
+     * @param device Name of a device to load a model to.
+     * @param properties Map of pairs: (property name, property value) relevant only for this load
+     *     operation.
+     * @return A compiled model.
+     */
+    public CompiledModel compile_model(
+            final String path, final String device, final Map<String, String> properties) {
+        return new CompiledModel(CompileModel3(nativeObj, path, device, properties));
+    }
+
+    /**
      * Creates a compiled model from a source model object.
      *
      * <p>Users can create as many compiled models as they need and use them simultaneously (up to
@@ -93,6 +136,19 @@ public class Core extends Wrapper {
         SetProperty(nativeObj, device, prop);
     }
 
+    /**
+     * Returns the devices available for inference.
+     *
+     * @return List of devices.
+     *     <p>The devices are returned as { CPU, GPU.0, GPU.1, GNA }. If there is more than one
+     *     device of a specific type, they are enumerated with the .# suffix. Such enumerated device
+     *     can later be used as a device name in all Core methods like {@link Core#compile_model},
+     *     {@link Core#set_property} and so on.
+     */
+    public List<String> get_available_devices() {
+        return GetAvailableDevices(nativeObj);
+    }
+
     /*----------------------------------- native methods -----------------------------------*/
 
     private static native long GetCore();
@@ -106,10 +162,23 @@ public class Core extends Wrapper {
 
     private static native long CompileModel(long core, long net, final String device);
 
+    private static native long CompileModel1(long core, final String device);
+
+    private static native long CompileModel2(
+            long core, final String modelPath, final String device);
+
+    private static native long CompileModel3(
+            long core,
+            final String modelPath,
+            final String device,
+            final Map<String, String> props);
+
     private static native long GetProperty(long core, final String device, final String name);
 
     private static native void SetProperty(
             long core, final String device, final Map<String, String> prop);
+
+    private static native List<String> GetAvailableDevices(long core);
 
     @Override
     protected native void delete(long nativeObj);

--- a/modules/java_api/src/main/java/org/intel/openvino/Core.java
+++ b/modules/java_api/src/main/java/org/intel/openvino/Core.java
@@ -113,6 +113,23 @@ public class Core extends Wrapper {
     }
 
     /**
+     * Creates a compiled model from a source model object.
+     *
+     * <p>Users can create as many compiled models as they need and use them simultaneously (up to
+     * the limitation of the hardware resources).
+     *
+     * @param model Model object acquired from {@link Core#read_model}.
+     * @param device Name of a device to load a model to.
+     * @param properties properties – Map of pairs: (property name, property value) relevant only
+     *     for this load operation.
+     * @return A compiled model.
+     */
+    public CompiledModel compile_model(
+            Model model, final String device, final Map<String, String> properties) {
+        return new CompiledModel(CompileModel4(nativeObj, model.getNativeObjAddr(), device, properties));
+    }
+
+    /**
      * Gets properties related to device behaviour.
      *
      * <p>The method extracts information that can be set via the set_property method.
@@ -166,6 +183,9 @@ public class Core extends Wrapper {
 
     private static native long CompileModel2(
             long core, final String modelPath, final String device);
+
+    private static native long CompileModel4(
+            long core, long net, final String device, final Map<String, String> properties);
 
     private static native long CompileModel3(
             long core,

--- a/modules/java_api/src/main/java/org/intel/openvino/InferRequest.java
+++ b/modules/java_api/src/main/java/org/intel/openvino/InferRequest.java
@@ -80,9 +80,19 @@ public class InferRequest extends Wrapper {
     }
 
     /**
-     * Detele the native object to release resources.
+     * Sets an input/output tensor to infer on.
      *
-     * <p>This mehtod is protected from double deallocation
+     * @param tensorName Name of the tensor.
+     * @param tensor The tensor to set.
+     */
+    public void set_tensor(String tensorName, Tensor tensor) {
+        SetTensor(nativeObj, tensorName, tensor.nativeObj);
+    }
+
+    /**
+     * Delete the native object to release resources.
+     *
+     * <p>This method is protected from double deallocation
      */
     public void release() {
         delete(nativeObj);
@@ -103,6 +113,8 @@ public class InferRequest extends Wrapper {
     private static native long GetOutputTensor(long addr);
 
     private static native long GetTensor(long addr, String tensorName);
+
+    private static native void SetTensor(long addr, String tensorName, long tensor);
 
     @Override
     protected native void delete(long nativeObj);

--- a/modules/java_api/src/main/java/org/intel/openvino/Openvino.java
+++ b/modules/java_api/src/main/java/org/intel/openvino/Openvino.java
@@ -1,0 +1,49 @@
+// Copyright (C) 2020-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+package org.intel.openvino;
+
+/** OpenVINO Runtime utility methods. */
+public class Openvino extends Wrapper {
+
+    protected Openvino(long addr) {
+        super(addr);
+    }
+
+    /**
+     * Save model into IR files (xml and bin).
+     *
+     * <p>This method saves a model to IR applying all necessary transformations that are usually
+     * applied in model conversion flow provided by mo tool. Particularly, floating point weights
+     * are compressed to FP16, debug information in model nodes are cleaned up, etc.
+     *
+     * @param model Model which will be converted to IR representation.
+     * @param outputModel Path to output model file.
+     * @param compressToFP16 Whether to compress floating point weights to FP16.
+     */
+    public static void save_model(Model model, final String outputModel, boolean compressToFP16) {
+        SaveModel(model.nativeObj, outputModel, compressToFP16);
+    }
+
+    /**
+     * Serialize given model into IR.
+     *
+     * <p>The generated .xml and .bin files will be saved into provided paths.This method serializes
+     * model "as-is" that means no weights compression is applied. It is recommended to use {@link
+     * Openvino#save_model} function in all cases when it is not related to debugging.
+     *
+     * @param model Model which will be converted to IR representation.
+     * @param xmlPath Path where .xml file will be saved.
+     * @param binPath Path where .bin file will be saved.
+     */
+    public static void serialize(Model model, final String xmlPath, final String binPath) {
+        serialize(model.nativeObj, xmlPath, binPath);
+    }
+
+    /*----------------------------------- native methods -----------------------------------*/
+    private static native void SaveModel(
+            long addr, final String outputModel, boolean compressToFP16);
+
+    private static native void serialize(
+            long modelAddr, final String xmlPath, final String binPath);
+}

--- a/modules/java_api/src/main/java/org/intel/openvino/Output.java
+++ b/modules/java_api/src/main/java/org/intel/openvino/Output.java
@@ -20,10 +20,17 @@ public class Output extends Wrapper {
         return GetShape(nativeObj);
     }
 
+    /** Returns the element type of the output referred to by this output handle. */
+    public ElementType get_element_type() {
+        return ElementType.valueOf(GetElementType(nativeObj));
+    }
+
     /*----------------------------------- native methods -----------------------------------*/
     private static native String GetAnyName(long addr);
 
     private static native int[] GetShape(long addr);
+
+    private static native int GetElementType(long addr);
 
     @Override
     protected native void delete(long nativeObj);

--- a/modules/java_api/src/main/java/org/intel/openvino/Tensor.java
+++ b/modules/java_api/src/main/java/org/intel/openvino/Tensor.java
@@ -23,6 +23,16 @@ public class Tensor extends Wrapper {
     }
 
     /**
+     * Constructs an Integer {@link Tensor} from the given int array.
+     *
+     * @param dims shape of the tensor
+     * @param data an integer array containing the tensor data
+     */
+    public Tensor(int[] dims, int[] data) {
+        super(TensorInt(dims, data));
+    }
+
+    /**
      * Returns the total number of elements (a product of all the dims or 1 for scalar)
      *
      * @return The total number of elements
@@ -41,14 +51,23 @@ public class Tensor extends Wrapper {
         return asFloat(nativeObj);
     }
 
+    /** Returns the tensor data as an integer array. */
+    public int[] as_int() {
+        return asInt(nativeObj);
+    }
+
     /*----------------------------------- native methods -----------------------------------*/
     private static native long TensorCArray(int type, int[] shape, long cArray);
 
     private static native long TensorFloat(int[] shape, float[] data);
 
+    private static native long TensorInt(int[] shape, int[] data);
+
     private static native int[] GetShape(long addr);
 
     private static native float[] asFloat(long addr);
+
+    private static native int[] asInt(long addr);
 
     private static native int GetSize(long addr);
 

--- a/modules/java_api/src/test/java/org/intel/openvino/CompiledModelTests.java
+++ b/modules/java_api/src/test/java/org/intel/openvino/CompiledModelTests.java
@@ -1,0 +1,42 @@
+package org.intel.openvino;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+public class CompiledModelTests extends OVTest {
+
+    CompiledModel model;
+
+    @Before
+    public void init() {
+        Core core = new Core();
+        model = core.compile_model(modelXml, device);
+    }
+
+    @Test
+    public void testInputs() {
+        List<Output> inputs = model.inputs();
+
+        assertEquals("data", inputs.get(0).get_any_name());
+        assertEquals(ElementType.f32, inputs.get(0).get_element_type());
+
+        int[] shape = new int[] {1, 3, 32, 32};
+        assertArrayEquals("Shape", shape, inputs.get(0).get_shape());
+    }
+
+    @Test
+    public void testOutputs() {
+        List<Output> outputs = model.outputs();
+
+        assertEquals("fc_out", outputs.get(0).get_any_name());
+        assertEquals(ElementType.f32, outputs.get(0).get_element_type());
+
+        int[] shape = new int[] {1, 10};
+        assertArrayEquals("Shape", shape, outputs.get(0).get_shape());
+    }
+}

--- a/modules/java_api/src/test/java/org/intel/openvino/CoreTests.java
+++ b/modules/java_api/src/test/java/org/intel/openvino/CoreTests.java
@@ -17,6 +17,26 @@ public class CoreTests extends OVTest {
     }
 
     @Test
+    public void testCompileModelFromFileDeviceAuto() {
+        CompiledModel model = core.compile_model(modelXml);
+        assertTrue(model instanceof CompiledModel);
+    }
+
+    @Test
+    public void testCompileModelFromFile() {
+        CompiledModel model = core.compile_model(modelXml, device);
+        assertTrue(model instanceof CompiledModel);
+    }
+
+    @Test
+    public void testCompileModelWithProps() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("INFERENCE_NUM_THREADS", "1");
+        CompiledModel model = core.compile_model(modelXml, device, properties);
+        assertTrue(model instanceof CompiledModel);
+    }
+
+    @Test
     public void testReadNetworkXmlOnly() {
         Model net = core.read_model(modelXml);
         PrePostProcessor p = new PrePostProcessor(net);

--- a/modules/java_api/src/test/java/org/intel/openvino/ModelTests.java
+++ b/modules/java_api/src/test/java/org/intel/openvino/ModelTests.java
@@ -32,6 +32,12 @@ public class ModelTests extends OVTest {
     }
 
     @Test
+    public void testOutputType() {
+        Output output = net.output();
+        assertEquals("Output element type", ElementType.f32, output.get_element_type());
+    }
+
+    @Test
     public void testGetShape() {
         ArrayList<Output> outputs = net.outputs();
         int[] ref = new int[] {1, 10};

--- a/modules/java_api/src/test/java/org/intel/openvino/TensorTests.java
+++ b/modules/java_api/src/test/java/org/intel/openvino/TensorTests.java
@@ -4,6 +4,8 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+
 public class TensorTests extends OVTest {
     int[] dimsArr = {1, 3, 2, 2};
     float[] data = {0.0f, 1.1f, 2.2f, 3.3f, 4.4f, 5.5f, 6.6f, 7.7f, 8.8f, 9.9f, 1.1f, 2.2f};
@@ -14,5 +16,18 @@ public class TensorTests extends OVTest {
 
         assertArrayEquals(tensor.get_shape(), dimsArr);
         assertArrayEquals(tensor.data(), data, 0.0f);
+    }
+
+    @Test
+    public void testGetTensorFromInt() {
+        int size = Arrays.stream(dimsArr).reduce((i, j) -> i * j).orElse(1);
+        int[] inputData = new int[size];
+        Arrays.fill(inputData, 1);
+
+        Tensor tensor = new Tensor(dimsArr, inputData);
+
+        assertArrayEquals(dimsArr, tensor.get_shape());
+        assertArrayEquals(inputData, tensor.as_int());
+        assertEquals(size, tensor.get_size());
     }
 }


### PR DESCRIPTION
## Details

This PR adds JNI wrappers to the OpenVINO Java API 2.0. The following method bindings are included: 

* Read and compile a model directly from the model path using Core.compileModel(modelPath)

    | ov::Core | Core |
    |----------|------|
    | compile_model(model_path, device_name, properties={}) | compile_model(modelPath, deviceName, properties) |


* List devices available for inference

    | ov::Core | Core |
    |----------|------|
    | get_available_devices() | get_available_devices() |

* List the input and output tensor information of a CompiledModel. Returns the tensor shape, name and element type of each input/output tensor. 

    | ov::CompiledModel | CompiledModel|
    |----------|------|
    | inputs() | inputs() |
    | outputs() | outputs() |

* Set input/output tensors to infer on by tensor name when the model has several input/output tensors

    | ov::InferRequest| InferRequest |
    |----------|------|
    | set_tensor(tensor_name, tensor) | set_tensor(tensorName, tensor) |

* Create integer tensors and extract data as an int array

    | ov::Tensor| Tensor|
    |----------|------|
    | Tensor(shape, data) | Tensor(shape, data) |
    | data() | as_int() |

* Save model into IR format from memory

    | | |
    |----------|------|
    | ov::serialize(model, xml_path, bin_path) | Openvino.serialize(model, xmlPath, binPath) |
    | ov::save_model(model, output_model, compress_to_fp16) | Openvino.save_model(model, outputModel, compressToFP16) |