### PR TITLE
[NVIDIA] Remove InferPadding from convolution

### DIFF
--- a/modules/nvidia_plugin/src/ops/convolution_components/convolution_components.cpp
+++ b/modules/nvidia_plugin/src/ops/convolution_components/convolution_components.cpp
@@ -38,8 +38,6 @@ ConvolutionParams::ConvolutionParams(const TConvNode& node)
     OPENVINO_ASSERT(groups_ >= 1U);
     filter_shape_[0] *= groups_;
 
-    InferPadding(node);
-
     if (input_shape_.size() == CONV_1D_DIMS_NUMBER) ConvertConv1DToConv2D();
 
     const size_t dims_number = NumberOfDims();
@@ -60,31 +58,6 @@ template ConvolutionParams::ConvolutionParams(const ov::op::v1::GroupConvolution
 template ConvolutionParams::ConvolutionParams(const ov::op::v1::Convolution& node);
 template ConvolutionParams::ConvolutionParams(const nodes::FusedConvolution& node);
 template ConvolutionParams::ConvolutionParams(const nodes::FusedGroupConvolution& node);
-
-template <typename TConvNode>
-void ConvolutionParams::InferPadding(const TConvNode& node) {
-    const ov::op::PadType pad_type = node.get_auto_pad();
-    switch (pad_type) {
-        case ov::op::PadType::EXPLICIT:
-            break;
-        // TODO: potentially it can be removed, because paddings are assigned in ngraph operation
-        case ov::op::PadType::SAME_LOWER:
-        case ov::op::PadType::SAME_UPPER: {
-            const ov::Shape filter_spatial_shape{filter_shape_.begin() + NON_SPATIAL_DIMS_NUMBER, filter_shape_.end()};
-            padding_before_.clear();
-            padding_after_.clear();
-            ov::infer_auto_padding(
-                input_shape_, filter_spatial_shape, strides_, dilations_, pad_type, padding_after_, padding_before_);
-        } break;
-        case ov::op::PadType::VALID: {
-            size_t spatial_dims_number = NumberOfSpatialDims();
-            padding_before_ = ov::CoordinateDiff(spatial_dims_number, 0);
-            padding_after_ = ov::CoordinateDiff(spatial_dims_number, 0);
-        } break;
-        default:
-            OPENVINO_ASSERT(false);
-    }
-}
 
 void ConvolutionParams::ConvertConv1DToConv2D() {
     if (input_shape_.size() != CONV_1D_DIMS_NUMBER) return;

--- a/modules/nvidia_plugin/src/ops/convolution_components/convolution_components.hpp
+++ b/modules/nvidia_plugin/src/ops/convolution_components/convolution_components.hpp
@@ -50,8 +50,6 @@ struct ConvolutionParams {
     size_t NumberOfSpatialDims() const { return input_shape_.size() - NON_SPATIAL_DIMS_NUMBER; }
 
 private:
-    template <typename TConvNode>
-    void InferPadding(const TConvNode& node);
     void ConvertConv1DToConv2D();
 };
 


### PR DESCRIPTION
Details:
Remove `InferPadding` as input node has static shapes and shape inference should calculate padding correctly. Padding can be just get and calculation should not be required.
The `InferPadding` depends on `infer_auto_padding` which is legacy implementation for shape inference and removed in [PR #22036](https://github.com/openvinotoolkit/openvino/pull/22036)
