### PR TITLE
Use API 2.0 properties in Java tests

### DIFF
--- a/modules/java_api/src/test/java/org/intel/openvino/CoreTests.java
+++ b/modules/java_api/src/test/java/org/intel/openvino/CoreTests.java
@@ -82,7 +82,7 @@ public class CoreTests extends OVTest {
         Map<String, String> config =
                 new HashMap<String, String>() {
                     {
-                        put("CPU_THROUGHPUT_STREAMS", "4");
+                        put("NUM_STREAMS", "4");
                     }
                 };
         core.set_property("CPU", config);
@@ -90,7 +90,7 @@ public class CoreTests extends OVTest {
 
         assertEquals("Final number of requests", 4, nireq2);
 
-        config.put("CPU_THROUGHPUT_STREAMS", "1");
+        config.put("NUM_STREAMS", "1");
         core.set_property("CPU", config); // Restore
     }
 


### PR DESCRIPTION
Fixed issue:
```
org.intel.openvino.CoreTests > testProperty FAILED
    java.lang.Exception: 
    InferenceEngineException: 
    	SetProperty: Exception from src/inference/src/cpp/core.cpp:216:
    Exception from src/inference/src/dev/plugin.cpp:49:
    Exception from src/plugins/intel_cpu/src/config.cpp:337:
    NotFound: Unsupported property CPU_THROUGHPUT_STREAMS by CPU plugin.
        at org.intel.openvino.Core.SetProperty(Native Method)
        at org.intel.openvino.Core.set_property(Core.java:157)
        at org.intel.openvino.CoreTests.testProperty(CoreTests.java:88)
```