### PR TITLE
Remove some builder functions usage

### DIFF
--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
@@ -99,7 +99,7 @@ protected:
         if (filterWeights.empty()) {
                 ov::Tensor random_tensor(type, filterWeightsShape);
                 ov::test::utils::fill_tensor_random(random_tensor);
-                auto constant = std::make_shared<ov::op::v0::Constant>(random_tensor);
+                filterWeightsNode = std::make_shared<ov::op::v0::Constant>(random_tensor);
         } else {
             filterWeightsNode = std::make_shared<ov::op::v0::Constant>(type, filterWeightsShape, filterWeights);
         }

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
@@ -92,12 +92,17 @@ protected:
                                                           bool addBiases = false,
                                                           const std::vector<float> &filterWeights = {},
                                                           const std::vector<float> &biasesWeights = {}) {
-        bool randomFilterWeights = filterWeights.empty();
         auto shape = in.get_shape();
         std::vector<size_t> filterWeightsShape = {shape[1], numOutChannels};
         filterWeightsShape.insert(filterWeightsShape.end(), filterSize.begin(), filterSize.end());
-        auto filterWeightsNode =
-            ngraph::builder::makeConstant(type, filterWeightsShape, filterWeights, randomFilterWeights);
+        std::shared_ptr<ov::op::v0::Constant> filterWeightsNode;
+        if (filterWeights.empty()) {
+                ov::Tensor random_tensor(type, filterWeightsShape);
+                ov::test::utils::fill_tensor_random(random_tensor);
+                auto constant = std::make_shared<ov::op::v0::Constant>(random_tensor);
+        } else {
+            filterWeightsNode = std::make_shared<ov::op::v0::Constant>(type, filterWeightsShape, filterWeights);
+        }
 
         return makeConvolutionBackpropData(in,
                                            filterWeightsNode,
@@ -149,10 +154,9 @@ protected:
         std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, outputPad) =
             convBackpropDataParams;
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape)))};
+        ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
 
-        auto outputShapeNode =
-            ngraph::builder::makeConstant(ov::element::Type_t::i64, {outputShapeData.size()}, outputShapeData);
+        auto outputShapeNode = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::i64, ov::Shape{outputShapeData.size()}, outputShapeData);
         auto paramOuts =
             ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(params));
         auto convBackpropData = std::dynamic_pointer_cast<ngraph::opset1::ConvolutionBackpropData>(

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data.cpp
@@ -149,7 +149,8 @@ protected:
         std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, outputPad) =
             convBackpropDataParams;
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
+        ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape)))};
+
         auto outputShapeNode =
             ngraph::builder::makeConstant(ov::element::Type_t::i64, {outputShapeData.size()}, outputShapeData);
         auto paramOuts =

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data_add.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data_add.cpp
@@ -94,9 +94,15 @@ protected:
         auto shape = in.get_shape();
         std::vector<size_t> filterWeightsShape = {shape[1], numOutChannels};
         filterWeightsShape.insert(filterWeightsShape.end(), filterSize.begin(), filterSize.end());
-        auto filterWeightsNode =
-            ngraph::builder::makeConstant(type, filterWeightsShape, filterWeights, randomFilterWeights);
 
+        std::shared_ptr<ov::Node> filterWeightsNode;
+        if (filterWeights.empty()) {
+                ov::Tensor random_tensor(type, filterWeightsShape);
+                ov::test::utils::fill_tensor_random(random_tensor);
+                filterWeightsNode = std::make_shared<ov::op::v0::Constant>(random_tensor);
+        } else {
+            filterWeightsNode = std::make_shared<ov::op::v0::Constant>(type, filterWeightsShape, filterWeights);
+        }
         return makeConvolutionBackpropData(in,
                                            filterWeightsNode,
                                            output,
@@ -147,10 +153,9 @@ protected:
         std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, outputPad) =
             convBackpropDataParams;
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape)))};
+        ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
 
-        auto outputShapeNode =
-            ngraph::builder::makeConstant(ov::element::Type_t::i64, {outputShapeData.size()}, outputShapeData);
+        auto outputShapeNode = std::make_shared<ov::op::v0::Constant>(ov::element::Type_t::i64, ov::Shape{outputShapeData.size()}, outputShapeData);
         auto paramOuts =
             ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(params));
         auto convBackpropData = std::dynamic_pointer_cast<ngraph::opset1::ConvolutionBackpropData>(
@@ -164,8 +169,11 @@ protected:
                                         dilation,
                                         padType,
                                         convOutChannels));
