### PR TITLE
[NVIDIA] Cleanup legacy ExecGraphInfoSerialization::ORIGINAL_NAMES

### DIFF
--- a/modules/nvidia_plugin/src/transformer/concat_transformation.cpp
+++ b/modules/nvidia_plugin/src/transformer/concat_transformation.cpp
@@ -60,15 +60,6 @@ bool change_concat_to_concat_optimized(Matcher& m) {
     auto concat_optimized = std::make_shared<ConcatOptimized>(inOuts, concat->get_axis());
     concat_optimized->set_friendly_name(concat->get_friendly_name());
     ov::copy_runtime_info(concat, concat_optimized);
-
-    auto& rt_info = concat->get_rt_info();
-    if (auto found = rt_info.find(ExecGraphInfoSerialization::ORIGINAL_NAMES); found != rt_info.end()) {
-        auto& rt_info_layer_names = found->second;
-        const auto original_names = rt_info_layer_names.as<std::string>();
-        const std::string original_names_with_activation = concat->get_friendly_name() + "," + original_names;
-        rt_info_layer_names = original_names_with_activation;
-    }
-
     ov::replace_node(concat, concat_optimized);
 
     return true;

--- a/modules/nvidia_plugin/src/transformer/fuse_conv_biasadd_activation.cpp
+++ b/modules/nvidia_plugin/src/transformer/fuse_conv_biasadd_activation.cpp
@@ -98,9 +98,6 @@ struct FusedConvCallbacks {
         ov::copy_runtime_info({m_conv, eltwise}, new_conv.get_node_shared_ptr());
         set_node_id(new_conv.get_node_shared_ptr(), get_node_id(eltwise));
 
-        const std::string originalLayers = eltwise->get_friendly_name() + "," + m_conv->get_friendly_name();
-        fused_conv->get_rt_info()[ExecGraphInfoSerialization::ORIGINAL_NAMES] = originalLayers;
-
         ov::replace_node(m.get_match_root(), new_conv.get_node_shared_ptr());
         return true;
     }
@@ -168,14 +165,6 @@ struct FusedConvCallbacks {
         ov::copy_runtime_info({node, fused_conv}, fused_conv_add);
         set_node_id(fused_conv_add, get_node_id(add));
 
-        auto &rt_info = fused_conv->get_rt_info();
-        if (rt_info.count(ExecGraphInfoSerialization::ORIGINAL_NAMES) > 0) {
-            auto &rt_info_layer_names = rt_info[ExecGraphInfoSerialization::ORIGINAL_NAMES];
-            const auto original_names = rt_info_layer_names.template as<std::string>();
-            const std::string original_names_with_activation = add->get_friendly_name() + "," + original_names;
-            rt_info_layer_names = original_names_with_activation;
-        }
-
         ov::replace_node(fused_conv, fused_conv_add);
         ov::replace_node(m.get_match_root(), fused_conv_add);
 
@@ -204,15 +193,6 @@ struct FusedConvCallbacks {
 
         fused_conv->set_friendly_name(activationNode->get_friendly_name());
         set_node_id(fused_conv, get_node_id(activationNode));
-
-        auto &rt_info = fused_conv->get_rt_info();
-        if (rt_info.count(ExecGraphInfoSerialization::ORIGINAL_NAMES) > 0) {
-            auto &rt_info_layer_names = rt_info[ExecGraphInfoSerialization::ORIGINAL_NAMES];
-            const auto original_names = rt_info_layer_names.template as<std::string>();
-            const std::string original_names_with_activation =
-                activationNode->get_friendly_name() + "," + original_names;
-            rt_info_layer_names = original_names_with_activation;
-        }
 
         ov::replace_node(m.get_match_root(), fused_conv);
 
@@ -274,14 +254,6 @@ bool fuse_convolution_backprop_data_with_add(Matcher &m) {
 
     fused_conv_backprop_data_add->set_friendly_name(add->get_friendly_name());
     ov::copy_runtime_info({conv_backprop_data, add}, fused_conv_backprop_data_add);
-
-    auto &rt_info = conv_backprop_data->get_rt_info();
-    if (rt_info.count(ExecGraphInfoSerialization::ORIGINAL_NAMES) > 0) {
-        auto &rt_info_layer_names = rt_info[ExecGraphInfoSerialization::ORIGINAL_NAMES];
-        const auto original_names = rt_info_layer_names.as<std::string>();
-        const std::string original_names_with_activation = add->get_friendly_name() + "," + original_names;
-        rt_info_layer_names = original_names_with_activation;
-    }
 
     ov::replace_node(add, fused_conv_backprop_data_add);
     ov::replace_node(conv_backprop_data, fused_conv_backprop_data_add);

--- a/modules/nvidia_plugin/src/transformer/fuse_matmul_add.cpp
+++ b/modules/nvidia_plugin/src/transformer/fuse_matmul_add.cpp
@@ -78,9 +78,6 @@ bool fuse_matmul_and_add(Matcher &m) {
     fully_connected_node->set_friendly_name(add_node->get_friendly_name());
     ov::copy_runtime_info({matmul_node, add_node}, fully_connected_node);
 
-    const std::string original_layers = matmul_node->get_friendly_name() + "," + add_node->get_friendly_name();
-    fully_connected_node->get_rt_info()[ExecGraphInfoSerialization::ORIGINAL_NAMES] = original_layers;
-
     for (auto input : consumers) {
         input.replace_source_output(fully_connected_node);
     }

--- a/modules/nvidia_plugin/src/transformer/matmul_transformations.cpp
+++ b/modules/nvidia_plugin/src/transformer/matmul_transformations.cpp
@@ -112,10 +112,6 @@ bool fuse_transpose_with_matmul(Matcher &m) {
     newMatMul->set_friendly_name(matmul->get_friendly_name());
 
     ov::copy_runtime_info({transpose, matmul}, newMatMul);
-
-    const std::string originalLayers = transpose->get_friendly_name() + "," + matmul->get_friendly_name();
-    newMatMul->get_rt_info()[ExecGraphInfoSerialization::ORIGINAL_NAMES] = originalLayers;
-
     ov::replace_node(matmul, newMatMul);
 
     return true;


### PR DESCRIPTION
### Details:
- *Cleanup legacy ExecGraphInfoSerialization::ORIGINAL_NAMES. Currently fused  names are used to fill ov::exec_model_info::ORIGINAL_NAMES in runtime graph*