### PR TITLE
[NVIDIA] Set proper math type for convolution

### DIFF
--- a/modules/nvidia_plugin/src/ops/convolution_components/convolution_cudnn_components.cpp
+++ b/modules/nvidia_plugin/src/ops/convolution_components/convolution_cudnn_components.cpp
@@ -74,7 +74,7 @@ CUDA::DnnConvolutionDescriptor ConvolutionParamsCuDnn::MakeConvolutionDescriptor
 
     // Enable computations on Tensor Core hardware which requires at least Volta GPU
     // (compute capability 7.0).
-    const cudnnMathType_t math_type = CUDNN_TENSOR_OP_MATH_ALLOW_CONVERSION;
+    const cudnnMathType_t math_type = CUDNN_TENSOR_OP_MATH;
     throwIfError(::cudnnSetConvolutionMathType(conv_desc.get(), math_type));
     throwIfError(::cudnnSetConvolutionGroupCount(conv_desc.get(), groups_));
 
@@ -96,6 +96,7 @@ ConvolutionDescriptorsCuDnn::ConvolutionDescriptorsCuDnn(const CreationContext& 
     } else {
         GetAlgo(dnnHandle);
     }
+    throwIfError(::cudnnSetConvolutionMathType(conv_.get(), algo_perf_.mathType));
 }
 
 void ConvolutionDescriptorsCuDnn::BenchmarkOptimalAlgo(const CUDA::DnnHandle& dnnHandle,
@@ -305,7 +306,7 @@ CUDA::DnnConvolutionDescriptor ConvolutionBackpropDataParamsCuDnn::MakeConvoluti
 
     // Enable computations on Tensor Core hardware which requires at least Volta GPU
     // (compute capability 7.0).
-    const cudnnMathType_t math_type = CUDNN_TENSOR_OP_MATH_ALLOW_CONVERSION;
+    const cudnnMathType_t math_type = CUDNN_TENSOR_OP_MATH;
     throwIfError(::cudnnSetConvolutionMathType(conv_desc.get(), math_type));
     throwIfError(::cudnnSetConvolutionGroupCount(conv_desc.get(), groups_));
 
@@ -327,6 +328,7 @@ ConvolutionBackpropDataDescriptorCuDnn::ConvolutionBackpropDataDescriptorCuDnn(
     } else {
         GetAlgo(dnnHandle);
     }
+    throwIfError(::cudnnSetConvolutionMathType(conv_.get(), algo_perf_.mathType));
 }
 
 void ConvolutionBackpropDataDescriptorCuDnn::BenchmarkOptimalAlgo(const CUDA::DnnHandle& dnnHandle) {


### PR DESCRIPTION
### Details:
- *Sets proper convolution math type according to the math type of the selected algo*