-        auto addConstant = ngraph::builder::makeConstant(ngPrc, outputShapeData, outputShapeData, true);
-        auto add = ngraph::builder::makeEltwise(convBackpropData, addConstant, ngraph::helpers::EltwiseTypes::ADD);
+
+        ov::Tensor random_tensor(ngPrc, outputShapeData);
+        ov::test::utils::fill_tensor_random(random_tensor);
+        auto addConstant = std::make_shared<ov::op::v0::Constant>(random_tensor);
+        auto add = std::make_shared<ov::op::v1::Add>(convBackpropData, addConstant);
         ov::ResultVector results{std::make_shared<ngraph::opset1::Result>(add)};
         function = std::make_shared<ngraph::Function>(results, params, "convolutionBackpropData");
     }

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data_add.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data_add.cpp
@@ -90,7 +90,6 @@ protected:
                                                           bool addBiases = false,
                                                           const std::vector<float> &filterWeights = {},
                                                           const std::vector<float> &biasesWeights = {}) {
-        bool randomFilterWeights = filterWeights.empty();
         auto shape = in.get_shape();
         std::vector<size_t> filterWeightsShape = {shape[1], numOutChannels};
         filterWeightsShape.insert(filterWeightsShape.end(), filterSize.begin(), filterSize.end());

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data_add.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convolution_backprop_data_add.cpp
@@ -147,7 +147,8 @@ protected:
         std::tie(kernel, stride, padBegin, padEnd, dilation, convOutChannels, padType, outputPad) =
             convBackpropDataParams;
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
+        ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape)))};
+
         auto outputShapeNode =
             ngraph::builder::makeConstant(ov::element::Type_t::i64, {outputShapeData.size()}, outputShapeData);
         auto paramOuts =

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convolution_biasadd_activation.hpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convolution_biasadd_activation.hpp
@@ -163,7 +163,8 @@ protected:
         }
 
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        auto params = ngraph::builder::makeParams(ngPrc, {inputShape});
+        ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape)))};
+
         auto paramOuts =
             ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(params));
         std::vector<float> filter_weights;

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convolution_biasadd_activation.hpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convolution_biasadd_activation.hpp
@@ -122,13 +122,13 @@ protected:
         }
         auto biasLayer = std::make_shared<ov::op::v0::Constant>(ngNetPrc, biasShape);
 
-        auto biasAddLayer = ngraph::builder::makeEltwise(convLayer, biasLayer, ngraph::helpers::EltwiseTypes::ADD);
+        auto biasAddLayer = std::make_shared<ov::op::v1::Add>(convLayer, biasLayer);
 
         std::shared_ptr<ov::Node> lastNode;
         if constexpr (HasAddNode) {
             auto addParam = std::make_shared<ngraph::opset1::Parameter>(ngNetPrc, convLayer->get_output_shape(0));
             params.push_back(addParam);
-            auto addLayer = ngraph::builder::makeEltwise(biasAddLayer, addParam, ngraph::helpers::EltwiseTypes::ADD);
+            auto addLayer = std::make_shared<ov::op::v1::Add>(biasAddLayer, addParam);
             lastNode = addLayer;
         } else {
             lastNode = biasAddLayer;
@@ -163,7 +163,7 @@ protected:
         }
 
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape)))};
+        ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShape))};
 
         auto paramOuts =
             ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(params));

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convolution_biasadd_activation.hpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convolution_biasadd_activation.hpp
@@ -120,8 +120,7 @@ protected:
         for (size_t i = 0; i < biasShape.size(); ++i) {
             if (i != channel_dim_index) biasShape[i] = 1;
         }
