### PR TITLE
Add references to Rust API

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This list gives an overview of all modules available inside the contrib reposito
 
 * [**nvidia_plugin**](./modules/nvidia_plugin): NVIDIA GPU Plugin -- allows to perform deep neural networks inference on NVIDIA GPUs using CUDA, using OpenVINO API.
 * [**java_api**](./modules/java_api): Inference Engine Java API -- provides Java wrappers for Inference Engine public API.
+* [**rust_api**](./modules/rust_api): Inference Engine Rust API -- explains how to use the OpenVINO APIs from Rust.
 * [**custom_operations**](./modules/custom_operations/): Collection of Custom Operations -- implement Custom Operations with OpenVINO Extensibility Mechanism.
 * [**Token Merging**](./modules/token_merging/): adaptation of [Token Merging method](https://arxiv.org/abs/2210.09461) for OpenVINO.
 * [**OpenVINO Code**](./modules/openvino_code): VSCode extension for AI code completion with OpenVINO.

--- a/modules/rust_api/README.md
+++ b/modules/rust_api/README.md
@@ -1,0 +1,24 @@
+# Rust bindings for OpenVINO
+
+[![Build Status](https://github.com/intel/openvino-rs/workflows/CI/badge.svg)][ci]
+[![Documentation Status](https://docs.rs/openvino/badge.svg)][docs]
+
+Rust bindings for OpenVINO's APIs are currently maintained elsewhere; please submit bug reports and
+feature requests to [openvino-rs].
+
+[openvino-rs]: https://github.com/intel/openvino-rs
+
+### Use
+
+In your `Cargo.toml`:
+
+```toml
+[dependencies]
+openvino = "<latest version>"
+```
+
+To check for the latest version, see the [crates.io page]. Documentation is available at the
+[docs.rs page].
+
+[crates.io page]: https://crates.io/crates/openvino/versions
+[docs.rs page]: https://docs.rs/openvino/latest/openvino


### PR DESCRIPTION
This change adds documentation, but no code, to explain how one might use OpenVINO from Rust. This is a partial response to https://github.com/intel/openvino-rs/issues/70; there are more things that need to be done before we re-evaluate moving any code.