### PR TITLE
[custom operations] Use ov::element in custom operations module

### DIFF
--- a/modules/custom_operations/user_ie_extensions/calculate_grid.cpp
+++ b/modules/custom_operations/user_ie_extensions/calculate_grid.cpp
@@ -61,5 +61,5 @@ bool CalculateGrid::evaluate(ov::TensorVector& outputs, const ov::TensorVector& 
 }
 
 bool CalculateGrid::has_evaluate() const {
-    return get_input_element_type(0) == ngraph::element::f32 ? true : false;
+    return get_input_element_type(0) == ov::element::f32 ? true : false;
 }

--- a/modules/custom_operations/user_ie_extensions/complex_mul.cpp
+++ b/modules/custom_operations/user_ie_extensions/complex_mul.cpp
@@ -67,7 +67,7 @@ bool ComplexMultiplication::evaluate(ov::TensorVector& outputs, const ov::Tensor
 
 bool ComplexMultiplication::has_evaluate() const {
     for (size_t i = 0; i < get_input_size(); ++i)
-        if (get_input_element_type(i) != ngraph::element::f32)
+        if (get_input_element_type(i) != ov::element::f32)
             return false;
     return true;
 }

--- a/modules/custom_operations/user_ie_extensions/fft.cpp
+++ b/modules/custom_operations/user_ie_extensions/fft.cpp
@@ -298,7 +298,7 @@ bool FFT::evaluate(ov::TensorVector& outputs, const ov::TensorVector& inputs) co
 }
 
 bool FFT::has_evaluate() const {
-    if (get_input_element_type(0) == ngraph::element::f32 && get_input_element_type(1) == ngraph::element::i32)
+    if (get_input_element_type(0) == ov::element::f32 && get_input_element_type(1) == ov::element::i32)
         return true;
     return false;
 }

--- a/modules/custom_operations/user_ie_extensions/grid_sample.cpp
+++ b/modules/custom_operations/user_ie_extensions/grid_sample.cpp
@@ -107,7 +107,7 @@ bool GridSample::evaluate(ov::TensorVector& outputs, const ov::TensorVector& inp
 
 bool GridSample::has_evaluate() const {
     for (size_t i = 0; i < get_input_size(); ++i)
-        if (get_input_element_type(i) != ngraph::element::f32)
+        if (get_input_element_type(i) != ov::element::f32)
             return false;
     return true;
 }

--- a/modules/custom_operations/user_ie_extensions/sparse_conv.cpp
+++ b/modules/custom_operations/user_ie_extensions/sparse_conv.cpp
@@ -88,7 +88,7 @@ bool SparseConv::evaluate(ov::TensorVector& outputs, const ov::TensorVector& inp
 
 bool SparseConv::has_evaluate() const {
     for (size_t i = 0; i < get_input_size(); ++i)
-        if (get_input_element_type(i) != ngraph::element::f32)
+        if (get_input_element_type(i) != ov::element::f32)
             return false;
     return true;
 }

--- a/modules/custom_operations/user_ie_extensions/sparse_conv_transpose.cpp
+++ b/modules/custom_operations/user_ie_extensions/sparse_conv_transpose.cpp
@@ -88,7 +88,7 @@ bool SparseConvTranspose::evaluate(ov::TensorVector& outputs, const ov::TensorVe
 
 bool SparseConvTranspose::has_evaluate() const {
     for (size_t i = 0; i < get_input_size(); ++i)
-        if (get_input_element_type(i) != ngraph::element::f32)
+        if (get_input_element_type(i) != ov::element::f32)
             return false;
     return true;
 }


### PR DESCRIPTION
Use `ov::element` instead of 'ngraph::element` to fix build issues after removing `HostTensor` in openvinotoolkit/openvino#22146