### PR TITLE
[OPENVINO_CODE] Move phi-2 and depseek-coder models to Intel repo

### DIFF
--- a/modules/openvino_code/package-lock.json
+++ b/modules/openvino_code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openvino-code-completion",
-  "version": "0.0.16",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openvino-code-completion",
-      "version": "0.0.16",
+      "version": "0.1.0",
       "license": "https://github.com/openvinotoolkit/openvino_contrib/blob/master/LICENSE",
       "workspaces": [
         "side-panel-ui"
@@ -7388,7 +7388,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
       "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",

--- a/modules/openvino_code/package.json
+++ b/modules/openvino_code/package.json
@@ -1,7 +1,7 @@
 {
   "publisher": "OpenVINO",
   "name": "openvino-code-completion",
-  "version": "0.0.16",
+  "version": "0.1.0",
   "displayName": "OpenVINO Code Completion",
   "description": "VSCode extension for AI code completion with OpenVINO",
   "icon": "media/logo.png",

--- a/modules/openvino_code/shared/model.ts
+++ b/modules/openvino_code/shared/model.ts
@@ -4,8 +4,8 @@ enum ModelId {
   CODE_T5_220M = 'Salesforce/codet5p-220m-py',
   DECICODER_1B_OPENVINO_INT8 = 'chgk13/decicoder-1b-openvino-int8',
   STABLECODE_COMPLETION_ALPHA_3B_4K_OPENVINO_INT8 = 'chgk13/stablecode-completion-alpha-3b-4k-openvino-int8',
-  DEEPSEEK_CODER_1_3B = 'kumarijy/deepseek-code-1.3b_base_ov_int8',
-  PHI_2_2_7B = 'kumarijy/phi-2-openvino',
+  DEEPSEEK_CODER_1_3B = 'Intel/deepseek-coder-1.3b_base_ov_int8',
+  PHI_2_2_7B = 'Intel/phi-2-ov-quantized',
 }
 
 export enum ModelName {


### PR DESCRIPTION
Moved below models from private hugging face repository to Intel repository

**Phi-2 model new location**: [Intel/phi-2-ov-quantized](https://huggingface.co/Intel/phi-2-ov-quantized)
**Deepseek-coder new location:** [Intel/deepseek-coder-1.3b_base_ov_int8](https://huggingface.co/Intel/deepseek-coder-1.3b_base_ov_int8)