### PR TITLE
OV deprectaed ov::descriptor::Tensor construct with name

### DIFF
--- a/modules/nvidia_plugin/tests/unit/result.cpp
+++ b/modules/nvidia_plugin/tests/unit/result.cpp
@@ -25,7 +25,7 @@ class ov::Output<ParameterStubNode> : public ov::Output<ov::Node> {
 public:
     explicit Output<ParameterStubNode>(std::shared_ptr<ParameterStubNode> node) : ov::Output<ov::Node>(node, 0) {
         auto tensor = std::make_shared<ov::descriptor::Tensor>(
-            ov::element::Type{}, ov::PartialShape{1}, ParameterStubNode::get_type_info_static().name);
+            ov::element::Type{}, ov::PartialShape{1}, {ParameterStubNode::get_type_info_static().name});
         node->m_outputs.emplace_back(node.get(), 0, tensor);
     }
 };

--- a/modules/nvidia_plugin/tests/unit/result.cpp
+++ b/modules/nvidia_plugin/tests/unit/result.cpp
@@ -25,7 +25,9 @@ class ov::Output<ParameterStubNode> : public ov::Output<ov::Node> {
 public:
     explicit Output<ParameterStubNode>(std::shared_ptr<ParameterStubNode> node) : ov::Output<ov::Node>(node, 0) {
         auto tensor = std::make_shared<ov::descriptor::Tensor>(
-            ov::element::Type{}, ov::PartialShape{1}, {ParameterStubNode::get_type_info_static().name});
+            ov::element::Type{},
+            ov::PartialShape{1},
+            std::unordered_set<std::string>{ParameterStubNode::get_type_info_static().name});
         node->m_outputs.emplace_back(node.get(), 0, tensor);
     }
 };


### PR DESCRIPTION
Remove API: Tensor(const element::Type& element_type, const PartialShape& pshape, const std::string& name)