### PR TITLE
[NVIDIA] Fix for windows debug build

### DIFF
--- a/modules/nvidia_plugin/CMakeLists.txt
+++ b/modules/nvidia_plugin/CMakeLists.txt
@@ -103,6 +103,11 @@ find_library(CUTENSOR_PATH
 get_filename_component(CUTENSOR_INCLUDE_DIR "${CUTENSOR_PATH}" DIRECTORY)
 get_filename_component(CUTENSOR_INCLUDE_DIR "${CUTENSOR_INCLUDE_DIR}/../../include" REALPATH)
 
+if(WIN32)
+    string(REPLACE "-Zi" "-Z7" CMAKE_CUDA_FLAGS_DEBUG "${CMAKE_CUDA_FLAGS_DEBUG}")
+    message("-- [nvidia_gpu] CMAKE_CUDA_FLAGS_DEBUG ${CMAKE_CUDA_FLAGS_DEBUG}")
+endif()
+
 message("-- [nvidia_gpu] CUTENSOR_PATH ${CUTENSOR_PATH}")
 message("-- [nvidia_gpu] CUTENSOR_INCLUDE_DIR ${CUTENSOR_INCLUDE_DIR}")
 message("-- [nvidia_gpu] CUDNN_PATH ${CUDNN_PATH}")


### PR DESCRIPTION
### Details:
- *Fix problem with windows debug build:  if multiple CL.EXE write to the same .PDB file, please use /FS*

### Ticket:
- 115171