### PR TITLE
[JAVA_API] Fix samples build

### DIFF
--- a/modules/java_api/gradle.properties
+++ b/modules/java_api/gradle.properties
@@ -1,4 +1,3 @@
-build_benchmark_app=false
 build_java_samples=false
 build_kotlin_samples=false
 build_hello_query_device=false

--- a/modules/java_api/samples/face_detection_java_sample/build.gradle
+++ b/modules/java_api/samples/face_detection_java_sample/build.gradle
@@ -35,7 +35,10 @@ sourceSets {
         }
     }
 }
-mainClassName = 'Main'
+
+application {
+    mainClass = 'Main'
+}
 
 dependencies {  
     implementation rootProject

--- a/modules/java_api/samples/face_detection_kotlin_sample/build.gradle
+++ b/modules/java_api/samples/face_detection_kotlin_sample/build.gradle
@@ -40,7 +40,10 @@ sourceSets {
     main.java.srcDirs = ['src/main/kotlin', '../common']
     main.kotlin.srcDirs = ['src/main/kotlin', '../common']
 }
-mainClassName = 'Main'
+
+application {
+    mainClass = 'Main'
+}
 
 dependencies {
     implementation rootProject

--- a/modules/java_api/samples/hello_query_device/build.gradle
+++ b/modules/java_api/samples/hello_query_device/build.gradle
@@ -10,7 +10,10 @@ sourceSets {
         }
     }
 }
-mainClassName = 'Main'
+
+application {
+    mainClass = 'Main'
+}
 
 dependencies {  
     implementation rootProject

--- a/modules/java_api/settings.gradle
+++ b/modules/java_api/settings.gradle
@@ -1,10 +1,7 @@
 rootProject.name = 'openvino'
 
-if (build_benchmark_app.toBoolean()) {
-    include 'samples:benchmark_app'
-}
 if (build_java_samples.toBoolean()) {
-    include 'samples:face_detection_java_sample', 'samples:face_detection_sample_async'
+    include 'samples:face_detection_java_sample'
 }
 if (build_kotlin_samples.toBoolean()) {
     include 'samples:face_detection_kotlin_sample'


### PR DESCRIPTION
 - Remove non-existing samples mention in `settings.gradle` and `gradle.properties` to fix samples build
 - Replace deprecated (in version 7) and later removed (in version 8) `mainClassName` gradle option with the `application { mainClass = <class_name> }` in the `hello_query_device` and `face_detection samples` so they build with newer Gradle versions