### PR TITLE
[NVIDIA]Fix set tensor descriptor in nvidia tests

### DIFF
--- a/modules/nvidia_plugin/tests/unit/result.cpp
+++ b/modules/nvidia_plugin/tests/unit/result.cpp
@@ -28,7 +28,7 @@ public:
             ov::element::Type{},
             ov::PartialShape{1},
             std::unordered_set<std::string>{ParameterStubNode::get_type_info_static().name});
-        node->m_outputs.emplace_back(node.get(), 0, tensor);
+        node->get_output_descriptor(0).set_tensor_ptr(tensor);
     }
 };
 


### PR DESCRIPTION
###Details
- Use OpenVINO API to to set tensor descriptor in output for `ParameterStubNode`

### Related PRs
- openvinotoolkit/openvino#23713