-        auto biasLayer =
-            ngraph::builder::makeInputLayer(ngNetPrc, ngraph::helpers::InputLayerType::CONSTANT, biasShape);
+        auto biasLayer = std::make_shared<ov::op::v0::Constant>(ngNetPrc, biasShape);
 
         auto biasAddLayer = ngraph::builder::makeEltwise(convLayer, biasLayer, ngraph::helpers::EltwiseTypes::ADD);
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/cuda_eltwise.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/cuda_eltwise.cpp
@@ -208,7 +208,7 @@ void CudaEltwiseLayerTest::SetUp() {
 
     init_input_shapes(shapes);
 
-    auto parameters = ngraph::builder::makeDynamicParams(netType, {inputDynamicShapes.front()});
+    ov::ParameterVector parameters {std::make_shared<ov::op::v0::Parameter>(netType, inputDynamicShapes.front)};
 
     ov::PartialShape shape_input_secondary;
     switch (opType) {
@@ -229,8 +229,9 @@ void CudaEltwiseLayerTest::SetUp() {
 
     std::shared_ptr<ngraph::Node> secondaryInput;
     if (secondaryInputType == ngraph::helpers::InputLayerType::PARAMETER) {
-        secondaryInput = ngraph::builder::makeDynamicParams(netType, {shape_input_secondary}).front();
-        parameters.push_back(std::dynamic_pointer_cast<ngraph::opset3::Parameter>(secondaryInput));
+        auto input = std::make_shared<ov::op::v0::Parameter>(netType, shape_input_secondary);
+        secondaryInput = input;
+        parameters.push_back(input);
     } else {
         constexpr bool is_random = true;
         ov::Shape shape = inputDynamicShapes.back().get_max_shape();

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/cuda_eltwise.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/cuda_eltwise.cpp
@@ -208,7 +208,7 @@ void CudaEltwiseLayerTest::SetUp() {
 
     init_input_shapes(shapes);
 
-    ov::ParameterVector parameters {std::make_shared<ov::op::v0::Parameter>(netType, inputDynamicShapes.front)};
+    ov::ParameterVector parameters {std::make_shared<ov::op::v0::Parameter>(netType, inputDynamicShapes.front())};
 
     ov::PartialShape shape_input_secondary;
     switch (opType) {
@@ -247,15 +247,17 @@ void CudaEltwiseLayerTest::SetUp() {
                         [](const auto& value) { return static_cast<int>(static_cast<float>(value)) == 0; },
                         1);
                 }
-                secondaryInput = ngraph::builder::makeConstant(netType, shape, data);
+                secondaryInput = std::make_shared<ov::op::v0::Constant>(netType, shape, data);
                 break;
             }
             case ngraph::helpers::EltwiseTypes::POWER: {
-                secondaryInput = ngraph::builder::makeConstant<float>(netType, shape, {}, is_random, 3);
+                ov::Tensor random_tensor(netType, shape);
+                ov::test::utils::fill_tensor_random(random_tensor, 3, -3);
+                secondaryInput = std::make_shared<ov::op::v0::Constant>(random_tensor);
                 break;
             }
             default: {
-                secondaryInput = ngraph::builder::makeConstant<float>(netType, shape, data);
+                secondaryInput = std::make_shared<ov::op::v0::Constant>(netType, shape, data);
             }
         }
     }

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/fully_connected.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/fully_connected.cpp
@@ -83,7 +83,7 @@ protected:
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        auto params = ngraph::builder::makeParams(ngPrc, {shapeRelatedParams.input1.first});
+        ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape{shapeRelatedParams.input1.first})};
 
         std::shared_ptr<ov::Node> secondaryInput;
         if (secondaryInputType == ngraph::helpers::InputLayerType::PARAMETER) {
@@ -190,8 +190,9 @@ protected:
         configuration.insert(additionalConfig.begin(), additionalConfig.end());
 
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        auto params = ngraph::builder::makeParams(
-            ngPrc, {shapeRelatedParams.matmul1_input1.first, shapeRelatedParams.matmul2_input1.first});
+        ov::ParameterVector params;
+        params.push_back(std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(shapeRelatedParams.matmul1_input1.first)));
+        params.push_back(std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(shapeRelatedParams.matmul2_input1.first)));
 
         std::shared_ptr<ov::Node> matmul0SecondaryInput;
         if (secondaryInputType == ngraph::helpers::InputLayerType::PARAMETER) {

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/fully_connected.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/fully_connected.cpp
@@ -3,7 +3,6 @@
 //
 
 #include <cuda_test_constants.hpp>
-#include <ngraph_functions/builders.hpp>
 #include <vector>
 
 #include "finite_comparer.hpp"
@@ -95,10 +94,8 @@ protected:
         auto thirdInput = std::make_shared<ov::op::v0::Constant>(ngPrc, shapeRelatedParams.input3);
         auto paramOuts =
             ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(params));
