### PR TITLE
[VSCode Extension] Enable code generation with user selected text only (CVS-119131)

### DIFF
--- a/modules/openvino_code/src/inline-completion/completion.service.ts
+++ b/modules/openvino_code/src/inline-completion/completion.service.ts
@@ -31,6 +31,15 @@ class CompletionService {
     if (fillInTheMiddleMode && textAfterCursor.trim()) {
       return `${startToken}${textBeforeCursor}${middleToken}${textAfterCursor}${endToken}`;
     }
+    
+    let editor = window.activeTextEditor;
+    if (!editor) {
+      return ``; // No open text editor
+    }
+    if (!editor.selection.isEmpty) {
+      return editor.document.getText(editor.selection)
+    }
+    
     return textBeforeCursor;
   }
 


### PR DESCRIPTION
### Enable code generation with user selected text only (CVS-119131)

For inline code completion context is used and it is sent to the generation model as input.
Now this context/input is a text from the beginning of the file till current cursor position.

The idea is to add mechanism that will limit this context by sending to generation model only text explicitly selected by user.

It is an open question how to implement it from the UI/UX perspective, how it should look like and how user should interact with it. 
Such feature and interaction examples can be found in other similar VSCode extensions (e.g. refact.ai, cody, etc.)