### PR TITLE
[NVIDIA] Move Transpose, VeriadicSplit layer tests to API 2.0

### DIFF
--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/transpose_test.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/transpose_test.cpp
@@ -2,42 +2,43 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "single_layer_tests/transpose.hpp"
-
-#include <cuda_test_constants.hpp>
 #include <vector>
 
 #include "common_test_utils/test_constants.hpp"
+#include "cuda_test_constants.hpp"
+#include "single_op_tests/transpose.hpp"
 
-using namespace LayerTestsDefinitions;
 
 namespace {
 
-const std::vector<InferenceEngine::Precision> netPrecisions = {
-    InferenceEngine::Precision::FP16,
-    InferenceEngine::Precision::FP32,
+using namespace ov::test;
+using namespace ov::test::utils;
+using ov::test::TransposeLayerTest;
+
+const std::vector<ov::element::Type> model_types = {
+    ov::element::f16,
+    ov::element::f32,
 };
 
-const std::vector<std::vector<size_t>> inputShapes = {
-    std::vector<size_t>{256, 3, 100, 100},
-    std::vector<size_t>{1, 2048, 1, 1},
+const std::vector<std::vector<ov::Shape>> input_shapes = {
+    {{256, 3, 100, 100}},
+    {{1, 2048, 1, 1}},
 };
 
-const std::vector<std::vector<size_t>> inputOrder = {
+const std::vector<std::vector<size_t>> input_order = {
     std::vector<size_t>{0, 3, 2, 1},
     // Empty inputs are currently unsupported in nvidia_gpu.
     //        std::vector<size_t>{},
 };
 
-const auto params = testing::Combine(testing::ValuesIn(inputOrder),
-                                     testing::ValuesIn(netPrecisions),
-                                     testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                     testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                     testing::Values(InferenceEngine::Layout::ANY),
-                                     testing::Values(InferenceEngine::Layout::ANY),
-                                     testing::ValuesIn(inputShapes),
-                                     testing::Values(ov::test::utils::DEVICE_NVIDIA));
+const auto params = testing::Combine(testing::ValuesIn(input_order),
+                                     testing::ValuesIn(model_types),
+                                     testing::ValuesIn(static_shapes_to_test_representation(input_shapes)),
+                                     testing::Values(DEVICE_NVIDIA));
 
-INSTANTIATE_TEST_CASE_P(smoke_Transpose, TransposeLayerTest, params, TransposeLayerTest::getTestCaseName);
+INSTANTIATE_TEST_CASE_P(smoke_Transpose,
+                        TransposeLayerTest,
+                        params,
+                        TransposeLayerTest::getTestCaseName);
 
 }  // namespace

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/variadic_split.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/variadic_split.cpp
@@ -2,24 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "single_layer_tests/variadic_split.hpp"
-
 #include <vector>
 
 #include "common_test_utils/test_constants.hpp"
 #include "cuda_test_constants.hpp"
-
-using namespace LayerTestsDefinitions;
+#include "single_op_tests/variadic_split.hpp"
 
 namespace {
 
-const std::vector<InferenceEngine::Precision> netPrecisions = {
-    InferenceEngine::Precision::FP32,
-    InferenceEngine::Precision::FP16,
+using namespace ov::test;
+using namespace ov::test::utils;
+using ov::test::VariadicSplitLayerTest;
+
+const std::vector<ov::element::Type> model_types = {
+    ov::element::f32,
+    ov::element::f16
 };
 
 // Sum of elements numSplits = inputShapes[Axis]
-const std::vector<std::vector<size_t>> smoke_numSplits = {
+const std::vector<std::vector<size_t>> num_splits = {
     {1, 16, 5, 8},
     {2, 19, 5, 4},
     {7, 13, 2, 8},
@@ -27,201 +28,122 @@ const std::vector<std::vector<size_t>> smoke_numSplits = {
     {4, 11, 6, 9},
 };
 
-const std::vector<int64_t> smoke_axis = {-3, -2, -1, 0, 1, 2, 3};
+const std::vector<int64_t> axis = {-3, -2, -1, 0, 1, 2, 3};
 
-INSTANTIATE_TEST_CASE_P(smoke_NumSplitsCheck,
+INSTANTIATE_TEST_CASE_P(num_splitsCheck,
                         VariadicSplitLayerTest,
-                        ::testing::Combine(::testing::ValuesIn(smoke_numSplits),
-                                           ::testing::ValuesIn(smoke_axis),
-                                           ::testing::ValuesIn(netPrecisions),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(std::vector<size_t>({30, 30, 30, 30})),
-                                           ::testing::Values(ov::test::utils::DEVICE_NVIDIA)),
-                        VariadicSplitLayerTest::getTestCaseName);
-
-INSTANTIATE_TEST_CASE_P(smoke_NumSplitsCheck_U32,
-                        VariadicSplitLayerTest,
-                        ::testing::Combine(::testing::ValuesIn(smoke_numSplits),
-                                           ::testing::ValuesIn(smoke_axis),
-                                           ::testing::Values(InferenceEngine::Precision::U32),
-                                           ::testing::Values(InferenceEngine::Precision::U32),
-                                           ::testing::Values(InferenceEngine::Precision::U32),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(std::vector<size_t>({30, 30, 30, 30})),
-                                           ::testing::Values(ov::test::utils::DEVICE_NVIDIA)),
-                        VariadicSplitLayerTest::getTestCaseName);
-
-INSTANTIATE_TEST_CASE_P(smoke_NumSplitsCheck_I64,
-                        VariadicSplitLayerTest,
-                        ::testing::Combine(::testing::ValuesIn(smoke_numSplits),
-                                           ::testing::ValuesIn(smoke_axis),
-                                           ::testing::Values(InferenceEngine::Precision::I64),
-                                           ::testing::Values(InferenceEngine::Precision::I64),
-                                           ::testing::Values(InferenceEngine::Precision::I64),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(std::vector<size_t>({30, 30, 30, 30})),
-                                           ::testing::Values(ov::test::utils::DEVICE_NVIDIA)),
+                        ::testing::Combine(::testing::ValuesIn(num_splits),
+                                           ::testing::ValuesIn(axis),
+                                           ::testing::ValuesIn(model_types),
+                                           ::testing::Values(static_shapes_to_test_representation({{30, 30, 30, 30}})),
+                                           ::testing::Values(DEVICE_NVIDIA)),
                         VariadicSplitLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(yolov5_NumSplitsCheck_shape0_axis1,
                         VariadicSplitLayerTest,
                         ::testing::Combine(::testing::Values(std::vector<size_t>{1, 1, 1}),
                                            ::testing::Values(1),
-                                           ::testing::ValuesIn(netPrecisions),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(std::vector<size_t>{1, 3, 40, 40, 85}),
-                                           ::testing::Values(ov::test::utils::DEVICE_NVIDIA)),
+                                           ::testing::ValuesIn(model_types),
+                                           ::testing::Values(static_shapes_to_test_representation({{1, 3, 40, 40, 85}})),
+                                           ::testing::Values(DEVICE_NVIDIA)),
                         VariadicSplitLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(yolov5_NumSplitsCheck_shape0_axis2,
                         VariadicSplitLayerTest,
                         ::testing::Combine(::testing::Values(std::vector<size_t>{10, 20, 10}),
                                            ::testing::Values(2),
-                                           ::testing::ValuesIn(netPrecisions),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(std::vector<size_t>{1, 3, 40, 40, 85}),
-                                           ::testing::Values(ov::test::utils::DEVICE_NVIDIA)),
+                                           ::testing::ValuesIn(model_types),
+                                           ::testing::Values(static_shapes_to_test_representation({{1, 3, 40, 40, 85}})),
+                                           ::testing::Values(DEVICE_NVIDIA)),
                         VariadicSplitLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(yolov5_NumSplitsCheck_shape0_axis3,
                         VariadicSplitLayerTest,
                         ::testing::Combine(::testing::Values(std::vector<size_t>{5, 5, 30}),
                                            ::testing::Values(3),
-                                           ::testing::ValuesIn(netPrecisions),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(std::vector<size_t>{1, 3, 40, 40, 85}),
-                                           ::testing::Values(ov::test::utils::DEVICE_NVIDIA)),
+                                           ::testing::ValuesIn(model_types),
+                                           ::testing::Values(static_shapes_to_test_representation({{1, 3, 40, 40, 85}})),
+                                           ::testing::Values(DEVICE_NVIDIA)),
                         VariadicSplitLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(yolov5_NumSplitsCheck_shape0_axis4,
                         VariadicSplitLayerTest,
                         ::testing::Combine(::testing::Values(std::vector<size_t>{20, 60, 5}),
                                            ::testing::Values(4),
-                                           ::testing::ValuesIn(netPrecisions),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(std::vector<size_t>{1, 3, 40, 40, 85}),
-                                           ::testing::Values(ov::test::utils::DEVICE_NVIDIA)),
+                                           ::testing::ValuesIn(model_types),
+                                           ::testing::Values(static_shapes_to_test_representation({{1, 3, 40, 40, 85}})),
+                                           ::testing::Values(DEVICE_NVIDIA)),
                         VariadicSplitLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(yolov5_NumSplitsCheck_shape1_axis1,
                         VariadicSplitLayerTest,
                         ::testing::Combine(::testing::Values(std::vector<size_t>{1, 1, 1}),
                                            ::testing::Values(1),
-                                           ::testing::ValuesIn(netPrecisions),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(std::vector<size_t>{1, 3, 20, 20, 85}),
-                                           ::testing::Values(ov::test::utils::DEVICE_NVIDIA)),
+                                           ::testing::ValuesIn(model_types),
+                                           ::testing::Values(static_shapes_to_test_representation({{1, 3, 20, 20, 85}})),
+                                           ::testing::Values(DEVICE_NVIDIA)),
                         VariadicSplitLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(yolov5_NumSplitsCheck_shape1_axis2,
                         VariadicSplitLayerTest,
                         ::testing::Combine(::testing::Values(std::vector<size_t>{5, 12, 3}),
                                            ::testing::Values(2),
-                                           ::testing::ValuesIn(netPrecisions),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(std::vector<size_t>{1, 3, 20, 20, 85}),
-                                           ::testing::Values(ov::test::utils::DEVICE_NVIDIA)),
+                                           ::testing::ValuesIn(model_types),
+                                           ::testing::Values(static_shapes_to_test_representation({{1, 3, 20, 20, 85}})),
+                                           ::testing::Values(DEVICE_NVIDIA)),
                         VariadicSplitLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(yolov5_NumSplitsCheck_shape1_axis3,
                         VariadicSplitLayerTest,
                         ::testing::Combine(::testing::Values(std::vector<size_t>{2, 8, 10}),
                                            ::testing::Values(3),
-                                           ::testing::ValuesIn(netPrecisions),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(std::vector<size_t>{1, 3, 20, 20, 85}),
-                                           ::testing::Values(ov::test::utils::DEVICE_NVIDIA)),
+                                           ::testing::ValuesIn(model_types),
+                                           ::testing::Values(static_shapes_to_test_representation({{1, 3, 20, 20, 85}})),
+                                           ::testing::Values(DEVICE_NVIDIA)),
                         VariadicSplitLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(yolov5_NumSplitsCheck_shape1_axis4,
                         VariadicSplitLayerTest,
                         ::testing::Combine(::testing::Values(std::vector<size_t>{65, 3, 17}),
                                            ::testing::Values(4),
-                                           ::testing::ValuesIn(netPrecisions),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(std::vector<size_t>{1, 3, 20, 20, 85}),
-                                           ::testing::Values(ov::test::utils::DEVICE_NVIDIA)),
+                                           ::testing::ValuesIn(model_types),
+                                           ::testing::Values(static_shapes_to_test_representation({{1, 3, 20, 20, 85}})),
+                                           ::testing::Values(DEVICE_NVIDIA)),
                         VariadicSplitLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(yolov5_NumSplitsCheck_shape2_axis1,
                         VariadicSplitLayerTest,
                         ::testing::Combine(::testing::Values(std::vector<size_t>{1, 1, 1}),
                                            ::testing::Values(1),
-                                           ::testing::ValuesIn(netPrecisions),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(std::vector<size_t>{1, 3, 80, 80, 85}),
-                                           ::testing::Values(ov::test::utils::DEVICE_NVIDIA)),
+                                           ::testing::ValuesIn(model_types),
+                                           ::testing::Values(static_shapes_to_test_representation({{1, 3, 80, 80, 85}})),
+                                           ::testing::Values(DEVICE_NVIDIA)),
                         VariadicSplitLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(yolov5_NumSplitsCheck_shape2_axis2,
                         VariadicSplitLayerTest,
                         ::testing::Combine(::testing::Values(std::vector<size_t>{13, 13, 54}),
                                            ::testing::Values(2),
-                                           ::testing::ValuesIn(netPrecisions),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(std::vector<size_t>{1, 3, 80, 80, 85}),
-                                           ::testing::Values(ov::test::utils::DEVICE_NVIDIA)),
+                                           ::testing::ValuesIn(model_types),
+                                           ::testing::Values(static_shapes_to_test_representation({{1, 3, 80, 80, 85}})),
+                                           ::testing::Values(DEVICE_NVIDIA)),
                         VariadicSplitLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(yolov5_NumSplitsCheck_shape2_axis3,
                         VariadicSplitLayerTest,
                         ::testing::Combine(::testing::Values(std::vector<size_t>{7, 3, 70}),
                                            ::testing::Values(3),
-                                           ::testing::ValuesIn(netPrecisions),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(std::vector<size_t>{1, 3, 80, 80, 85}),
-                                           ::testing::Values(ov::test::utils::DEVICE_NVIDIA)),
+                                           ::testing::ValuesIn(model_types),
+                                           ::testing::Values(static_shapes_to_test_representation({{1, 3, 80, 80, 85}})),
+                                           ::testing::Values(DEVICE_NVIDIA)),
                         VariadicSplitLayerTest::getTestCaseName);
 
 INSTANTIATE_TEST_CASE_P(yolov5_NumSplitsCheck_shape2_axis4,
                         VariadicSplitLayerTest,
                         ::testing::Combine(::testing::Values(std::vector<size_t>{1, 1, 83}),
                                            ::testing::Values(4),
-                                           ::testing::ValuesIn(netPrecisions),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Precision::UNSPECIFIED),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(InferenceEngine::Layout::ANY),
-                                           ::testing::Values(std::vector<size_t>{1, 3, 80, 80, 85}),
-                                           ::testing::Values(ov::test::utils::DEVICE_NVIDIA)),
+                                           ::testing::ValuesIn(model_types),
+                                           ::testing::Values(static_shapes_to_test_representation({{1, 3, 80, 80, 85}})),
+                                           ::testing::Values(DEVICE_NVIDIA)),
                         VariadicSplitLayerTest::getTestCaseName);
-
 }  // namespace


### PR DESCRIPTION
### Details:
- *Move Transpose, VeriadicSplit layer tests to API 2.0*

### Tickets:
- *111380*