-        auto MatMul = std::dynamic_pointer_cast<ov::op::v0::MatMul>(ngraph::builder::makeMatMul(
-            paramOuts[0], secondaryInput, shapeRelatedParams.input1.second, shapeRelatedParams.input2.second));
-        auto Add = std::dynamic_pointer_cast<ov::op::v1::Add>(
-            ngraph::builder::makeEltwise(MatMul, thirdInput, ngraph::helpers::EltwiseTypes::ADD));
+        auto MatMul = std::make_shared<ov::op::v0::MatMul>(paramOuts[0], secondaryInput, shapeRelatedParams.input1.second, shapeRelatedParams.input2.second);
+        auto Add = std::make_shared<ov::op::v1::Add>(MatMul, thirdInput);
         ov::ResultVector results{std::make_shared<ngraph::opset1::Result>(Add)};
         function = std::make_shared<ngraph::Function>(results, params, "FullyConnected");
     }
@@ -210,20 +207,16 @@ protected:
             matmul1SecondaryInput = std::make_shared<ov::op::v0::Constant>(ngPrc, shapeRelatedParams.matmul1_input2.first);
         }
 
-        auto paramOuts =
-            ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(params));
-        auto matMul0 = std::dynamic_pointer_cast<ov::op::v0::MatMul>(
-            ngraph::builder::makeMatMul(paramOuts[0],
-                                        matmul0SecondaryInput,
-                                        shapeRelatedParams.matmul1_input1.second,
-                                        shapeRelatedParams.matmul1_input2.second));
-        auto matMul1 = std::dynamic_pointer_cast<ov::op::v0::MatMul>(
-            ngraph::builder::makeMatMul(paramOuts[1],
-                                        matmul1SecondaryInput,
-                                        shapeRelatedParams.matmul2_input1.second,
-                                        shapeRelatedParams.matmul2_input2.second));
-        auto Add = std::dynamic_pointer_cast<ov::op::v1::Add>(
-            ngraph::builder::makeEltwise(matMul0, matMul1, ngraph::helpers::EltwiseTypes::ADD));
+        auto paramOuts = ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(params));
+        auto matMul0 = std::make_shared<ov::op::v0::MatMul>(paramOuts[0],
+                                                            matmul0SecondaryInput,
+                                                            shapeRelatedParams.matmul1_input1.second,
+                                                            shapeRelatedParams.matmul1_input2.second);
+        auto matMul1 = std::make_shared<ov::op::v0::MatMul>(paramOuts[1],
+                                                            matmul1SecondaryInput,
+                                                            shapeRelatedParams.matmul2_input1.second,
+                                                            shapeRelatedParams.matmul2_input2.second);
+        auto Add = std::make_shared<ov::op::v1::Add>(matMul0, matMul1);
         ov::ResultVector results{std::make_shared<ngraph::opset1::Result>(Add)};
         function = std::make_shared<ngraph::Function>(results, params, "FullyConnected");
     }

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/fully_connected.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/fully_connected.cpp
@@ -85,13 +85,14 @@ protected:
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto params = ngraph::builder::makeParams(ngPrc, {shapeRelatedParams.input1.first});
 
-        auto secondaryInput =
-            ngraph::builder::makeInputLayer(ngPrc, secondaryInputType, shapeRelatedParams.input2.first);
+        std::shared_ptr<ov::Node> secondaryInput;
         if (secondaryInputType == ngraph::helpers::InputLayerType::PARAMETER) {
-            params.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(secondaryInput));
+            secondaryInput = std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(shapeRelatedParams.input2.first));
+            params.push_back(std::static_pointer_cast<ov::op::v0::Parameter>(secondaryInput));
+        } else {
+            secondaryInput = std::make_shared<ov::op::v0::Constant>(ngPrc, shapeRelatedParams.input2.first);
         }
