### PR TITLE
Disable llama_cpp_plugin build

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -120,6 +120,8 @@ jobs:
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} \
             -DBUILD_nvidia_plugin=OFF \
+            -DBUILD_ollama_openvino=OFF \
+            -DBUILD_llama_cpp_plugin=OFF \
             -DENABLE_INTEL_GPU=OFF \
             -DENABLE_OV_TF_FRONTEND=OFF \
             -DENABLE_OV_PADDLE_FRONTEND=OFF \
@@ -131,7 +133,6 @@ jobs:
             -DENABLE_WHEEL=ON \
             -DENABLE_TESTS=ON \
             -DENABLE_INTEL_NPU=OFF \
-            -DBUILD_ollama_openvino=OFF \
             -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CMAKE_CXX_COMPILER_LAUNCHER }} \
             -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CMAKE_C_COMPILER_LAUNCHER }} \
             -S ${OPENVINO_REPO} \

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -101,6 +101,8 @@ jobs:
             -DCMAKE_VERBOSE_MAKEFILE=ON \
             -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} \
             -DBUILD_nvidia_plugin=OFF \
+            -DBUILD_ollama_openvino=OFF \
+            -DBUILD_llama_cpp_plugin=OFF \
             -DOPENVINO_EXTRA_MODULES=${{ env.OPENVINO_CONTRIB_REPO }}/modules \
             -DCMAKE_OSX_DEPLOYMENT_TARGET=${{ env.MACOSX_DEPLOYMENT_TARGET }} \
             -DCMAKE_OSX_ARCHITECTURES=${{ env.OSX_ARCHITECTURES }} \
@@ -112,7 +114,6 @@ jobs:
             -DENABLE_OV_PYTORCH_FRONTEND=OFF \
             -DENABLE_CPPLINT=OFF \
             -DENABLE_INTEL_NPU=OFF \
-            -DBUILD_ollama_openvino=OFF \
             -S ${{ env.OPENVINO_REPO }} \
             -B ${{ env.BUILD_DIR }}
 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -127,6 +127,8 @@ jobs:
           cmake -GNinja `
             -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} `
             -DBUILD_nvidia_plugin=OFF `
+            -DBUILD_ollama_openvino=OFF `
+            -DBUILD_llama_cpp_plugin=OFF `
             -DENABLE_OV_TF_FRONTEND=OFF `
             -DENABLE_OV_PADDLE_FRONTEND=OFF `
             -DENABLE_OV_TF_LITE_FRONTEND=OFF `
@@ -137,7 +139,6 @@ jobs:
             -DENABLE_PYTHON=ON `
             -DENABLE_INTEL_NPU=OFF `
             -DENABLE_JS=OFF `
-            -DBUILD_ollama_openvino=OFF `
             -DOPENVINO_EXTRA_MODULES=${{ env.OPENVINO_CONTRIB_REPO }}/modules `
             -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CMAKE_CXX_COMPILER_LAUNCHER }} `
             -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CMAKE_C_COMPILER_LAUNCHER }} `


### PR DESCRIPTION
Disable the `llama_cpp_plugin` build until #992 is not merged.