### PR TITLE
docs(ollama_openvino): fix download links for macOS and Windows (#967)

### DIFF
--- a/modules/ollama_openvino/README.md
+++ b/modules/ollama_openvino/README.md
@@ -20,9 +20,13 @@ Get up and running with large language models.
 
 ### macOS
 
+Download the latest macOS executable:
+
 [Download](https://ollama.com/download/Ollama-darwin.zip)
 
 ### Windows
+
+Download the latest Windows installer:
 
 [Download](https://ollama.com/download/OllamaSetup.exe)
 


### PR DESCRIPTION
Replaced the placeholder Ollama download URLs in `modules/ollama_openvino/README.md` with the official macOS and Windows links:

- macOS → `https://ollama.com/download/Ollama-darwin.zip`
- Windows → `https://ollama.com/download/OllamaSetup.exe`

Fixes openvinotoolkit/openvino_contrib#967