### PR TITLE
[JAVA_API] update for element type passing

### DIFF
--- a/modules/java_api/src/main/cpp/input_tensor_info.cpp
+++ b/modules/java_api/src/main/cpp/input_tensor_info.cpp
@@ -13,7 +13,7 @@ JNIEXPORT void JNICALL Java_org_intel_openvino_InputTensorInfo_SetElementType(JN
 {
     JNI_METHOD("SetElementType",
         preprocess::InputTensorInfo *info = (preprocess::InputTensorInfo *)addr;
-        auto t_type = element::Type_t(type);
+        auto t_type = get_ov_type(type);
 
         info->set_element_type(t_type);
     )

--- a/modules/java_api/src/main/cpp/jni_common.hpp
+++ b/modules/java_api/src/main/cpp/jni_common.hpp
@@ -231,3 +231,37 @@ static jobject vectorToJavaList(JNIEnv *env, std::vector<std::string> items)
 
     return nullptr;
 }
+
+static const ov::element::Type_t& get_ov_type(int type)
+{
+    static const std::vector<ov::element::Type_t> java_type_to_ov_type
+    {
+        ov::element::Type_t::undefined,
+        ov::element::Type_t::dynamic,
+        ov::element::Type_t::boolean,
+        ov::element::Type_t::bf16,
+        ov::element::Type_t::f16,
+        ov::element::Type_t::f32,
+        ov::element::Type_t::f64,
+        ov::element::Type_t::i4,
+        ov::element::Type_t::i8,
+        ov::element::Type_t::i16,
+        ov::element::Type_t::i32,
+        ov::element::Type_t::i64,
+        ov::element::Type_t::u1,
+        ov::element::Type_t::u2,
+        ov::element::Type_t::u3,
+        ov::element::Type_t::u4,
+        ov::element::Type_t::u6,
+        ov::element::Type_t::u8,
+        ov::element::Type_t::u16,
+        ov::element::Type_t::u32,
+        ov::element::Type_t::u64,
+        ov::element::Type_t::nf4,
+        ov::element::Type_t::f8e4m3,
+        ov::element::Type_t::f8e5m2,
+        ov::element::Type_t::string
+    };
+
+    return java_type_to_ov_type.at(type);
+}

--- a/modules/java_api/src/main/cpp/tensor.cpp
+++ b/modules/java_api/src/main/cpp/tensor.cpp
@@ -13,7 +13,7 @@ JNIEXPORT jlong JNICALL Java_org_intel_openvino_Tensor_TensorCArray(JNIEnv *env,
 {
     JNI_METHOD(
         "TensorCArray",
-        auto input_type = element::Type_t(type);
+        auto input_type = get_ov_type(type);
         Shape input_shape = jintArrayToVector(env, shape);
         Tensor *ov_tensor = new Tensor();
 

--- a/modules/java_api/src/main/java/org/intel/openvino/ElementType.java
+++ b/modules/java_api/src/main/java/org/intel/openvino/ElementType.java
@@ -20,11 +20,18 @@ public enum ElementType {
     i32(10),
     i64(11),
     u1(12),
-    u4(13),
-    u8(14),
-    u16(15),
-    u32(16),
-    u64(17);
+    u2(13),
+    u3(14),
+    u4(15),
+    u6(16),
+    u8(17),
+    u16(18),
+    u32(19),
+    u64(20),
+    nf4(21),
+    f8e4m3(22),
+    f8e5m2(23),
+    string(24);
 
     private int value;
     private static Map<Integer, ElementType> map = new HashMap<Integer, ElementType>();


### PR DESCRIPTION
Added a hard dependency for data type mapping to avoid errors when the values of [the original enum](https://github.com/openvinotoolkit/openvino/blob/96f6251c21d0c94c18a6128fa185167b6cbcb49b/src/core/include/openvino/core/type/element_type.hpp#L37) are changing.