### PR TITLE
[JAVA_API] Add get_element_type() to Tensor

### DIFF
--- a/modules/java_api/src/main/cpp/openvino_java.hpp
+++ b/modules/java_api/src/main/cpp/openvino_java.hpp
@@ -64,6 +64,7 @@ extern "C"
     JNIEXPORT jlong JNICALL Java_org_intel_openvino_Tensor_TensorLong(JNIEnv *, jobject, jintArray, jlongArray);
     JNIEXPORT jint JNICALL Java_org_intel_openvino_Tensor_GetSize(JNIEnv *, jobject, jlong);
     JNIEXPORT jintArray JNICALL Java_org_intel_openvino_Tensor_GetShape(JNIEnv *, jobject, jlong);
+    JNIEXPORT jint JNICALL Java_org_intel_openvino_Tensor_GetElementType(JNIEnv *, jobject, jlong);
     JNIEXPORT jfloatArray JNICALL Java_org_intel_openvino_Tensor_asFloat(JNIEnv *, jobject, jlong);
     JNIEXPORT jintArray JNICALL Java_org_intel_openvino_Tensor_asInt(JNIEnv *, jobject, jlong);
     JNIEXPORT void JNICALL Java_org_intel_openvino_Tensor_delete(JNIEnv *, jobject, jlong);

--- a/modules/java_api/src/main/cpp/tensor.cpp
+++ b/modules/java_api/src/main/cpp/tensor.cpp
@@ -114,6 +114,19 @@ JNIEXPORT jintArray JNICALL Java_org_intel_openvino_Tensor_GetShape(JNIEnv *env,
     return 0;
 }
 
+JNIEXPORT jint JNICALL Java_org_intel_openvino_Tensor_GetElementType(JNIEnv *env, jobject, jlong addr)
+{
+    JNI_METHOD(
+        "GetElementType",
+        Tensor *ov_tensor = (Tensor *)addr;
+
+        element::Type_t t_type = ov_tensor->get_element_type();
+        jint type = static_cast<jint>(t_type);
+        return type;
+    )
+    return 0;
+}
+
 JNIEXPORT jfloatArray JNICALL Java_org_intel_openvino_Tensor_asFloat(JNIEnv *env, jobject, jlong addr)
 {
     JNI_METHOD(

--- a/modules/java_api/src/main/java/org/intel/openvino/Tensor.java
+++ b/modules/java_api/src/main/java/org/intel/openvino/Tensor.java
@@ -56,6 +56,11 @@ public class Tensor extends Wrapper {
         return GetShape(nativeObj);
     }
 
+    /** Returns the tensor element type. */
+    public ElementType get_element_type() {
+        return ElementType.valueOf(GetElementType(nativeObj));
+    }
+
     /** Returns a tensor data as floating point array. */
     public float[] data() {
         return asFloat(nativeObj);
@@ -76,6 +81,8 @@ public class Tensor extends Wrapper {
     private static native long TensorLong(int[] shape, long[] data);
 
     private static native int[] GetShape(long addr);
+
+    private static native int GetElementType(long addr);
 
     private static native float[] asFloat(long addr);
 

--- a/modules/java_api/src/test/java/org/intel/openvino/TensorTests.java
+++ b/modules/java_api/src/test/java/org/intel/openvino/TensorTests.java
@@ -16,6 +16,7 @@ public class TensorTests extends OVTest {
 
         assertArrayEquals(tensor.get_shape(), dimsArr);
         assertArrayEquals(tensor.data(), data, 0.0f);
+        assertEquals(ElementType.f32, tensor.get_element_type());
     }
 
     @Test
@@ -29,6 +30,7 @@ public class TensorTests extends OVTest {
         assertArrayEquals(dimsArr, tensor.get_shape());
         assertArrayEquals(inputData, tensor.as_int());
         assertEquals(size, tensor.get_size());
+        assertEquals(ElementType.i32, tensor.get_element_type());
     }
 
     @Test
@@ -41,5 +43,6 @@ public class TensorTests extends OVTest {
 
         assertArrayEquals(dimsArr, tensor.get_shape());
         assertEquals(size, tensor.get_size());
+        assertEquals(ElementType.i64, tensor.get_element_type());
     }
 }


### PR DESCRIPTION
Add get_element_type() to org.intel.openvino.Tensor, allowing to check the data type of a tensor to call the proper method to retrieve its data.