### PR TITLE
Fix OpenCV path for non-Linux platforms

### DIFF
--- a/modules/java_api/samples/face_detection_java_sample/build.gradle
+++ b/modules/java_api/samples/face_detection_java_sample/build.gradle
@@ -3,9 +3,22 @@ plugins {
     id 'application'
 }
 
+import org.gradle.internal.os.OperatingSystem
+
 def opencv_path = System.getenv('OpenCV_DIR')
 def opencv_build_path = new File(opencv_path + '/bin')
 def opencv_install_path = new File(opencv_path + '/share/java')
+
+if (OperatingSystem.current().isLinux()) {
+    opencv_build_path = new File(opencv_path + '/bin')
+    opencv_install_path = new File(opencv_path + '/share/java/opencv4')
+} else if (OperatingSystem.current().isMacOsX()) {
+    opencv_build_path = new File(opencv_path + '/share/java/opencv4')
+    opencv_install_path = new File(opencv_path + '/share/OpenCV/java')
+} else if (OperatingSystem.current().isWindows()) {
+    opencv_build_path = new File(opencv_path + '/java')
+    opencv_install_path = new File(opencv_path + '/java')
+}
 
 if (opencv_build_path.exists() ) {
   opencv_path = opencv_build_path

--- a/modules/java_api/samples/face_detection_kotlin_sample/build.gradle
+++ b/modules/java_api/samples/face_detection_kotlin_sample/build.gradle
@@ -6,9 +6,22 @@ java {
     toolchain.languageVersion.set(JavaLanguageVersion.of(11))
 }
 
+import org.gradle.internal.os.OperatingSystem
+
 def opencv_path = System.getenv('OpenCV_DIR')
 def opencv_build_path = new File(opencv_path + '/bin')
 def opencv_install_path = new File(opencv_path + '/share/java')
+
+if (OperatingSystem.current().isLinux()) {
+    opencv_build_path = new File(opencv_path + '/bin')
+    opencv_install_path = new File(opencv_path + '/share/java/opencv4')
+} else if (OperatingSystem.current().isMacOsX()) {
+    opencv_build_path = new File(opencv_path + '/share/java/opencv4')
+    opencv_install_path = new File(opencv_path + '/share/OpenCV/java')
+} else if (OperatingSystem.current().isWindows()) {
+    opencv_build_path = new File(opencv_path + '/java')
+    opencv_install_path = new File(opencv_path + '/java')
+}
 
 if (opencv_build_path.exists() ) {
     opencv_path = opencv_build_path

--- a/modules/java_api/samples/face_detection_sample_async/build.gradle
+++ b/modules/java_api/samples/face_detection_sample_async/build.gradle
@@ -3,9 +3,22 @@ plugins {
     id 'application'
 }
 
+import org.gradle.internal.os.OperatingSystem
+
 def opencv_path = System.getenv('OpenCV_DIR')
 def opencv_build_path = new File(opencv_path + '/bin')
 def opencv_install_path = new File(opencv_path + '/share/java')
+
+if (OperatingSystem.current().isLinux()) {
+    opencv_build_path = new File(opencv_path + '/bin')
+    opencv_install_path = new File(opencv_path + '/share/java/opencv4')
+} else if (OperatingSystem.current().isMacOsX()) {
+    opencv_build_path = new File(opencv_path + '/share/java/opencv4')
+    opencv_install_path = new File(opencv_path + '/share/OpenCV/java')
+} else if (OperatingSystem.current().isWindows()) {
+    opencv_build_path = new File(opencv_path + '/java')
+    opencv_install_path = new File(opencv_path + '/java')
+}
 
 if (opencv_build_path.exists() ) {
   opencv_path = opencv_build_path


### PR DESCRIPTION
## Details

Currently, the build scripts for the Java sample applications resolve the OpenCV jar location for Linux installations correctly based on the `OpenCV_DIR` env variable but fail on Windows platforms. 
This PR updates the build scripts to locate the jar based on the OS.