### PR TITLE
[Tokenizer] Fix Windows Related Bugs

### DIFF
--- a/modules/custom_operations/user_ie_extensions/tokenizer/python/ov_tokenizer/hf_parser.py
+++ b/modules/custom_operations/user_ie_extensions/tokenizer/python/ov_tokenizer/hf_parser.py
@@ -116,7 +116,8 @@ class TransformersTokenizerPipelineParser:
         self.original_tokenizer = tokenizer_object
         with TemporaryDirectory() as tmpdir:
             tokenizer_object.save_pretrained(tmpdir)
-            with open(Path(tmpdir) / "tokenizer.json") as tj:
+            # Windows uses cp1252 encoding by default, need to use utf-8 explicitly
+            with open(Path(tmpdir) / "tokenizer.json", encoding="utf-8") as tj:
                 self.tokenizer_json = json.load(tj)
         self.pipeline = TokenizerPipeline()
         self.number_of_inputs = number_of_inputs
@@ -267,7 +268,7 @@ class TransformersTokenizerPipelineParser:
             self.pipeline.add_steps(VocabDecoderStep())
             self.pipeline.add_steps(CharsToBytesStep())
 
-        if self.original_tokenizer.clean_up_tokenization_spaces:
+        if self.original_tokenizer.clean_up_tokenization_spaces and self.pipeline.decoding_steps:
             self.pipeline.add_steps(RegexDecodingStep.clean_up_tokenization_spaces())
         return
 

--- a/modules/custom_operations/user_ie_extensions/tokenizer/python/ov_tokenizer/tokenizer_pipeline.py
+++ b/modules/custom_operations/user_ie_extensions/tokenizer/python/ov_tokenizer/tokenizer_pipeline.py
@@ -774,7 +774,7 @@ class TokenizerPipeline:
         batch_size = opset.gather(shape, as_node(0), as_node(0))
         ragged_begins = opset.range(as_node(0), batch_size, as_node(1), output_type="i32").outputs()
         ragged_ends = opset.range(
-            as_node(1), opset.add(batch_size, as_node(1)), as_node(1), output_type="i32"
+            as_node(1), opset.add(batch_size, make_constant_node(1, Type.i64)), as_node(1), output_type="i32"
         ).outputs()
         return ragged_begins + ragged_ends + input_node
 


### PR DESCRIPTION
Explicitly use utf-8 to read json - Windows uses cp1252
Use i64 constant where needed - as_node returns i32 on Windows