-        auto thirdInput = ngraph::builder::makeInputLayer(
-            ngPrc, ngraph::helpers::InputLayerType::CONSTANT, shapeRelatedParams.input3);
+        auto thirdInput = std::make_shared<ov::op::v0::Constant>(ngPrc, shapeRelatedParams.input3);
         auto paramOuts =
             ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(params));
         auto MatMul = std::dynamic_pointer_cast<ov::op::v0::MatMul>(ngraph::builder::makeMatMul(
@@ -191,15 +192,21 @@ protected:
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
         auto params = ngraph::builder::makeParams(
             ngPrc, {shapeRelatedParams.matmul1_input1.first, shapeRelatedParams.matmul2_input1.first});
-        auto matmul0SecondaryInput =
-            ngraph::builder::makeInputLayer(ngPrc, secondaryInputType, shapeRelatedParams.matmul1_input2.first);
+
+        std::shared_ptr<ov::Node> matmul0SecondaryInput;
         if (secondaryInputType == ngraph::helpers::InputLayerType::PARAMETER) {
-            params.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(matmul0SecondaryInput));
+            matmul0SecondaryInput = std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(shapeRelatedParams.matmul1_input2.first));
+            params.push_back(std::static_pointer_cast<ov::op::v0::Parameter>(matmul0SecondaryInput));
+        } else {
+            matmul0SecondaryInput = std::make_shared<ov::op::v0::Constant>(ngPrc, shapeRelatedParams.matmul1_input2.first);
         }
-        auto matmul1SecondaryInput =
-            ngraph::builder::makeInputLayer(ngPrc, secondaryInputType, shapeRelatedParams.matmul2_input2.first);
+
+        std::shared_ptr<ov::Node> matmul1SecondaryInput;
         if (secondaryInputType == ngraph::helpers::InputLayerType::PARAMETER) {
-            params.push_back(std::dynamic_pointer_cast<ov::op::v0::Parameter>(matmul1SecondaryInput));
+            matmul1SecondaryInput = std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(shapeRelatedParams.matmul1_input2.first));
+            params.push_back(std::static_pointer_cast<ov::op::v0::Parameter>(matmul1SecondaryInput));
+        } else {
+            matmul1SecondaryInput = std::make_shared<ov::op::v0::Constant>(ngPrc, shapeRelatedParams.matmul1_input2.first);
         }
 
         auto paramOuts =

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/gru_cell.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/gru_cell.cpp
@@ -34,10 +34,9 @@ protected:
         int seed = SEED_FIRST;
         for (const auto& op : ops) {
             if (std::dynamic_pointer_cast<ngraph::opset1::Constant>(op)) {
-                const auto constant = ngraph::builder::makeConstant(
-                    op->get_element_type(), op->get_shape(), std::vector<float>{}, true, up_to, start_from, seed);
-                function->replace_node(op, constant);
-                ++seed;
+                ov::Tensor random_tensor(op->get_element_type(), op->get_shape());
+                ov::test::utils::fill_tensor_random(random_tensor, up_to - start_from, start_from, 1, seed++);
+                function->replace_node(op, std::make_shared<ov::op::v0::Constant>(random_tensor));
             }
         }
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/gru_sequence.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/gru_sequence.cpp
@@ -100,7 +100,9 @@ public:
         };
         m_max_seq_len_ = seq_lengths;
         auto ngPrc = FuncTestUtils::PrecisionUtils::convertIE2nGraphPrc(netPrecision);
-        auto params = ngraph::builder::makeParams(ngPrc, {inputShapes[0], inputShapes[1]});
+        ov::ParameterVector params;
+        params.push_back(std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShapes[0])));
+        params.push_back(std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape(inputShapes[1])));
 
         ASSERT_EQ(InputLayerType::CONSTANT, WRBType);
         std::vector<ov::Shape> WRB = {inputShapes[3], inputShapes[4], inputShapes[5], inputShapes[2]};

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/gru_sequence.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/gru_sequence.cpp
@@ -27,9 +27,9 @@ public:
         for (const auto& op : ops) {
             if (std::dynamic_pointer_cast<ngraph::opset1::Constant>(op)) {
                 if (op->get_element_type() == ov::element::Type_t::f32) {
-                    const auto constant = ngraph::builder::makeConstant(
-                        op->get_element_type(), op->get_shape(), std::vector<float>{}, true, up_to, start_from, seed++);
-                    function->replace_node(op, constant);
+                    ov::Tensor random_tensor(op->get_element_type(), op->get_shape());
+                    ov::test::utils::fill_tensor_random(random_tensor, up_to - start_from, start_from, 1, seed++);
+                    function->replace_node(op, std::make_shared<ov::op::v0::Constant>(random_tensor));
                 }
             }
         }
