### PR TITLE
[GHA] Update to Windows 2022 runner image

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,7 +26,7 @@ jobs:
     defaults:
       run:
         shell: pwsh
-    runs-on: windows-2019-16-core
+    runs-on: windows-2022-16-core
     env:
       CMAKE_BUILD_TYPE: 'Release'
       CMAKE_CXX_COMPILER_LAUNCHER: ccache


### PR DESCRIPTION
**Details**
Upgrade GHA windows action runner from `windows-2019` to `windows-2022`

Windows 2019 Actions runner image fully unsupported by 2025-06-30: https://github.com/actions/runner-images/issues/12045