### PR TITLE
[NVIDIA] DetectionOutput fix input types

### DIFF
--- a/modules/nvidia_plugin/src/ops/detection_output.cpp
+++ b/modules/nvidia_plugin/src/ops/detection_output.cpp
@@ -16,6 +16,11 @@ DetectionOutputOp::DetectionOutputOp(const CreationContext& context,
                                      IndexCollection&& inputIds,
                                      IndexCollection&& outputIds)
     : OperationBase{context, node, move(inputIds), move(outputIds)}, element_type_{node.get_input_element_type(0)} {
+    OPENVINO_ASSERT(node.get_element_type() == element_type_, "Node name: ", GetName());
+    for (const auto& input : node.inputs()) {
+        OPENVINO_ASSERT(input.get_element_type() == element_type_, "Node name: ", GetName());
+    }
+
     const auto& ngraph_attrs = node.get_attrs();
     kernel::DetectionOutput::Attrs kernel_attrs;
 

--- a/modules/nvidia_plugin/src/transformer/cuda_graph_transformer.cpp
+++ b/modules/nvidia_plugin/src/transformer/cuda_graph_transformer.cpp
@@ -29,6 +29,7 @@
 
 #include "bidirectional_lstm_sequence_composition.hpp"
 #include "concat_transformation.hpp"
+#include "detection_output_fix_input_types_transformation.hpp"
 #include "fuse_matmul_add.hpp"
 #include "matmul_transformations.hpp"
 #include "reduce_transformation.hpp"
@@ -52,6 +53,7 @@ void GraphTransformer::transform(const CUDA::Device& device,
     if (inference_precision == ov::element::f16 && !isHalfSupported(device)) {
         inference_precision = ov::element::f32;
     }
+
     auto upscale_precision = [&]() -> bool {
         return !isHalfSupported(device) || inference_precision == ov::element::f32;
     };
@@ -151,6 +153,8 @@ void GraphTransformer::transform(const CUDA::Device& device,
     pass_manager.register_pass<ov::nvidia_gpu::pass::FullyConnectedTransformation>();
     pass_manager.register_pass<ov::nvidia_gpu::pass::ConcatTransformation>();
     pass_manager.register_pass<ov::nvidia_gpu::pass::ReduceTransformation>();
+    pass_manager.register_pass<ov::nvidia_gpu::pass::DetectionOutputFixInputTypesTransformation>();
+
     // Do we actually need to eliminate broadcast one more time at the end?
     pass_manager.register_pass<ov::pass::NopElimination>();
 

--- a/modules/nvidia_plugin/src/transformer/detection_output_fix_input_types_transformation.cpp
+++ b/modules/nvidia_plugin/src/transformer/detection_output_fix_input_types_transformation.cpp
@@ -1,0 +1,57 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "detection_output_fix_input_types_transformation.hpp"
+
+#include "openvino/cc/pass/itt.hpp"
+#include "openvino/core/rt_info.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/detection_output.hpp"
+#include "openvino/pass/pattern/op/pattern.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+
+using namespace ov::pass::pattern;
+
+namespace ov::nvidia_gpu::pass {
+
+bool detection_output_fix_input_types(Matcher& m) {
+    const auto d_out = std::dynamic_pointer_cast<ov::op::v0::DetectionOutput>(m.get_match_root());
+    if (!d_out) {
+        return false;
+    }
+    const auto& type = d_out->get_element_type();
+    ov::OutputVector inputs;
+    bool needs_transform = false;
+    for (std::size_t i = 0; i < d_out->inputs().size(); ++i) {
+        const auto& input_type = d_out->input(i).get_element_type();
+        if (input_type != type) {
+            needs_transform = true;
+            const auto convert = std::make_shared<ov::op::v0::Convert>(d_out->input_value(i), type);
+            ov::copy_runtime_info(d_out, convert);
+            inputs.emplace_back(convert);
+        } else {
+            inputs.emplace_back(d_out->input_value(i));
+        }
+    }
+    if (!needs_transform) {
+        return false;
+    }
+    auto new_d_out = d_out->clone_with_new_inputs(inputs);
+    new_d_out->set_friendly_name(d_out->get_friendly_name());
+    ov::copy_runtime_info(d_out, new_d_out);
+    ov::replace_node(d_out, new_d_out);
+    return true;
+}
+
+DetectionOutputFixInputTypesTransformation::DetectionOutputFixInputTypesTransformation() {
+    MATCHER_SCOPE(DetectionOutputFixInputTypesTransformation);
+
+    const auto d_out = wrap_type<ov::op::v0::DetectionOutput>();
+    matcher_pass_callback callback = [](Matcher& m) { return detection_output_fix_input_types(m); };
+
+    const auto m = std::make_shared<Matcher>(d_out, matcher_name);
+    register_matcher(m, callback);
+}
+
+}  // namespace ov::nvidia_gpu::pass

--- a/modules/nvidia_plugin/src/transformer/detection_output_fix_input_types_transformation.hpp
+++ b/modules/nvidia_plugin/src/transformer/detection_output_fix_input_types_transformation.hpp
@@ -1,0 +1,17 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/pass/graph_rewrite.hpp"
+
+namespace ov::nvidia_gpu::pass {
+
+class DetectionOutputFixInputTypesTransformation : public ov::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("DetectionOutputFixInputTypesTransformation", "0");
+    DetectionOutputFixInputTypesTransformation();
+};
+
+}  // namespace ov::nvidia_gpu::pass

--- a/modules/nvidia_plugin/tests/unit/transformations/detection_output_fix_input_types.cpp
+++ b/modules/nvidia_plugin/tests/unit/transformations/detection_output_fix_input_types.cpp
@@ -1,0 +1,148 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "common_test_utils/ov_test_utils.hpp"
+#include "cuda_operation_registry.hpp"
+#include "openvino/core/model.hpp"
+#include "openvino/op/convert.hpp"
+#include "openvino/op/detection_output.hpp"
+#include "openvino/pass/manager.hpp"
+#include "transformations/init_node_info.hpp"
+#include "transformer/detection_output_fix_input_types_transformation.hpp"
+
+using namespace ov;
+
+namespace {
+
+op::v0::DetectionOutput::Attributes get_attrs() {
+    op::v0::DetectionOutput::Attributes attrs;
+
+    attrs.background_label_id = 12;
+    attrs.top_k = 75;
+    attrs.variance_encoded_in_target = true;
+    attrs.keep_top_k = {50};
+    attrs.code_type = "caffe.PriorBoxParameter.CORNER";
+    attrs.share_location = true;
+    attrs.nms_threshold = 0.5f;
+    attrs.confidence_threshold = 0.3f;
+    attrs.clip_after_nms = true;
+    attrs.clip_before_nms = true;
+    attrs.decrease_label_id = true;
+    attrs.normalized = true;
+    attrs.input_height = 1ul;
+    attrs.input_width = 1ul;
+    attrs.objectness_score = 0.4f;
+    attrs.num_classes = 11;
+
+    return attrs;
+}
+
+ov::nvidia_gpu::OperationBase::Ptr createPluginOperation(const std::shared_ptr<ov::Node>& node) {
+    return ov::nvidia_gpu::OperationRegistry::getInstance().createOperation(
+        ov::nvidia_gpu::CreationContext{CUDA::Device{}, false},
+        node,
+        std::vector<ov::nvidia_gpu::TensorID>{ov::nvidia_gpu::TensorID{0u}},
+        std::vector<ov::nvidia_gpu::TensorID>{ov::nvidia_gpu::TensorID{0u}});
+}
+
+template <typename T>
+std::shared_ptr<T> find_op(const std::shared_ptr<Model> model) {
+    for (const auto& node : model->get_ordered_ops()) {
+        if (const auto op = std::dynamic_pointer_cast<T>(node)) {
+            return op;
+        }
+    }
+    return nullptr;
+}
+
+}  // namespace
+
+namespace testing {
+
+TEST(detection_output_fix_input_types, three_params) {
+    // Proposals type is different
+    const ParameterVector param_vec{std::make_shared<op::v0::Parameter>(element::Type_t::f16, Shape{1, 60}),
+                                    std::make_shared<op::v0::Parameter>(element::Type_t::f16, Shape{1, 165}),
+                                    std::make_shared<op::v0::Parameter>(element::Type_t::f32, Shape{1, 1, 60})};
+
+    std::shared_ptr<Model> model, model_ref;
+    {
+        const auto d_out =
+            std::make_shared<op::v0::DetectionOutput>(param_vec[0], param_vec[1], param_vec[2], get_attrs());
+        ASSERT_THROW(createPluginOperation(d_out), ov::AssertFailure);
+
+        model = std::make_shared<Model>(d_out, param_vec);
+
+        pass::Manager pass_manager;
+        pass_manager.register_pass<pass::InitNodeInfo>();
+        pass_manager.register_pass<nvidia_gpu::pass::DetectionOutputFixInputTypesTransformation>();
+        pass_manager.run_passes(model);
+
+        ASSERT_EQ(count_ops_of_type<op::v0::DetectionOutput>(model), 1);
+        ASSERT_EQ(model->get_results()[0]->input(0).get_element_type(), element::f16);
+
+        const auto new_d_out = find_op<op::v0::DetectionOutput>(model);
+        ASSERT_NE(new_d_out, nullptr);
+        ASSERT_NO_THROW(createPluginOperation(new_d_out));
+    }
+    {
+        const auto convert = std::make_shared<op::v0::Convert>(param_vec[2], element::Type_t::f16);
+
+        const auto d_out = std::make_shared<op::v0::DetectionOutput>(param_vec[0], param_vec[1], convert, get_attrs());
+        ASSERT_NO_THROW(createPluginOperation(d_out));
+
+        model_ref = std::make_shared<Model>(d_out, param_vec);
+        ASSERT_EQ(count_ops_of_type<op::v0::DetectionOutput>(model), 1);
+    }
+    const auto res = FunctionsComparator::with_default().compare(model, model_ref);
+    ASSERT_TRUE(res.valid) << res.message;
+}
+
+TEST(detection_output_fix_input_types, five_params) {
+    // Proposals type is different
+    const ParameterVector param_vec{std::make_shared<op::v0::Parameter>(element::Type_t::f32, Shape{1, 60}),
+                                    std::make_shared<op::v0::Parameter>(element::Type_t::f32, Shape{1, 165}),
+                                    std::make_shared<op::v0::Parameter>(element::Type_t::f16, Shape{1, 1, 60}),
+                                    std::make_shared<op::v0::Parameter>(element::Type_t::f32, Shape{1, 30}),
+                                    std::make_shared<op::v0::Parameter>(element::Type_t::f32, Shape{1, 60})};
+
+    std::shared_ptr<Model> model, model_ref;
+    {
+        const auto d_out = std::make_shared<op::v0::DetectionOutput>(
+            param_vec[0], param_vec[1], param_vec[2], param_vec[3], param_vec[4], get_attrs());
+        ASSERT_THROW(createPluginOperation(d_out), ov::AssertFailure);
+
+        model = std::make_shared<Model>(d_out, param_vec);
+
+        pass::Manager pass_manager;
+        pass_manager.register_pass<pass::InitNodeInfo>();
+        pass_manager.register_pass<nvidia_gpu::pass::DetectionOutputFixInputTypesTransformation>();
+        pass_manager.run_passes(model);
+
+        ASSERT_EQ(count_ops_of_type<op::v0::DetectionOutput>(model), 1);
+        ASSERT_EQ(model->get_results()[0]->input(0).get_element_type(), element::f32);
+
+        const auto new_d_out = find_op<op::v0::DetectionOutput>(model);
+        ASSERT_NE(new_d_out, nullptr);
+        ASSERT_NO_THROW(createPluginOperation(new_d_out));
+    }
+    {
+        const auto convert = std::make_shared<op::v0::Convert>(param_vec[2], element::Type_t::f32);
+
+        const auto d_out = std::make_shared<op::v0::DetectionOutput>(
+            param_vec[0], param_vec[1], convert, param_vec[3], param_vec[4], get_attrs());
+        ASSERT_NO_THROW(createPluginOperation(d_out));
+
+        model_ref = std::make_shared<Model>(d_out, param_vec);
+        ASSERT_EQ(count_ops_of_type<op::v0::DetectionOutput>(model), 1);
+    }
+    const auto res = FunctionsComparator::with_default().compare(model, model_ref);
+    ASSERT_TRUE(res.valid) << res.message;
+}
+
+}  // namespace testing


### PR DESCRIPTION
### Details:
- *DetectionOutput operation in NVIDIA plugin is missing a check to assure that all the input/output types are the same.
In case all types are FP16 but the 3rd input type is FP32 the operation result is incorrect.
This PR adds the proper check and a transformation to covert any inputs with incorrect type*
### Ticket:
- 119127
### Note:
- *According to DetectionOutput specification (https://docs.openvino.ai/2023.0/openvino_docs_ops_detection_DetectionOutput_1.html):
"The first tuple with batch_id equal to -1 means end of output."
So the implementation in NVIDIA plugin doesn't change the rest of the values in the output after the 1st '-1.0' value and all other values should be ignored.*