### PR TITLE
[TEST] Legacy fn 'disabledTestPatterns' was removed

### DIFF
--- a/modules/nvidia_plugin/tests/functional/skip_tests_config.cpp
+++ b/modules/nvidia_plugin/tests/functional/skip_tests_config.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2023 Intel Corporation
+// Copyright (C) 2020-2026 Intel Corporation
 // SPDX-License-Identifier: Apache-2.0
 //
 
@@ -64,58 +64,4 @@ const std::vector<std::regex>& disabled_test_patterns() {
     const static std::vector<std::regex> patterns = get_patterns();
 
     return patterns;
-}
-
-// TODO: Remove after merging disabled_test_patterns into OV
-std::vector<std::string> disabledTestPatterns() {
-    std::vector<std::string> retVector{
-        // CVS-55937
-        R"(.*SplitLayerTest.*numSplits=30.*)",
-        // CVS-51758
-        R"(.*InferRequestPreprocessConversionTest.*oLT=(NHWC|NCHW).*)",
-        R"(.*InferRequestPreprocessDynamicallyInSetBlobTest.*oPRC=0.*oLT=1.*)",
-        // Not Implemented
-        R"(.*Behavior.*ExecutableNetworkBaseTest.*(CheckExecGraphInfoBeforeExecution|CheckExecGraphInfoAfterExecution|CheckExecGraphInfoSerialization).*)",
-        R"(.*smoke_BehaviorTests.*OVExecGraphImportExportTest.ieImportExportedFunction.*)",
-        R"(.*CachingSupportCase*.*ReadConcatSplitAssign.*)",
-        // 101751, 101746, 101747, 101748, 101755
-        R"(.*(d|D)ynamic*.*)",
-        R"(.*smoke_AutoBatch_BehaviorTests*.*)",
-        R"(.*smoke_Auto_BehaviorTests*.*)",
-        R"(.*smoke_Multi_BehaviorTests*.*)",
-        R"(.*HETERO(W|w)ithMULTI*.*)",
-        // Plugin version was changed to ov::Version
-        R"(.*VersionTest.*pluginCurrentVersionIsCorrect.*)",
-        // New plugin API doesn't support changes of pre-processing
-        R"(.*InferRequestPreprocessTest.*SetPreProcessToInputInfo.*)",
-        R"(.*InferRequestPreprocessTest.*SetPreProcessToInferRequest.*)",
-        // New plugin work with tensors, so it means that blob in old API can have different pointers
-        R"(.*InferRequestIOBBlobTest.*secondCallGetInputDoNotReAllocateData.*)",
-        R"(.*InferRequestIOBBlobTest.*secondCallGetOutputDoNotReAllocateData.*)",
-        R"(.*InferRequestIOBBlobTest.*secondCallGetInputAfterInferSync.*)",
-        R"(.*InferRequestIOBBlobTest.*secondCallGetOutputAfterInferSync.*)",
-        // Old API cannot deallocate tensor
-        R"(.*InferRequestIOBBlobTest.*canProcessDeallocatedOutputBlobAfterGetAndSetBlob.*)",
-        // 119703
-        R"(.*smoke_GroupConvolutionBias(Add|AddAdd)_2D_ExplicitPaddingSymmetric2.*FP16*.*)",
-        // Issue: 128924
-        R"(.*smoke_OVClassNetworkTestP/OVClassModelTestP.ImportModelWithNullContextThrows.*)",
-    };
-
-#ifdef _WIN32
-    // CVS-63989
-    retVector.emplace_back(R"(.*ReferenceSigmoidLayerTest.*u64.*)");
-    // CVS-64054
-    retVector.emplace_back(R"(.*ReferenceTopKTest.*topk_max_sort_none)");
-    retVector.emplace_back(R"(.*ReferenceTopKTest.*topk_min_sort_none)");
-#endif
-
-    if (!CUDA::isHalfSupported(CUDA::Device{})) {
-        retVector.emplace_back(
-            R"(.*OVExecGraphImportExportTest.*importExportedFunctionParameterResultOnly.*targetDevice=NVIDIA_elementType=f16.*)");
-        retVector.emplace_back(
-            R"(.*OVExecGraphImportExportTest.*importExportedIENetworkParameterResultOnly.*targetDevice=NVIDIA_elementType=f16.*)");
-    }
-
-    return retVector;
 }


### PR DESCRIPTION
OV PR [#33926](https://github.com/openvinotoolkit/openvino/pull/33926) was merged, so fn `disabledTestPatterns` can be removed