### PR TITLE
[JAVA_API] Add as_long() to Tensor

### DIFF
--- a/modules/java_api/src/main/cpp/openvino_java.hpp
+++ b/modules/java_api/src/main/cpp/openvino_java.hpp
@@ -67,6 +67,7 @@ extern "C"
     JNIEXPORT jint JNICALL Java_org_intel_openvino_Tensor_GetElementType(JNIEnv *, jobject, jlong);
     JNIEXPORT jfloatArray JNICALL Java_org_intel_openvino_Tensor_asFloat(JNIEnv *, jobject, jlong);
     JNIEXPORT jintArray JNICALL Java_org_intel_openvino_Tensor_asInt(JNIEnv *, jobject, jlong);
+    JNIEXPORT jlongArray JNICALL Java_org_intel_openvino_Tensor_asLong(JNIEnv *, jobject, jlong);
     JNIEXPORT void JNICALL Java_org_intel_openvino_Tensor_delete(JNIEnv *, jobject, jlong);
 
     // ov::PrePostProcessor

--- a/modules/java_api/src/main/cpp/tensor.cpp
+++ b/modules/java_api/src/main/cpp/tensor.cpp
@@ -173,6 +173,29 @@ JNIEXPORT jintArray JNICALL Java_org_intel_openvino_Tensor_asInt(JNIEnv *env, jo
     return 0;
 }
 
+JNIEXPORT jlongArray JNICALL Java_org_intel_openvino_Tensor_asLong(JNIEnv *env, jobject, jlong addr)
+{
+    JNI_METHOD(
+        "asLong",
+        Tensor *ov_tensor = (Tensor *)addr;
+
+        size_t size = ov_tensor->get_size();
+        const int64_t *data = ov_tensor->data<const int64_t>();
+
+        jlongArray result = env->NewLongArray(size);
+        if (!result) {
+            throw std::runtime_error("Out of memory!");
+        } jlong *arr = env->GetLongArrayElements(result, nullptr);
+
+        for (size_t i = 0; i < size; ++i)
+            arr[i] = static_cast<jlong>(data[i]);
+
+        env->ReleaseLongArrayElements(result, arr, 0);
+        return result;
+    )
+    return 0;
+}
+
 JNIEXPORT void JNICALL Java_org_intel_openvino_Tensor_delete(JNIEnv *, jobject, jlong addr)
 {
     Tensor *tensor = (Tensor *)addr;

--- a/modules/java_api/src/main/java/org/intel/openvino/Tensor.java
+++ b/modules/java_api/src/main/java/org/intel/openvino/Tensor.java
@@ -71,6 +71,11 @@ public class Tensor extends Wrapper {
         return asInt(nativeObj);
     }
 
+    /** Returns the tensor data as a long array. */
+    public long[] as_long() {
+        return asLong(nativeObj);
+    }
+
     /*----------------------------------- native methods -----------------------------------*/
     private static native long TensorCArray(int type, int[] shape, long cArray);
 
@@ -87,6 +92,8 @@ public class Tensor extends Wrapper {
     private static native float[] asFloat(long addr);
 
     private static native int[] asInt(long addr);
+
+    private static native long[] asLong(long addr);
 
     private static native int GetSize(long addr);
 

--- a/modules/java_api/src/test/java/org/intel/openvino/TensorTests.java
+++ b/modules/java_api/src/test/java/org/intel/openvino/TensorTests.java
@@ -42,6 +42,7 @@ public class TensorTests extends OVTest {
         Tensor tensor = new Tensor(dimsArr, inputData);
 
         assertArrayEquals(dimsArr, tensor.get_shape());
+        assertArrayEquals(inputData, tensor.as_long());
         assertEquals(size, tensor.get_size());
         assertEquals(ElementType.i64, tensor.get_element_type());
     }


### PR DESCRIPTION
Add as_long() method to org.intel.openvino.Tensor to allow retrieving data from i64 tensors.