### PR TITLE
Replace undefined type with dynamic

### DIFF
--- a/modules/java_api/src/main/cpp/jni_common.hpp
+++ b/modules/java_api/src/main/cpp/jni_common.hpp
@@ -236,7 +236,7 @@ static const ov::element::Type_t& get_ov_type(int type)
 {
     static const std::vector<ov::element::Type_t> java_type_to_ov_type
     {
-        ov::element::Type_t::undefined,
+        ov::element::Type_t::dynamic,
         ov::element::Type_t::dynamic,
         ov::element::Type_t::boolean,
         ov::element::Type_t::bf16,

--- a/modules/nvidia_plugin/src/cuda_config.hpp
+++ b/modules/nvidia_plugin/src/cuda_config.hpp
@@ -57,7 +57,7 @@ private:
     ov::streams::Num num_streams = 0;
     ov::hint::PerformanceMode performance_mode = ov::hint::PerformanceMode::LATENCY;
     ov::hint::ExecutionMode execution_mode = ov::hint::ExecutionMode::PERFORMANCE;
-    ov::element::Type inference_precision = ov::element::undefined;
+    ov::element::Type inference_precision = ov::element::dynamic;
 };
 
 }  // namespace nvidia_gpu

--- a/modules/nvidia_plugin/src/cuda_operation_base.hpp
+++ b/modules/nvidia_plugin/src/cuda_operation_base.hpp
@@ -131,7 +131,7 @@ public:
 protected:
     std::string node_name_;
     std::string type_name_;
-    ov::element::Type runtime_precision_ = ov::element::undefined;
+    ov::element::Type runtime_precision_ = ov::element::dynamic;
     const IndexCollection input_ids_;
     const IndexCollection output_ids_;
     WorkbufferIds workbuffer_ids_;

--- a/modules/nvidia_plugin/src/ops/gather.cpp
+++ b/modules/nvidia_plugin/src/ops/gather.cpp
@@ -48,7 +48,6 @@ GatherOp::GatherOp(const CreationContext& context,
 
     const ov::element::Type_t element_type = node.get_input_element_type(0);
     switch (element_type) {
-        case ov::element::Type_t::undefined:
         case ov::element::Type_t::dynamic:
         case ov::element::Type_t::u1:
             throw_ov_exception(fmt::format("Params element type = {} is not supported by Gather operation!",

--- a/modules/nvidia_plugin/src/ops/scatter_nd_update.cpp
+++ b/modules/nvidia_plugin/src/ops/scatter_nd_update.cpp
@@ -23,7 +23,6 @@ ScatterNDUpdateOp::ScatterNDUpdateOp(const CreationContext& context,
 
     const ov::element::Type_t input_type = node.get_input_element_type(0);
     switch (input_type) {
-        case ov::element::Type_t::undefined:
         case ov::element::Type_t::dynamic:
         case ov::element::Type_t::u1:
             throw_ov_exception(fmt::format("Params element type = {} is not supported by ScatterNDUpdate operation!",

--- a/modules/nvidia_plugin/src/ops/split.cpp
+++ b/modules/nvidia_plugin/src/ops/split.cpp
@@ -36,7 +36,6 @@ SplitOp::SplitOp(const CreationContext& context,
     OPENVINO_ASSERT(splitOp->get_output_size() == num_splits_, "Node name: ", GetName());
     OPENVINO_ASSERT(input_element_type == output_element_type, "Node name: ", GetName());
     switch (input_element_type) {
-        case ov::element::Type_t::undefined:
         case ov::element::Type_t::dynamic:
         case ov::element::Type_t::u1:
             throw_ov_exception(

--- a/modules/nvidia_plugin/src/ops/variadic_split.cpp
+++ b/modules/nvidia_plugin/src/ops/variadic_split.cpp
@@ -81,7 +81,6 @@ VariadicSplitOp::VariadicSplitOp(const CreationContext& context,
     OPENVINO_ASSERT(variadic_split_node->get_input_size() == 3, "Node name: ", GetName());
     OPENVINO_ASSERT(input_element_type == output_element_type, "Node name: ", GetName());
     switch (input_element_type) {
-        case ov::element::Type_t::undefined:
         case ov::element::Type_t::dynamic:
         case ov::element::Type_t::u1:
             throw_ov_exception(

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/ov_finite_comparer.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/ov_finite_comparer.cpp
@@ -77,7 +77,6 @@ inline void call_compare(const ov::Tensor& expected,
                 expected.data<ov::bfloat16>(), actual_buffer, size, threshold, to_check_nans, infinity_value);
             break;
         case ov::element::Type_t::dynamic:
-        case ov::element::Type_t::undefined:
             FiniteLayerComparer::compare<T_IE, T_IE>(
                 expected.data<T_IE>(), actual_buffer, size, threshold, to_check_nans, infinity_value);
             break;
@@ -98,8 +97,7 @@ void FiniteLayerComparer::compare(const ov::Tensor& expected,
     if (expected.get_element_type() == ov::element::Type_t::u4 ||
         expected.get_element_type() == ov::element::Type_t::i4) {
         k /= 2;
-    } else if (expected.get_element_type() == ov::element::Type_t::undefined ||
-               expected.get_element_type() == ov::element::Type_t::dynamic) {
+    } else if (expected.get_element_type() == ov::element::Type_t::dynamic) {
         k = 1;
     }
     ASSERT_EQ(expected.get_byte_size(), actual.get_byte_size() * k);

--- a/modules/nvidia_plugin/tests/unit/memory_manager/cuda_memory_manager_test.cpp
+++ b/modules/nvidia_plugin/tests/unit/memory_manager/cuda_memory_manager_test.cpp
@@ -60,7 +60,7 @@ public:  // ov::nvidia_gpu::IOperationMeta
         static constexpr std::string_view empty{""};
         return empty;
     }
-    const ov::element::Type& GetRuntimePrecision() const override { return ov::element::undefined; }
+    const ov::element::Type& GetRuntimePrecision() const override { return ov::element::dynamic; }
     gsl::span<const ov::nvidia_gpu::TensorID> GetInputIds() const override { return inputIds_; }
     gsl::span<const ov::nvidia_gpu::TensorID> GetOutputIds() const override { return outputIds_; }
 };


### PR DESCRIPTION
### Description
- Use same enum for undefined and dynamic cause compile warning/error in switch cases.
- Repalce undefined with dynamic

### Related PR
- openvinotoolkit/openvino#28766