### PR TITLE
Change threading related interface from API 1.0 to 2.0

### DIFF
--- a/modules/nvidia_plugin/src/cuda_compiled_model.cpp
+++ b/modules/nvidia_plugin/src/cuda_compiled_model.cpp
@@ -9,9 +9,9 @@
 #include <fmt/format.h>
 
 #include <memory_manager/cuda_memory_manager.hpp>
+#include <openvino/runtime/threading/executor_manager.hpp>
 #include <ops/nop_op.hpp>
 #include <ops/subgraph.hpp>
-#include <threading/ie_executor_manager.hpp>
 #include <utility>
 
 #include "cuda_compiled_model.hpp"
@@ -26,15 +26,13 @@
 #include "memory_manager/model/cuda_memory_model_builder.hpp"
 #include "nvidia/nvidia_config.hpp"
 #include "nvidia/properties.hpp"
-
+#include "openvino/runtime/exec_model_info.hpp"
+#include "openvino/runtime/internal_properties.hpp"
+#include "openvino/runtime/iplugin.hpp"
 #include "ops/parameter.hpp"
 #include "ops/result.hpp"
 #include "transformations/utils/utils.hpp"
 #include "transformer/cuda_graph_transformer.hpp"
-
-#include "openvino/runtime/exec_model_info.hpp"
-#include "openvino/runtime/internal_properties.hpp"
-#include "openvino/runtime/iplugin.hpp"
 
 namespace {
 static constexpr const char* nv_stream_executor_name = "NvidiaStreamExecutor";

--- a/modules/nvidia_plugin/src/cuda_compiled_model.cpp
+++ b/modules/nvidia_plugin/src/cuda_compiled_model.cpp
@@ -9,7 +9,6 @@
 #include <fmt/format.h>
 
 #include <memory_manager/cuda_memory_manager.hpp>
-#include <openvino/runtime/threading/executor_manager.hpp>
 #include <ops/nop_op.hpp>
 #include <ops/subgraph.hpp>
 #include <utility>
@@ -29,6 +28,7 @@
 #include "openvino/runtime/exec_model_info.hpp"
 #include "openvino/runtime/internal_properties.hpp"
 #include "openvino/runtime/iplugin.hpp"
+#include "openvino/runtime/threading/executor_manager.hpp"
 #include "ops/parameter.hpp"
 #include "ops/result.hpp"
 #include "transformations/utils/utils.hpp"

--- a/modules/nvidia_plugin/src/cuda_config.hpp
+++ b/modules/nvidia_plugin/src/cuda_config.hpp
@@ -10,7 +10,7 @@
 
 #include "nvidia/nvidia_config.hpp"
 #include "openvino/runtime/properties.hpp"
-#include "threading/ie_istreams_executor.hpp"
+#include "openvino/runtime/threading/istreams_executor.hpp"
 
 namespace ov {
 namespace nvidia_gpu {

--- a/modules/nvidia_plugin/src/cuda_infer_request.cpp
+++ b/modules/nvidia_plugin/src/cuda_infer_request.cpp
@@ -13,8 +13,8 @@
 #include <gsl/span_ext>
 #include <map>
 #include <memory>
+#include <openvino/runtime/threading/executor_manager.hpp>
 #include <string>
-#include <threading/ie_executor_manager.hpp>
 #include <utility>
 
 #include "cuda_compiled_model.hpp"

--- a/modules/nvidia_plugin/src/cuda_infer_request.cpp
+++ b/modules/nvidia_plugin/src/cuda_infer_request.cpp
@@ -13,7 +13,6 @@
 #include <gsl/span_ext>
 #include <map>
 #include <memory>
-#include <openvino/runtime/threading/executor_manager.hpp>
 #include <string>
 #include <utility>
 
@@ -25,6 +24,7 @@
 #include "cuda_simple_execution_delegator.hpp"
 #include "nvidia/properties.hpp"
 #include "openvino/runtime/make_tensor.hpp"
+#include "openvino/runtime/threading/executor_manager.hpp"
 
 namespace ov {
 namespace nvidia_gpu {

--- a/modules/nvidia_plugin/src/cuda_plugin.cpp
+++ b/modules/nvidia_plugin/src/cuda_plugin.cpp
@@ -1,9 +1,9 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-#include <fmt/format.h>
+#include "cuda_plugin.hpp"
 
-#include "ie_metric_helpers.hpp"
+#include <fmt/format.h>
 
 #include "cpp_interfaces/interface/ie_internal_plugin_config.hpp"
 #include "cuda/props.hpp"
@@ -11,13 +11,13 @@
 #include "cuda_infer_request.hpp"
 #include "cuda_itt.hpp"
 #include "cuda_operation_registry.hpp"
-#include "cuda_plugin.hpp"
+#include "ie_metric_helpers.hpp"
 #include "nvidia/nvidia_config.hpp"
 #include "openvino/core/op_extension.hpp"
 #include "openvino/op/util/op_types.hpp"
 #include "openvino/runtime/core.hpp"
 #include "openvino/runtime/properties.hpp"
-#include "threading/ie_executor_manager.hpp"
+#include "openvino/runtime/threading/executor_manager.hpp"
 #include "transformations/rt_info/fused_names_attribute.hpp"
 
 using namespace ov::nvidia_gpu;
@@ -215,7 +215,9 @@ ov::Any Plugin::get_property(const std::string& name, const ov::AnyMap& properti
     } else if (METRIC_KEY(SUPPORTED_CONFIG_KEYS) == name) {
         std::vector<std::string> configKeys = {
             CONFIG_KEY(DEVICE_ID), CONFIG_KEY(PERF_COUNT), NVIDIA_CONFIG_KEY(THROUGHPUT_STREAMS)};
-        auto streamExecutorConfigKeys = InferenceEngine::IStreamsExecutor::Config{}.SupportedKeys();
+        auto streamExecutorConfigKeys = ov::threading::IStreamsExecutor::Config{}
+                                            .get_property(ov::supported_properties.name())
+                                            .as<std::vector<std::string>>();
         for (auto&& configKey : streamExecutorConfigKeys) {
             if (configKey != InferenceEngine::PluginConfigParams::KEY_CPU_THROUGHPUT_STREAMS) {
                 configKeys.emplace_back(configKey);

--- a/modules/nvidia_plugin/src/cuda_plugin.cpp
+++ b/modules/nvidia_plugin/src/cuda_plugin.cpp
@@ -1,9 +1,9 @@
 // Copyright (C) 2018-2023 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
-#include "cuda_plugin.hpp"
-
 #include <fmt/format.h>
+
+#include "ie_metric_helpers.hpp"
 
 #include "cpp_interfaces/interface/ie_internal_plugin_config.hpp"
 #include "cuda/props.hpp"
@@ -11,7 +11,7 @@
 #include "cuda_infer_request.hpp"
 #include "cuda_itt.hpp"
 #include "cuda_operation_registry.hpp"
-#include "ie_metric_helpers.hpp"
+#include "cuda_plugin.hpp"
 #include "nvidia/nvidia_config.hpp"
 #include "openvino/core/op_extension.hpp"
 #include "openvino/op/util/op_types.hpp"

--- a/modules/nvidia_plugin/src/cuda_thread_pool.hpp
+++ b/modules/nvidia_plugin/src/cuda_thread_pool.hpp
@@ -9,9 +9,9 @@
 #include <cuda_thread_context.hpp>
 #include <deque>
 #include <mutex>
+#include <openvino/runtime/threading/itask_executor.hpp>
 #include <queue>
 #include <thread>
-#include <threading/ie_itask_executor.hpp>
 
 #include "cuda_jthread.hpp"
 

--- a/modules/nvidia_plugin/src/cuda_thread_pool.hpp
+++ b/modules/nvidia_plugin/src/cuda_thread_pool.hpp
@@ -9,11 +9,11 @@
 #include <cuda_thread_context.hpp>
 #include <deque>
 #include <mutex>
-#include <openvino/runtime/threading/itask_executor.hpp>
 #include <queue>
 #include <thread>
 
 #include "cuda_jthread.hpp"
+#include "openvino/runtime/threading/itask_executor.hpp"
 
 namespace ov {
 namespace nvidia_gpu {


### PR DESCRIPTION
Change threading related interface from API 1.0 to 2.0 due to migration interface from API 1.0 to 2.0 in openvino. 
This PR must be merged before [PR21167](https://github.com/openvinotoolkit/openvino/pull/21167)