### PR TITLE
[NVIDIA] Fix Unit Tests

### DIFF
--- a/modules/nvidia_plugin/tests/unit/compile_model.cpp
+++ b/modules/nvidia_plugin/tests/unit/compile_model.cpp
@@ -72,10 +72,9 @@ TEST_P(MatMulCompileModelTest, BuildExecutableSequence_MatMul_Success) {
     auto plugin = std::make_shared<Plugin>();
     auto cuda_compiled_model = std::dynamic_pointer_cast<CompiledModel>(plugin->compile_model(model_, properties));
     const auto& execSequence = GetExecSequence(cuda_compiled_model);
-    bool is_f32 = properties.at(ov::hint::inference_precision.name()).as<ov::element::Type>() == ov::element::f32;
-    auto expected_ops = is_f32 ? 3 : 5;  // +2 Converts for f16
+    ASSERT_TRUE(execSequence.size() == 3 || execSequence.size() == 5);
+    bool is_f32 = execSequence.size() == 3;
     auto matmul_index = is_f32 ? 1 : 2;
-    ASSERT_EQ(execSequence.size(), expected_ops);
     ASSERT_EQ(std::type_index(typeid(*execSequence[matmul_index].get())), std::type_index(typeid(MatMulOp)));
 }
 

--- a/modules/nvidia_plugin/tests/unit/memory_manager/cuda_immutable_memory_block_builder_test.cpp
+++ b/modules/nvidia_plugin/tests/unit/memory_manager/cuda_immutable_memory_block_builder_test.cpp
@@ -63,14 +63,8 @@ TEST(ImmutableMemoryBlockBuilder, HandleDuplicateAllocation) {
 
     builder.addAllocation(duplicate_buffer_id, &t0_data[0], t0_data.size());
 
-#ifdef NDEBUG
     ASSERT_THROW(builder.addAllocation(duplicate_buffer_id, &t0_data[0], t0_data.size()), ov::Exception);
     ASSERT_THROW(builder.addAllocation(duplicate_buffer_id, &t1_data[0], t1_data.size()), ov::Exception);
-#else
-    testing::FLAGS_gtest_death_test_style = "threadsafe";
-    ASSERT_DEATH(builder.addAllocation(duplicate_buffer_id, &t0_data[0], t0_data.size()), "Assertion");
-    ASSERT_DEATH(builder.addAllocation(duplicate_buffer_id, &t1_data[0], t1_data.size()), "Assertion");
-#endif
 }
 
 TEST(ImmutableMemoryBlockBuilder, HandleZeroAllocationSize) {
@@ -81,14 +75,8 @@ TEST(ImmutableMemoryBlockBuilder, HandleZeroAllocationSize) {
     BufferID buffer_id = 1;
     const std::vector<uint8_t> data(16, 0xA5);
 
-#ifdef NDEBUG
     ASSERT_THROW(builder.addAllocation(buffer_id, &data[0], 0), ov::Exception);
     ASSERT_THROW(builder.addAllocation(buffer_id, nullptr, 0), ov::Exception);
-#else
-    testing::FLAGS_gtest_death_test_style = "threadsafe";
-    ASSERT_DEATH(builder.addAllocation(buffer_id, &data[0], 0), "Assertion");
-    ASSERT_DEATH(builder.addAllocation(buffer_id, nullptr, 0), "Assertion");
-#endif
 }
 
 TEST(ImmutableMemoryBlockBuilder, HandleNullDataPointer) {
@@ -98,10 +86,5 @@ TEST(ImmutableMemoryBlockBuilder, HandleNullDataPointer) {
 
     BufferID buffer_id = 1;
 
-#ifdef NDEBUG
     ASSERT_THROW(builder.addAllocation(buffer_id, nullptr, 128), ov::Exception);
-#else
-    testing::FLAGS_gtest_death_test_style = "threadsafe";
-    ASSERT_DEATH(builder.addAllocation(buffer_id, nullptr, 128), "Assertion");
-#endif
 }

--- a/modules/nvidia_plugin/tests/unit/memory_manager/cuda_memory_manager_test.cpp
+++ b/modules/nvidia_plugin/tests/unit/memory_manager/cuda_memory_manager_test.cpp
@@ -170,12 +170,7 @@ TEST_F(MemoryManagerTest, InvalidInputTensorID) {
 
     auto allocation = CUDA::DefaultStream::stream().malloc(immutableTensors_->memoryModel()->deviceMemoryBlockSize() +
                                                            mutableMemoryModel_->deviceMemoryBlockSize());
-#ifdef NDEBUG
     ASSERT_THROW(memory_manager->inputTensorPointers(*this, allocation), ov::Exception);
-#else
-    testing::FLAGS_gtest_death_test_style = "threadsafe";
-    ASSERT_DEATH(memory_manager->inputTensorPointers(*this, allocation), "Assertion");
-#endif
 }
 
 TEST_F(MemoryManagerTest, InvalidOutputTensorID) {
@@ -191,12 +186,7 @@ TEST_F(MemoryManagerTest, InvalidOutputTensorID) {
 
     auto allocation = CUDA::DefaultStream::stream().malloc(immutableTensors_->memoryModel()->deviceMemoryBlockSize() +
                                                            mutableMemoryModel_->deviceMemoryBlockSize());
-#ifdef NDEBUG
     ASSERT_THROW(memory_manager->outputTensorPointers(*this, allocation), ov::Exception);
-#else
-    testing::FLAGS_gtest_death_test_style = "threadsafe";
-    ASSERT_DEATH(memory_manager->outputTensorPointers(*this, allocation), "Assertion");
-#endif
 }
 
 TEST_F(MemoryManagerTest, ConstantsCanNotBeOutputs) {
@@ -208,10 +198,5 @@ TEST_F(MemoryManagerTest, ConstantsCanNotBeOutputs) {
 
     auto allocation = CUDA::DefaultStream::stream().malloc(immutableTensors_->memoryModel()->deviceMemoryBlockSize() +
                                                            mutableMemoryModel_->deviceMemoryBlockSize());
-#ifdef NDEBUG
     ASSERT_THROW(memory_manager->outputTensorPointers(*this, allocation), ov::Exception);
-#else
-    testing::FLAGS_gtest_death_test_style = "threadsafe";
-    ASSERT_DEATH(memory_manager->outputTensorPointers(*this, allocation), "Assertion");
-#endif
 }

--- a/modules/nvidia_plugin/tests/unit/memory_manager/model/cuda_immutable_memory_model_builder_test.cpp
+++ b/modules/nvidia_plugin/tests/unit/memory_manager/model/cuda_immutable_memory_model_builder_test.cpp
@@ -66,14 +66,8 @@ TEST(ImmutableMemoryModelBuilder, HandleDuplicateAllocation) {
 
     builder.addAllocation(duplicate_buffer_id, size1);
 
-#ifdef NDEBUG
     ASSERT_THROW(builder.addAllocation(duplicate_buffer_id, size1), ov::Exception);
     ASSERT_THROW(builder.addAllocation(duplicate_buffer_id, size2), ov::Exception);
-#else
-    testing::FLAGS_gtest_death_test_style = "threadsafe";
-    ASSERT_DEATH(builder.addAllocation(duplicate_buffer_id, size1), "Assertion");
-    ASSERT_DEATH(builder.addAllocation(duplicate_buffer_id, size2), "Assertion");
-#endif
 }
 
 TEST(ImmutableMemoryModelBuilder, HandleZeroAllocationSize) {
@@ -83,10 +77,5 @@ TEST(ImmutableMemoryModelBuilder, HandleZeroAllocationSize) {
 
     BufferID buffer_id = 1;
 
-#ifdef NDEBUG
     ASSERT_THROW(builder.addAllocation(buffer_id, 0), ov::Exception);
-#else
-    testing::FLAGS_gtest_death_test_style = "threadsafe";
-    ASSERT_DEATH(builder.addAllocation(buffer_id, 0), "Assertion");
-#endif
 }

--- a/modules/nvidia_plugin/tests/unit/memory_manager/model/cuda_memory_model_builder_test.cpp
+++ b/modules/nvidia_plugin/tests/unit/memory_manager/model/cuda_memory_model_builder_test.cpp
@@ -101,16 +101,9 @@ TEST(MemoryModelBuilder, HandleDuplicateAllocation) {
 
     builder.addAllocation(duplicate_buffer_id, 0, 1, size1);
 
-#ifdef NDEBUG
     ASSERT_THROW(builder.addAllocation(duplicate_buffer_id, 0, 1, size1), ov::Exception);
     ASSERT_THROW(builder.addAllocation(duplicate_buffer_id, 0, 1, size2), ov::Exception);
     ASSERT_THROW(builder.addAllocation(duplicate_buffer_id, 1, 2, size1), ov::Exception);
-#else
-    testing::FLAGS_gtest_death_test_style = "threadsafe";
-    ASSERT_DEATH(builder.addAllocation(duplicate_buffer_id, 0, 1, size1), "Assertion");
-    ASSERT_DEATH(builder.addAllocation(duplicate_buffer_id, 0, 1, size2), "Assertion");
-    ASSERT_DEATH(builder.addAllocation(duplicate_buffer_id, 1, 2, size1), "Assertion");
-#endif
 }
 
 TEST(MemoryModelBuilder, HandleZeroAllocationSize) {
@@ -121,12 +114,7 @@ TEST(MemoryModelBuilder, HandleZeroAllocationSize) {
     BufferID buffer_id = 1;
     const size_t size = 0;
 
-#ifdef NDEBUG
     ASSERT_THROW(builder.addAllocation(buffer_id, 0, 1, size), ov::Exception);
-#else
-    testing::FLAGS_gtest_death_test_style = "threadsafe";
-    ASSERT_DEATH(builder.addAllocation(buffer_id, 0, 1, size), "Assertion");
-#endif
 }
 
 /*


### PR DESCRIPTION
## Description

Changes:
- Previously in release mode some of Unit Tests expected to crash with ASSERT_DEATH, but after switching to OPENVINO_ASSERT which always throws exception it is not anymore a case
- Updated MatMul test which not always converts to FP16