### PR TITLE
Update of the copyright year 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ All guidelines for contributing to the OpenVINO repositories can be found [here]
 
 OpenVINO is a trademark of Intel Corporation or its subsidiaries in the U.S. and/or other countries.
 
-Copyright &copy; 2018-2023 Intel Corporation
+Copyright &copy; 2018-2024 Intel Corporation
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 ```

--- a/modules/custom_operations/user_ie_extensions/CMakeLists.txt
+++ b/modules/custom_operations/user_ie_extensions/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2018-2023 Intel Corporation
+# Copyright (C) 2018-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 #
 

--- a/modules/nvidia_plugin/src/cuda/float16.hpp
+++ b/modules/nvidia_plugin/src/cuda/float16.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda/math.cuh
+++ b/modules/nvidia_plugin/src/cuda/math.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_async_infer_request.cpp
+++ b/modules/nvidia_plugin/src/cuda_async_infer_request.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 #include "cuda_async_infer_request.hpp"

--- a/modules/nvidia_plugin/src/cuda_async_infer_request.hpp
+++ b/modules/nvidia_plugin/src/cuda_async_infer_request.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_compiled_model.cpp
+++ b/modules/nvidia_plugin/src/cuda_compiled_model.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_compiled_model.hpp
+++ b/modules/nvidia_plugin/src/cuda_compiled_model.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_config.hpp
+++ b/modules/nvidia_plugin/src/cuda_config.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_create_extensions.cpp
+++ b/modules/nvidia_plugin/src/cuda_create_extensions.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_eager_topology_runner.cpp
+++ b/modules/nvidia_plugin/src/cuda_eager_topology_runner.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_eager_topology_runner.hpp
+++ b/modules/nvidia_plugin/src/cuda_eager_topology_runner.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_graph_context.cpp
+++ b/modules/nvidia_plugin/src/cuda_graph_context.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_graph_context.hpp
+++ b/modules/nvidia_plugin/src/cuda_graph_context.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_graph_topology_runner.cpp
+++ b/modules/nvidia_plugin/src/cuda_graph_topology_runner.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_graph_topology_runner.hpp
+++ b/modules/nvidia_plugin/src/cuda_graph_topology_runner.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_iexecution_delegator.hpp
+++ b/modules/nvidia_plugin/src/cuda_iexecution_delegator.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_infer_request.hpp
+++ b/modules/nvidia_plugin/src/cuda_infer_request.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_inference_request_context.hpp
+++ b/modules/nvidia_plugin/src/cuda_inference_request_context.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_itopology_runner.hpp
+++ b/modules/nvidia_plugin/src/cuda_itopology_runner.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_perf_counts.hpp
+++ b/modules/nvidia_plugin/src/cuda_perf_counts.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_plugin.cpp
+++ b/modules/nvidia_plugin/src/cuda_plugin.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <fmt/format.h>

--- a/modules/nvidia_plugin/src/cuda_plugin.hpp
+++ b/modules/nvidia_plugin/src/cuda_plugin.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_profiler.cpp
+++ b/modules/nvidia_plugin/src/cuda_profiler.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_profiler.hpp
+++ b/modules/nvidia_plugin/src/cuda_profiler.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_simple_execution_delegator.hpp
+++ b/modules/nvidia_plugin/src/cuda_simple_execution_delegator.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_tensor_mapping_context.hpp
+++ b/modules/nvidia_plugin/src/cuda_tensor_mapping_context.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_thread_pool.cpp
+++ b/modules/nvidia_plugin/src/cuda_thread_pool.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/cuda_thread_pool.hpp
+++ b/modules/nvidia_plugin/src/cuda_thread_pool.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/kernels/details/numpy_broadcast_mapper.cuh
+++ b/modules/nvidia_plugin/src/kernels/details/numpy_broadcast_mapper.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/kernels/insert.cu
+++ b/modules/nvidia_plugin/src/kernels/insert.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/kernels/insert.hpp
+++ b/modules/nvidia_plugin/src/kernels/insert.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/kernels/slice.cu
+++ b/modules/nvidia_plugin/src/kernels/slice.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/kernels/slice.hpp
+++ b/modules/nvidia_plugin/src/kernels/slice.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/memory_manager/cuda_device_mem_block.hpp
+++ b/modules/nvidia_plugin/src/memory_manager/cuda_device_mem_block.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/components/numpy_broadcast_params.cpp
+++ b/modules/nvidia_plugin/src/ops/components/numpy_broadcast_params.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/components/numpy_broadcast_params.h
+++ b/modules/nvidia_plugin/src/ops/components/numpy_broadcast_params.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/components/workbuffer_desc.hpp
+++ b/modules/nvidia_plugin/src/ops/components/workbuffer_desc.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/detection_output.cpp
+++ b/modules/nvidia_plugin/src/ops/detection_output.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/fused_convolution.cpp
+++ b/modules/nvidia_plugin/src/ops/fused_convolution.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/fused_convolution_cudnn.cpp
+++ b/modules/nvidia_plugin/src/ops/fused_convolution_cudnn.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/fused_convolution_cudnn_be.cpp
+++ b/modules/nvidia_plugin/src/ops/fused_convolution_cudnn_be.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/fused_convolution_cudnn_be.hpp
+++ b/modules/nvidia_plugin/src/ops/fused_convolution_cudnn_be.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/interpolate.cpp
+++ b/modules/nvidia_plugin/src/ops/interpolate.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/parameter.cpp
+++ b/modules/nvidia_plugin/src/ops/parameter.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/reduce.hpp
+++ b/modules/nvidia_plugin/src/ops/reduce.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/reduce_max.hpp
+++ b/modules/nvidia_plugin/src/ops/reduce_max.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/reduce_mean.hpp
+++ b/modules/nvidia_plugin/src/ops/reduce_mean.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/reduce_min.hpp
+++ b/modules/nvidia_plugin/src/ops/reduce_min.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/reduce_prod.hpp
+++ b/modules/nvidia_plugin/src/ops/reduce_prod.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/reduce_sum.hpp
+++ b/modules/nvidia_plugin/src/ops/reduce_sum.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/result.cpp
+++ b/modules/nvidia_plugin/src/ops/result.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/subgraph.cpp
+++ b/modules/nvidia_plugin/src/ops/subgraph.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/subgraph.hpp
+++ b/modules/nvidia_plugin/src/ops/subgraph.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/tensor_iterator.cpp
+++ b/modules/nvidia_plugin/src/ops/tensor_iterator.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/ops/tensor_iterator.hpp
+++ b/modules/nvidia_plugin/src/ops/tensor_iterator.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/transformer/cuda_graph_transformer.cpp
+++ b/modules/nvidia_plugin/src/transformer/cuda_graph_transformer.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/transformer/detection_output_fix_input_types_transformation.cpp
+++ b/modules/nvidia_plugin/src/transformer/detection_output_fix_input_types_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/transformer/detection_output_fix_input_types_transformation.hpp
+++ b/modules/nvidia_plugin/src/transformer/detection_output_fix_input_types_transformation.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/transformer/fuse_conv_biasadd_activation.cpp
+++ b/modules/nvidia_plugin/src/transformer/fuse_conv_biasadd_activation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <type_traits>

--- a/modules/nvidia_plugin/src/transformer/fuse_conv_biasadd_activation.hpp
+++ b/modules/nvidia_plugin/src/transformer/fuse_conv_biasadd_activation.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/transformer/nodes/activation_type.cpp
+++ b/modules/nvidia_plugin/src/transformer/nodes/activation_type.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/transformer/nodes/activation_type.hpp
+++ b/modules/nvidia_plugin/src/transformer/nodes/activation_type.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/transformer/nodes/fully_connected.hpp
+++ b/modules/nvidia_plugin/src/transformer/nodes/fully_connected.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/transformer/nodes/fused_convolution.hpp
+++ b/modules/nvidia_plugin/src/transformer/nodes/fused_convolution.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/transformer/nodes/fused_convolution_backprop_data.hpp
+++ b/modules/nvidia_plugin/src/transformer/nodes/fused_convolution_backprop_data.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/transformer/nodes/lstm_sequence_optimized.cpp
+++ b/modules/nvidia_plugin/src/transformer/nodes/lstm_sequence_optimized.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/transformer/nodes/lstm_sequence_optimized.hpp
+++ b/modules/nvidia_plugin/src/transformer/nodes/lstm_sequence_optimized.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/transformer/reduce_transformation.cpp
+++ b/modules/nvidia_plugin/src/transformer/reduce_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/transformer/reduce_transformation.hpp
+++ b/modules/nvidia_plugin/src/transformer/reduce_transformation.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/src/transformer/rt_info/cuda_node_id.hpp
+++ b/modules/nvidia_plugin/src/transformer/rt_info/cuda_node_id.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_executable_network/ov_exec_net_import_export.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_executable_network/ov_exec_net_import_export.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 #include <common_test_utils/test_constants.hpp>

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_executable_network/properties.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_executable_network/properties.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_infer_request/batched_tensors.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_infer_request/batched_tensors.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_infer_request/callback.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_infer_request/callback.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_infer_request/cancellation.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_infer_request/cancellation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_infer_request/infer_request_dynamic.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_infer_request/infer_request_dynamic.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_infer_request/inference.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_infer_request/inference.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_infer_request/inference_chaining.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_infer_request/inference_chaining.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_infer_request/io_tensor.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_infer_request/io_tensor.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_infer_request/multithreading.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_infer_request/multithreading.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_infer_request/wait.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_infer_request/wait.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_plugin/caching_tests.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_plugin/caching_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_plugin/core_integration.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_plugin/core_integration.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifcorer: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_plugin/life_time.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_plugin/life_time.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/behavior/ov_plugin/properties_tests.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/set_device_name.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/set_device_name.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convert_color_common.hpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convert_color_common.hpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convert_color_i420.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convert_color_i420.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convert_color_nv12.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/convert_color_nv12.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/unit/cuda/stl/atomic.cu
+++ b/modules/nvidia_plugin/tests/unit/cuda/stl/atomic.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/unit/cuda/stl/mdspan.cu
+++ b/modules/nvidia_plugin/tests/unit/cuda/stl/mdspan.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/unit/cuda/stl/mdvector.cu
+++ b/modules/nvidia_plugin/tests/unit/cuda/stl/mdvector.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/unit/cuda/stl/span.cu
+++ b/modules/nvidia_plugin/tests/unit/cuda/stl/span.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/unit/cuda/stl/vector.cu
+++ b/modules/nvidia_plugin/tests/unit/cuda/stl/vector.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/unit/cuda/wrappers/graph.cpp
+++ b/modules/nvidia_plugin/tests/unit/cuda/wrappers/graph.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 #include "graph.cuh"

--- a/modules/nvidia_plugin/tests/unit/cuda/wrappers/graph.cu
+++ b/modules/nvidia_plugin/tests/unit/cuda/wrappers/graph.cu
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/unit/cuda/wrappers/graph.cuh
+++ b/modules/nvidia_plugin/tests/unit/cuda/wrappers/graph.cuh
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/unit/transformations/bidirectional_lstm_sequence_composition.cpp
+++ b/modules/nvidia_plugin/tests/unit/transformations/bidirectional_lstm_sequence_composition.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/unit/transformations/concat_transformation.cpp
+++ b/modules/nvidia_plugin/tests/unit/transformations/concat_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/unit/transformations/detection_output_fix_input_types.cpp
+++ b/modules/nvidia_plugin/tests/unit/transformations/detection_output_fix_input_types.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/unit/transformations/fuse_conv_biasadd_activation.cpp
+++ b/modules/nvidia_plugin/tests/unit/transformations/fuse_conv_biasadd_activation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/unit/transformations/fuse_matmul_add.cpp
+++ b/modules/nvidia_plugin/tests/unit/transformations/fuse_matmul_add.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/unit/transformations/reduce_transformation.cpp
+++ b/modules/nvidia_plugin/tests/unit/transformations/reduce_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/tests/unit/transformations/remove_redundant_convert_transformation.cpp
+++ b/modules/nvidia_plugin/tests/unit/transformations/remove_redundant_convert_transformation.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2018-2023 Intel Corporation
+// Copyright (C) 2018-2024 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 

--- a/modules/nvidia_plugin/wheel/setup.py
+++ b/modules/nvidia_plugin/wheel/setup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2023 Intel Corporation
+# Copyright (C) 2018-2024 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
 import os.path


### PR DESCRIPTION
Updated copyright for 2024 year. 

Ticket: https://jira.devtools.intel.com/browse/CVS-133175 

Command used:
```bash
git grep -lz '2018-2023 Intel Corporation' | xargs -0 sed -i '' -e 's/2018-2023 Intel Corporation/2018-2024 Intel Corporation/g'
```