@@ -57,9 +57,9 @@ public:
         for (const auto& op : ops) {
             if (std::dynamic_pointer_cast<ngraph::opset1::Constant>(op)) {
                 if (op->get_element_type() == ov::element::Type_t::f32) {
-                    const auto constant = ngraph::builder::makeConstant(
-                        op->get_element_type(), op->get_shape(), std::vector<float>{}, true, up_to, start_from, seed++);
-                    function->replace_node(op, constant);
+                    ov::Tensor random_tensor(op->get_element_type(), op->get_shape());
+                    ov::test::utils::fill_tensor_random(random_tensor, up_to - start_from, start_from, 1, seed++);
+                    function->replace_node(op, std::make_shared<ov::op::v0::Constant>(random_tensor));
                 }
             }
         }

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/lstm_cell.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/lstm_cell.cpp
@@ -37,8 +37,9 @@ public:
         int seed = SEED_FIRST;
         for (const auto& op : ops) {
             if (std::dynamic_pointer_cast<ngraph::opset1::Constant>(op)) {
-                const auto constant = ngraph::builder::makeConstant(
-                    op->get_element_type(), op->get_shape(), std::vector<float>{}, true, up_to, start_from, seed);
+                ov::Tensor random_tensor(op->get_element_type(), op->get_shape());
+                ov::test::utils::fill_tensor_random(random_tensor, up_to - start_from, start_from, 1, seed);
+                auto constant = std::make_shared<ov::op::v0::Constant>(random_tensor);
                 function->replace_node(op, constant);
                 ++seed;
             }

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/lstm_sequence.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/lstm_sequence.cpp
@@ -26,14 +26,9 @@ class CUDALSTMSequenceTest : public UnsymmetricalComparer<LSTMSequenceTest> {
         for (const auto& op : ops) {
             if (std::dynamic_pointer_cast<ngraph::opset1::Constant>(op)) {
                 if (op->get_element_type() == ov::element::Type_t::f32) {
-                    const auto constant = ngraph::builder::makeConstant(op->get_element_type(),
-                                                                        op->get_shape(),
-                                                                        std::vector<float>{},
-                                                                        true,
-                                                                        up_to,
-                                                                        start_from,
-                                                                        counter++);
-                    function->replace_node(op, constant);
+                    ov::Tensor random_tensor(op->get_element_type(), op->get_shape());
+                    ov::test::utils::fill_tensor_random(random_tensor, up_to - start_from, start_from, 1, counter++);
+                    function->replace_node(op, std::make_shared<ov::op::v0::Constant>(random_tensor));
                 }
             }
         }

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/range.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/range.cpp
@@ -220,9 +220,9 @@ protected:
         CUDA::Device device{};
         const bool optimizeOption = false;
         NodeVector params;
-        params.push_back(builder::makeConstant<decltype(start)>(Type(start_type), std::vector<size_t>(), {start}));
-        params.push_back(builder::makeConstant<decltype(stop)>(Type(Type_t::f32), std::vector<size_t>(), {stop}));
-        params.push_back(builder::makeConstant<decltype(step)>(Type(step_type), std::vector<size_t>(), {step}));
+        params.push_back(std::make_shared<ov::op::v0::Constant>(ov::element::Type(start_type), ov::Shape(), start));
+        params.push_back(std::make_shared<ov::op::v0::Constant>(ov::element::f32, ov::Shape(), stop));
+        params.push_back(std::make_shared<ov::op::v0::Constant>(ov::element::Type(step_type), ov::Shape(), step));
         params[0]->set_friendly_name("start");
         params[1]->set_friendly_name("stop");
         params[2]->set_friendly_name("step");

--- a/modules/nvidia_plugin/tests/unit/test_networks.hpp
+++ b/modules/nvidia_plugin/tests/unit/test_networks.hpp
@@ -18,8 +18,7 @@ inline std::shared_ptr<ngraph::Function> CreateMatMulTestNetwork() {
     auto secondaryInput = std::make_shared<ov::op::v0::Constant>(ngPrc, ov::Shape{3, 2, 10, 20});
     auto paramOuts =
         ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(params));
-    auto MatMul = std::dynamic_pointer_cast<ov::op::v0::MatMul>(
-        ngraph::builder::makeMatMul(paramOuts[0], secondaryInput, false, false));
+    auto MatMul = std::make_shared<ov::op::v0::MatMul>(paramOuts[0], secondaryInput, false, false);
     ov::ResultVector results{std::make_shared<ngraph::opset1::Result>(MatMul)};
     return std::make_shared<ngraph::Function>(results, params, "MatMul");
 }

--- a/modules/nvidia_plugin/tests/unit/test_networks.hpp
+++ b/modules/nvidia_plugin/tests/unit/test_networks.hpp
@@ -9,14 +9,13 @@
 #include <ngraph_functions/utils/ngraph_helpers.hpp>
 
 inline std::shared_ptr<ngraph::Function> CreateMatMulTestNetwork() {
-    ngraph::helpers::InputLayerType secondaryInputType = ngraph::helpers::InputLayerType::CONSTANT;
     auto netPrecision = InferenceEngine::Precision::FP32;
     std::map<std::string, std::string> additionalConfig;
 
     auto ngPrc = InferenceEngine::details::convertPrecision(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {{3, 2, 10, 10}});
 
-    auto secondaryInput = ngraph::builder::makeInputLayer(ngPrc, secondaryInputType, {3, 2, 10, 20});
+    auto secondaryInput = std::make_shared<ov::op::v0::Constant>(ngPrc, ov::Shape{3, 2, 10, 20});
     auto paramOuts =
         ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(params));
     auto MatMul = std::dynamic_pointer_cast<ov::op::v0::MatMul>(
@@ -63,14 +62,13 @@ public:
 };
 
 inline std::shared_ptr<ngraph::Function> CreateSuperOperationTestNetwork() {
-    ngraph::helpers::InputLayerType secondaryInputType = ngraph::helpers::InputLayerType::CONSTANT;
     auto netPrecision = InferenceEngine::Precision::FP32;
     std::map<std::string, std::string> additionalConfig;
 
     auto ngPrc = InferenceEngine::details::convertPrecision(netPrecision);
     auto params = ngraph::builder::makeParams(ngPrc, {{3, 2, 10, 10}});
 
-    auto secondaryInput = ngraph::builder::makeInputLayer(ngPrc, secondaryInputType, {3, 2, 10, 20});
+    auto secondaryInput = std::make_shared<ov::op::v0::Constant>(ngPrc, ov::Shape{3, 2, 10, 20});
     auto paramOuts =
         ngraph::helpers::convert2OutputVector(ngraph::helpers::castOps2Nodes<ov::op::v0::Parameter>(params));
     auto superOp = std::make_shared<SuperDummyOp>(paramOuts[0], secondaryInput);

--- a/modules/nvidia_plugin/tests/unit/test_networks.hpp
+++ b/modules/nvidia_plugin/tests/unit/test_networks.hpp
@@ -13,7 +13,7 @@ inline std::shared_ptr<ngraph::Function> CreateMatMulTestNetwork() {
     std::map<std::string, std::string> additionalConfig;
 
     auto ngPrc = InferenceEngine::details::convertPrecision(netPrecision);
-    auto params = ngraph::builder::makeParams(ngPrc, {{3, 2, 10, 10}});
+    ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape{3, 2, 10, 10})};
 
     auto secondaryInput = std::make_shared<ov::op::v0::Constant>(ngPrc, ov::Shape{3, 2, 10, 20});
     auto paramOuts =
@@ -66,7 +66,7 @@ inline std::shared_ptr<ngraph::Function> CreateSuperOperationTestNetwork() {
     std::map<std::string, std::string> additionalConfig;
 
     auto ngPrc = InferenceEngine::details::convertPrecision(netPrecision);
-    auto params = ngraph::builder::makeParams(ngPrc, {{3, 2, 10, 10}});
+    ov::ParameterVector params {std::make_shared<ov::op::v0::Parameter>(ngPrc, ov::Shape{3, 2, 10, 10})};
 
     auto secondaryInput = std::make_shared<ov::op::v0::Constant>(ngPrc, ov::Shape{3, 2, 10, 20});
     auto paramOuts =


### PR DESCRIPTION
- ngraph::builder::makeInputLayer function is being deleted from openvino repo. Exclude from contrib repo as well 
- ngraph::builder::makeParameter and ngraph::builder::makeDynamicParameter function is being deleted from openvino repo. Exclude from contrib repo as well 
