### PR TITLE
[NVIDIA] Move Convert, ConvertColorI420, ConvertColorNV12 tests to API2.0

### DIFF
--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convert.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convert.cpp
@@ -1,96 +1,56 @@
 // Copyright (C) 2021-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
+#include "single_op_tests/conversion.hpp"
+#include "functional_test_utils/skip_tests_config.hpp"
 
 #include <cuda_test_constants.hpp>
 #include <vector>
 
-#include "ie_precision.hpp"
-#include "single_layer_tests/conversion.hpp"
+namespace {
 
-using namespace LayerTestsDefinitions;
-using namespace InferenceEngine;
-
-namespace CUDALayerTestsDefinitions {
+using namespace ov::test;
+using namespace ov::test::utils;
 
 class ConversionCUDALayerTest : public ConversionLayerTest {};
 
-TEST_P(ConversionCUDALayerTest, CompareWithRefs) {
+TEST_P(ConversionCUDALayerTest, Inference) {
     SKIP_IF_CURRENT_TEST_IS_DISABLED()
-
-    ConversionParamsTuple params = GetParam();
-    inPrc = std::get<2>(params);
-    outPrc = std::get<3>(params);
-
-    Run();
+    run();
 }
 
-namespace {
-const std::vector<ngraph::helpers::ConversionTypes> conversionOpTypes = {
-    ngraph::helpers::ConversionTypes::CONVERT,
+const std::vector<ConversionTypes> conversion_op_types = {
+    ConversionTypes::CONVERT,
 };
 
-const std::vector<std::vector<size_t>> inShape = {{1, 2, 3, 4}};
+const std::vector<ov::Shape> in_shapes = {{1, 2, 3, 4}};
 
 // List of precisions natively supported by CUDA.
-// CUDA device supports only U8, FP16 and FP32 output precision
-const std::vector<Precision> out_precisions = {
-    Precision::U8,
-    Precision::FP16,
-    Precision::FP32,
+// CUDA device supports only u8, f16 and f32 output precision
+const std::vector<ov::element::Type> out_precisions = {
+    ov::element::u8,
+    ov::element::i16,
+    ov::element::f16,
+    ov::element::bf16,
+    ov::element::f32,
 };
 
-// Supported formats are: BOOL, FP32, FP16, I16 and U8
-const std::vector<Precision> in_precisions = {
-    Precision::BOOL,
-    Precision::U8,
-    Precision::I16,
-    // TODO: Uncomment when we find way to omit conversion from FP16 -> FP32 in tests
-    //        Precision::FP16,
-    Precision::FP32,
+// Supported formats are: boolean, f32, f6, i16 and u8
+const std::vector<ov::element::Type> in_precisions = {
+    ov::element::boolean,
+    ov::element::u8,
+    ov::element::i16,
+    ov::element::f16,
+    ov::element::bf16,
+    ov::element::f32,
 };
 
-INSTANTIATE_TEST_SUITE_P(smoke_ConversionLayerTest_From_F32,
+INSTANTIATE_TEST_SUITE_P(smoke_ConversionLayerTest,
                          ConversionCUDALayerTest,
-                         ::testing::Combine(::testing::ValuesIn(conversionOpTypes),
-                                            ::testing::Values(inShape),
-                                            ::testing::Values(Precision::FP32),
-                                            ::testing::ValuesIn(out_precisions),
-                                            ::testing::Values(InferenceEngine::Layout::ANY),
-                                            ::testing::Values(InferenceEngine::Layout::ANY),
-                                            ::testing::Values(ov::test::utils::DEVICE_NVIDIA)),
-                         ConversionLayerTest::getTestCaseName);
-
-INSTANTIATE_TEST_SUITE_P(smoke_ConversionLayerTest_To_F32,
-                         ConversionCUDALayerTest,
-                         ::testing::Combine(::testing::ValuesIn(conversionOpTypes),
-                                            ::testing::Values(inShape),
+                         ::testing::Combine(::testing::ValuesIn(conversion_op_types),
+                                            ::testing::Values(static_shapes_to_test_representation(in_shapes)),
                                             ::testing::ValuesIn(in_precisions),
-                                            ::testing::Values(Precision::FP32),
-                                            ::testing::Values(InferenceEngine::Layout::ANY),
-                                            ::testing::Values(InferenceEngine::Layout::ANY),
-                                            ::testing::Values(ov::test::utils::DEVICE_NVIDIA)),
+                                            ::testing::ValuesIn(out_precisions),
+                                            ::testing::Values(DEVICE_NVIDIA)),
                          ConversionLayerTest::getTestCaseName);
-
-/* TODO Uncomment when BF16 support is implemented
-INSTANTIATE_TEST_CASE_P(smoke_ConvertLayerTest_From_BF16, ConversionCUDALayerTest,
-                        ::testing::Combine(
-                                ::testing::Values(inShape),
-                                ::testing::Values(Precision::BF16),
-                                ::testing::ValuesIn(precisions),
-                                ::testing::Values(Layout::ANY),
-                                ::testing::Values(Layout::ANY),
-                                ::testing::Values(ov::test::utils::DEVICE_NVIDIA)),
-                        ConvertLayerTest::getTestCaseName);
-INSTANTIATE_TEST_CASE_P(smoke_ConvertLayerTest_To_BF16, ConversionCUDALayerTest,
-                        ::testing::Combine(
-                                ::testing::Values(inShape),
-                                ::testing::ValuesIn(precisions),
-                                ::testing::Values(Precision::BF16),
-                                ::testing::Values(Layout::ANY),
-                                ::testing::Values(Layout::ANY),
-                                ::testing::Values(ov::test::utils::DEVICE_NVIDIA)),
-                        ConvertLayerTest::getTestCaseName);
-*/
 }  // namespace
-}  // namespace CUDALayerTestsDefinitions

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convert_color_common.hpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convert_color_common.hpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2018-2023 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+#include "common_test_utils/ov_tensor_utils.hpp"
+
+namespace ov {
+namespace test {
+namespace nvidia_gpu {
+
+class ConvertColorCUDALayerTest : virtual public ov::test::SubgraphBaseTest {
+private:
+    ov::Tensor generate_input(const ov::element::Type element_type, const ov::Shape& shape) const {
+        return utils::create_and_fill_tensor(element_type, shape, 255);
+    };
+    void generate_inputs(const std::vector<ov::Shape>& target_input_static_shapes) override {
+        inputs.clear();
+        const auto& func_inputs = function->inputs();
+        for (int i = 0; i < func_inputs.size(); ++i) {
+            const auto& param = func_inputs[i];
+            auto tensor = generate_input(param.get_element_type(), target_input_static_shapes[i]);
+            inputs.insert({param.get_node_shared_ptr(), tensor});
+        }
+    }
+};
+} // nvidia_gpu
+} // test
+} // ov

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convert_color_i420.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convert_color_i420.cpp
@@ -2,104 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "single_layer_tests/convert_color_i420.hpp"
+#include "single_op_tests/convert_color_i420.hpp"
+#include "convert_color_common.hpp"
 
-#include <cuda_test_constants.hpp>
+#include "cuda_test_constants.hpp"
 #include <vector>
-
-using namespace LayerTestsDefinitions;
 
 namespace {
 
-class ConvertColorI420CUDALayerTest : public ConvertColorI420LayerTest {
-private:
-    void SetUp() override {
-        ov::Shape inputShape;
-        ov::element::Type ngPrc;
-        bool conversionToRGB, singlePlane;
-        abs_threshold = 1.0f;  // I420 conversion can use various algorithms, thus some absolute deviation is allowed
-        threshold = 1.f;       // Ignore relative comparison for I420 convert (allow 100% relative deviation)
-        std::tie(inputShape, ngPrc, conversionToRGB, singlePlane, targetDevice) = GetParam();
-        if (singlePlane) {
-            inputShape[1] = inputShape[1] * 3 / 2;
-            auto param = std::make_shared<ov::op::v0::Parameter>(ngPrc, inputShape);
-            std::shared_ptr<ov::Node> convert_color;
-            if (conversionToRGB) {
-                convert_color = std::make_shared<ov::op::v8::I420toRGB>(param);
-            } else {
-                convert_color = std::make_shared<ov::op::v8::I420toRGB>(param);
-            }
-            function = std::make_shared<ov::Model>(
-                std::make_shared<ov::op::v0::Result>(convert_color), ov::ParameterVector{param}, "ConvertColorI420");
-        } else {
-            auto uvShape = ov::Shape{inputShape[0], inputShape[1] / 2, inputShape[2] / 2, 1};
-            auto param_y = std::make_shared<ov::op::v0::Parameter>(ngPrc, inputShape);
-            auto param_u = std::make_shared<ov::op::v0::Parameter>(ngPrc, uvShape);
-            auto param_v = std::make_shared<ov::op::v0::Parameter>(ngPrc, uvShape);
-            std::shared_ptr<ov::Node> convert_color;
-            if (conversionToRGB) {
-                convert_color = std::make_shared<ov::op::v8::I420toRGB>(param_y, param_u, param_v);
-            } else {
-                convert_color = std::make_shared<ov::op::v8::I420toBGR>(param_y, param_u, param_v);
-            }
-            function = std::make_shared<ov::Model>(std::make_shared<ov::op::v0::Result>(convert_color),
-                                                   ov::ParameterVector{param_y, param_u, param_v},
-                                                   "ConvertColorI420");
-        }
-    }
+using namespace ov::test;
+using namespace ov::test::nvidia_gpu;
+using namespace ov::test::utils;
 
-    InferenceEngine::Blob::Ptr GenerateInput(const InferenceEngine::InputInfo& info) const override {
-        return FuncTestUtils::createAndFillBlob(info.getTensorDesc(), 255);
-    }
-};
+class ConvertColorI420CUDALayerTest : public ConvertColorCUDALayerTest, public ConvertColorI420LayerTest {};
 
-TEST_P(ConvertColorI420CUDALayerTest, CompareWithRefs) { Run(); }
+TEST_P(ConvertColorI420CUDALayerTest, Inference) { run(); }
 
-class ConvertColorI420CUDAAccuracyTest : public ConvertColorI420AccuracyTest {
-private:
-    void SetUp() override {
-        ov::Shape inputShape;
-        ov::element::Type ngPrc;
-        bool conversionToRGB, singlePlane;
-        abs_threshold = 1.0f;  // I420 conversion can use various algorithms, thus some absolute deviation is allowed
-        threshold = 1.f;       // Ignore relative comparison for I420 convert (allow 100% relative deviation)
-        std::tie(inputShape, ngPrc, conversionToRGB, singlePlane, targetDevice) = GetParam();
-        if (singlePlane) {
-            inputShape[1] = inputShape[1] * 3 / 2;
-            auto param = std::make_shared<ov::op::v0::Parameter>(ngPrc, inputShape);
-            std::shared_ptr<ov::Node> convert_color;
-            if (conversionToRGB) {
-                convert_color = std::make_shared<ov::op::v8::I420toRGB>(param);
-            } else {
-                convert_color = std::make_shared<ov::op::v8::I420toRGB>(param);
-            }
-            function = std::make_shared<ov::Model>(
-                std::make_shared<ov::op::v0::Result>(convert_color), ov::ParameterVector{param}, "ConvertColorI420");
-        } else {
-            auto uvShape = ov::Shape{inputShape[0], inputShape[1] / 2, inputShape[2] / 2, 1};
-            auto param_y = std::make_shared<ov::op::v0::Parameter>(ngPrc, inputShape);
-            auto param_u = std::make_shared<ov::op::v0::Parameter>(ngPrc, uvShape);
-            auto param_v = std::make_shared<ov::op::v0::Parameter>(ngPrc, uvShape);
-            std::shared_ptr<ov::Node> convert_color;
-            if (conversionToRGB) {
-                convert_color = std::make_shared<ov::op::v8::I420toRGB>(param_y, param_u, param_v);
-            } else {
-                convert_color = std::make_shared<ov::op::v8::I420toBGR>(param_y, param_u, param_v);
-            }
-            function = std::make_shared<ov::Model>(std::make_shared<ov::op::v0::Result>(convert_color),
-                                                   ov::ParameterVector{param_y, param_u, param_v},
-                                                   "ConvertColorI420");
-        }
-    }
-
-    InferenceEngine::Blob::Ptr GenerateInput(const InferenceEngine::InputInfo& info) const override {
-        return FuncTestUtils::createAndFillBlob(info.getTensorDesc(), 255);
-    }
-};
-
-TEST_P(ConvertColorI420CUDAAccuracyTest, CompareWithRefs) { Run(); }
-
-const std::vector<ov::Shape> inShapes_nhwc = {
+const std::vector<ov::Shape> in_shapes_nhwc = {
     {1, 10, 10, 1},
     {1, 50, 10, 1},
     {1, 100, 10, 1},
@@ -112,43 +31,78 @@ const std::vector<ov::Shape> inShapes_nhwc = {
     {1, 96, 16, 1},
 };
 
-const std::vector<ov::element::Type> inTypes = {
+auto generate_input_static_shapes = [] (const std::vector<ov::Shape>& original_shapes, bool single_plane) {
+    std::vector<std::vector<ov::Shape>> result_shapes;
+    for (const auto& original_shape : original_shapes) {
+        std::vector<ov::Shape> one_result_shapes;
+        if (single_plane) {
+            auto shape = original_shape;
+            shape[1] = shape[1] * 3 / 2;
+            one_result_shapes.push_back(shape);
+        } else {
+            auto shape = original_shape;
+            one_result_shapes.push_back(shape);
+            auto uvShape = ov::Shape{shape[0], shape[1] / 2, shape[2] / 2, 1};
+            one_result_shapes.push_back(uvShape);
+            one_result_shapes.push_back(uvShape);
+        }
+        result_shapes.push_back(one_result_shapes);
+    }
+    return result_shapes;
+};
+
+auto in_shapes_single_plain_static     = generate_input_static_shapes(in_shapes_nhwc, true);
+auto in_shapes_not_single_plain_static = generate_input_static_shapes(in_shapes_nhwc, false);
+
+const std::vector<ov::element::Type> in_types = {
     ov::element::u8,
     ov::element::f32,
     ov::element::f16,
 };
 
-const auto testCase_values = ::testing::Combine(::testing::ValuesIn(inShapes_nhwc),
-                                                ::testing::ValuesIn(inTypes),
-                                                ::testing::Bool(),
-                                                ::testing::Bool(),
-                                                ::testing::Values(ov::test::utils::DEVICE_NVIDIA));
+const auto test_case_values_single_plain = ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(in_shapes_single_plain_static)),
+                                                              ::testing::ValuesIn(in_types),
+                                                              ::testing::Bool(),
+                                                              ::testing::Values(true),
+                                                              ::testing::Values(DEVICE_NVIDIA));
 
-INSTANTIATE_TEST_SUITE_P(smoke_TestsConvertColorI420,
+INSTANTIATE_TEST_SUITE_P(smoke_TestsConvertColorI420_single_plain,
                          ConvertColorI420CUDALayerTest,
-                         testCase_values,
+                         test_case_values_single_plain,
                          ConvertColorI420CUDALayerTest::getTestCaseName);
 
-const auto testCase_accuracy_values = ::testing::Combine(::testing::Values(ov::Shape{1, 96, 16, 1}),
-                                                         ::testing::Values(ov::element::u8),
-                                                         ::testing::Values(false),
-                                                         ::testing::Values(true),
-                                                         ::testing::Values(ov::test::utils::DEVICE_NVIDIA));
+const auto test_case_values_not_single_plain = ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(in_shapes_not_single_plain_static)),
+                                                                  ::testing::ValuesIn(in_types),
+                                                                  ::testing::Bool(),
+                                                                  ::testing::Values(false),
+                                                                  ::testing::Values(DEVICE_NVIDIA));
+
+INSTANTIATE_TEST_SUITE_P(smoke_TestsConvertColorI420_not_single_plain,
+                         ConvertColorI420CUDALayerTest,
+                         test_case_values_not_single_plain,
+                         ConvertColorI420CUDALayerTest::getTestCaseName);
+
+
+const auto test_case_accuracy_values = ::testing::Combine(::testing::Values(static_shapes_to_test_representation({ov::Shape{1, 96, 16, 1}})),
+                                                          ::testing::Values(ov::element::u8),
+                                                          ::testing::Values(false),
+                                                          ::testing::Values(true),
+                                                          ::testing::Values(DEVICE_NVIDIA));
 
 INSTANTIATE_TEST_SUITE_P(smoke_TestsConvertColorI420_acc,
-                         ConvertColorI420CUDAAccuracyTest,
-                         testCase_accuracy_values,
+                         ConvertColorI420CUDALayerTest,
+                         test_case_accuracy_values,
                          ConvertColorI420CUDALayerTest::getTestCaseName);
 
-const auto testCase_accuracy_values_nightly = ::testing::Combine(::testing::Values(ov::Shape{1, 65536, 256, 1}),
-                                                                 ::testing::Values(ov::element::u8),
-                                                                 ::testing::Values(false),
-                                                                 ::testing::Values(true),
-                                                                 ::testing::Values(ov::test::utils::DEVICE_NVIDIA));
+const auto test_case_accuracy_values_nightly = ::testing::Combine(::testing::Values(static_shapes_to_test_representation({ov::Shape{1, 65538, 256, 1}})),
+                                                                  ::testing::Values(ov::element::u8),
+                                                                  ::testing::Values(false),
+                                                                  ::testing::Values(true),
+                                                                  ::testing::Values(DEVICE_NVIDIA));
 
 INSTANTIATE_TEST_SUITE_P(nightly_TestsConvertColorI420_acc,
-                         ConvertColorI420CUDAAccuracyTest,
-                         testCase_accuracy_values_nightly,
+                         ConvertColorI420CUDALayerTest,
+                         test_case_accuracy_values_nightly,
                          ConvertColorI420CUDALayerTest::getTestCaseName);
 
 }  // namespace

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convert_color_nv12.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convert_color_nv12.cpp
@@ -2,25 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "single_layer_tests/convert_color_nv12.hpp"
+#include "single_op_tests/convert_color_nv12.hpp"
+#include "convert_color_common.hpp"
 
 #include <cuda_test_constants.hpp>
 #include <vector>
 
-using namespace LayerTestsDefinitions;
-
 namespace {
 
-class ConvertColorNV12CUDALayerTest : public ConvertColorNV12LayerTest {
-private:
-    InferenceEngine::Blob::Ptr GenerateInput(const InferenceEngine::InputInfo& info) const override {
-        return FuncTestUtils::createAndFillBlob(info.getTensorDesc(), 255);
-    }
-};
+using namespace ov::test;
+using namespace ov::test::nvidia_gpu;
+using namespace ov::test::utils;
 
-TEST_P(ConvertColorNV12CUDALayerTest, CompareWithRefs) { Run(); }
+class ConvertColorNV12CUDALayerTest : public ConvertColorCUDALayerTest, public ConvertColorNV12LayerTest {};
 
-const std::vector<ov::Shape> inShapes_nhwc = {
+TEST_P(ConvertColorNV12CUDALayerTest, Inference) { run(); }
+
+const std::vector<ov::Shape> in_shapes_nhwc = {
     {1, 10, 10, 1},
     {1, 50, 10, 1},
     {1, 100, 10, 1},
@@ -33,52 +31,77 @@ const std::vector<ov::Shape> inShapes_nhwc = {
     {1, 96, 16, 1},
 };
 
-const std::vector<ov::element::Type> inTypes = {
+auto generate_input_static_shapes = [] (const std::vector<ov::Shape>& original_shapes, bool single_plane) {
+    std::vector<std::vector<ov::Shape>> result_shapes;
+    for (const auto& original_shape : original_shapes) {
+        std::vector<ov::Shape> one_result_shapes;
+        if (single_plane) {
+            auto shape = original_shape;
+            shape[1] = shape[1] * 3 / 2;
+            one_result_shapes.push_back(shape);
+        } else {
+            auto shape = original_shape;
+            one_result_shapes.push_back(shape);
+            auto uvShape = ov::Shape{shape[0], shape[1] / 2, shape[2] / 2, 2};
+            one_result_shapes.push_back(uvShape);
+        }
+        result_shapes.push_back(one_result_shapes);
+    }
+    return result_shapes;
+};
+
+auto in_shapes_single_plain_static     = generate_input_static_shapes(in_shapes_nhwc, true);
+auto in_shapes_not_single_plain_static = generate_input_static_shapes(in_shapes_nhwc, false);
+
+const std::vector<ov::element::Type> in_types = {
     ov::element::u8,
     ov::element::f32,
     ov::element::f16,
 };
 
-const auto testCase_values = ::testing::Combine(::testing::ValuesIn(inShapes_nhwc),
-                                                ::testing::ValuesIn(inTypes),
-                                                ::testing::Bool(),
-                                                ::testing::Bool(),
-                                                ::testing::Values(ov::test::utils::DEVICE_NVIDIA));
+const auto test_case_values_single_plain = ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(in_shapes_single_plain_static)),
+                                                              ::testing::ValuesIn(in_types),
+                                                              ::testing::Bool(),
+                                                              ::testing::Values(true),
+                                                              ::testing::Values(DEVICE_NVIDIA));
 
-INSTANTIATE_TEST_SUITE_P(smoke_TestsConvertColorNV12,
+INSTANTIATE_TEST_SUITE_P(smoke_TestsConvertColorNV12_single_plain,
                          ConvertColorNV12CUDALayerTest,
-                         testCase_values,
+                         test_case_values_single_plain,
                          ConvertColorNV12CUDALayerTest::getTestCaseName);
 
-class ConvertColorNV12CUDAAccuracyTest : public ConvertColorNV12AccuracyTest {
-private:
-    InferenceEngine::Blob::Ptr GenerateInput(const InferenceEngine::InputInfo& info) const override {
-        return FuncTestUtils::createAndFillBlob(info.getTensorDesc(), 255);
-    }
-};
+const auto test_case_values_not_single_plain = ::testing::Combine(::testing::ValuesIn(static_shapes_to_test_representation(in_shapes_not_single_plain_static)),
+                                                              ::testing::ValuesIn(in_types),
+                                                              ::testing::Bool(),
+                                                              ::testing::Values(false),
+                                                              ::testing::Values(DEVICE_NVIDIA));
 
-TEST_P(ConvertColorNV12CUDAAccuracyTest, CompareWithRefs) { Run(); }
+INSTANTIATE_TEST_SUITE_P(smoke_TestsConvertColorNV12_not_single_plain,
+                         ConvertColorNV12CUDALayerTest,
+                         test_case_values_not_single_plain,
+                         ConvertColorNV12CUDALayerTest::getTestCaseName);
 
-const auto testCase_accuracy_values = ::testing::Combine(::testing::Values(ov::Shape{1, 96, 16, 1}),
-                                                         ::testing::Values(ov::element::u8),
-                                                         ::testing::Values(false),
-                                                         ::testing::Values(true),
-                                                         ::testing::Values(ov::test::utils::DEVICE_NVIDIA));
+
+const auto test_case_accuracy_values = ::testing::Combine(::testing::Values(static_shapes_to_test_representation({ov::Shape{1, 96, 16, 1}})),
+                                                          ::testing::Values(ov::element::u8),
+                                                          ::testing::Values(false),
+                                                          ::testing::Values(true),
+                                                          ::testing::Values(DEVICE_NVIDIA));
 
 INSTANTIATE_TEST_SUITE_P(smoke_TestsConvertColorNV12_acc,
-                         ConvertColorNV12CUDAAccuracyTest,
-                         testCase_accuracy_values,
+                         ConvertColorNV12CUDALayerTest,
+                         test_case_accuracy_values,
                          ConvertColorNV12LayerTest::getTestCaseName);
 
-const auto testCase_accuracy_values_nightly = ::testing::Combine(::testing::Values(ov::Shape{1, 65536, 256, 1}),
-                                                                 ::testing::Values(ov::element::u8),
-                                                                 ::testing::Values(false),
-                                                                 ::testing::Values(true),
-                                                                 ::testing::Values(ov::test::utils::DEVICE_NVIDIA));
+const auto test_case_accuracy_values_nightly = ::testing::Combine(::testing::Values(static_shapes_to_test_representation({ov::Shape{1, 65538, 256, 1}})),
+                                                                  ::testing::Values(ov::element::u8),
+                                                                  ::testing::Values(false),
+                                                                  ::testing::Values(true),
+                                                                  ::testing::Values(DEVICE_NVIDIA));
 
 INSTANTIATE_TEST_SUITE_P(nightly_TestsConvertColorNV12_acc,
-                         ConvertColorNV12CUDAAccuracyTest,
-                         testCase_accuracy_values_nightly,
+                         ConvertColorNV12CUDALayerTest,
+                         test_case_accuracy_values_nightly,
                          ConvertColorNV12LayerTest::getTestCaseName);
 
 }  // namespace


### PR DESCRIPTION
### Details:
- *Move Convert, ConvertColorI420, ConvertColorNV12 tests to API2.0*

Depends on https://github.com/openvinotoolkit/openvino/pull/20227

### Tickets:
- *111380*
