### PR TITLE
[Openvino code] Fix deepseek coder model run for fill-in-middle mode

### DIFF
--- a/modules/openvino_code/package-lock.json
+++ b/modules/openvino_code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openvino-code-completion",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openvino-code-completion",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "https://github.com/openvinotoolkit/openvino_contrib/blob/master/LICENSE",
       "workspaces": [
         "side-panel-ui"

--- a/modules/openvino_code/package.json
+++ b/modules/openvino_code/package.json
@@ -1,7 +1,7 @@
 {
   "publisher": "OpenVINO",
   "name": "openvino-code-completion",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "displayName": "OpenVINO Code Completion",
   "description": "VSCode extension for AI code completion with OpenVINO",
   "icon": "media/logo.png",

--- a/modules/openvino_code/server/pyproject.toml
+++ b/modules/openvino_code/server/pyproject.toml
@@ -11,10 +11,10 @@ dependencies = [
     'torch @ https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.0.1%2Bcpu.cxx11.abi-cp310-cp310-linux_x86_64.whl ; sys_platform=="linux" and python_version == "3.10"',
     'torch @ https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.0.1%2Bcpu.cxx11.abi-cp311-cp311-linux_x86_64.whl ; sys_platform=="linux" and python_version == "3.11"',
     'torch ; sys_platform != "linux"',
-    'openvino==2023.1.0',
+    'openvino==2023.3.0',
     'transformers==4.36.0',
-    'optimum==1.12.0',
-    'optimum-intel[openvino]==1.10.1',
+    'optimum==1.17.1',
+    'optimum-intel[openvino]==1.15.0',
 ]
 
 [project.optional-dependencies]

--- a/modules/openvino_code/shared/model.ts
+++ b/modules/openvino_code/shared/model.ts
@@ -4,7 +4,7 @@ enum ModelId {
   CODE_T5_220M = 'Salesforce/codet5p-220m-py',
   DECICODER_1B_OPENVINO_INT8 = 'chgk13/decicoder-1b-openvino-int8',
   STABLECODE_COMPLETION_ALPHA_3B_4K_OPENVINO_INT8 = 'chgk13/stablecode-completion-alpha-3b-4k-openvino-int8',
-  DEEPSEEK_CODER_1_3B = 'Intel/deepseek-coder-1_3b-instruct-openvino-int8',
+  DEEPSEEK_CODER_1_3B = 'kumarijy/deepseek-code-1.3b_base_ov_int8',
 }
 
 export enum ModelName {


### PR DESCRIPTION
Below changes done in this Pull request:
1) Changed model location to kumarijy/deepseek-code-1.3b_base_ov_int8
2) Upgraded versions at pyproject.toml
    'openvino==2023.3.0',
    'optimum==1.17.1',
    'optimum-intel[openvino]==1.15.0'