### PR TITLE
llama_cpp_plugin: fix "Unknown CMake command "FetchContent_Declare" while building for Android

### DIFF
--- a/modules/llama_cpp_plugin/CMakeLists.txt
+++ b/modules/llama_cpp_plugin/CMakeLists.txt
@@ -11,6 +11,8 @@ ov_option(ENABLE_LLAMA_CPP_PLUGIN_REGISTRATION "Enables registration of LLAMA_CP
 
 add_subdirectory(src)
 
+include(FetchContent)
+
 FetchContent_Declare(
     llama_cpp
     GIT_REPOSITORY https://github.com/ggerganov/llama.cpp


### PR DESCRIPTION
Android build throws the following error -
```
keyurmaru@fatman:~/openvino_all$ ${CMAKE_DIR}/bin/cmake   -DCMAKE_BUILD_TYPE=Release   -DANDROID_ABI=x86_64   -DANDROID_PLATFORM=26   -DCMAKE_TOOLCHAIN_FILE=${NDK_DIR}/build/cmake/android.toolchain.cmake   -DCMAKE_MAKE_PROGRAM=${CMAKE_DIR}/bin/ninja   -DANDROID_USE_LEGACY_TOOLCHAIN_FILE=OFF   -DENABLE_CLDNN=OFF   -DENABLE_OPENCV=OFF   -DENABLE_TEMPLATE=OFF   -DENABLE_SAMPLES=OFF   -DENABLE_PLUGINS_XML=ON   -DTHREADING=TBB   -DTBB_DIR=$(realpath oneTBB_install_x86/lib/cmake/TBB)   -DBUILD_nvidia_plugin=OFF   -DBUILD_custom_operations=OFF   -DIE_EXTRA_MODULES=$(realpath openvino_contrib/modules)   -GNinja   -S openvino -B openvino_build_x86
.
.
.
-- Register llama_cpp_plugin to be built in build-modules/llama_cpp_plugin
CMake Error at /home/keyurmaru/openvino_all/openvino_contrib/modules/llama_cpp_plugin/CMakeLists.txt:14 (FetchContent_Declare):
  Unknown CMake command "FetchContent_Declare".
```

Addition of `include(FetchContent)` seemed to resolve the issue