### PR TITLE
[NVIDIA] Fix ResultOp fused names

### DIFF
--- a/modules/nvidia_plugin/src/cuda_plugin.cpp
+++ b/modules/nvidia_plugin/src/cuda_plugin.cpp
@@ -129,11 +129,11 @@ std::shared_ptr<ov::ICompiledModel> Plugin::import_model(std::istream& model_str
 
     auto full_config = get_full_config(_properties);
     auto wait_executor = get_stream_executor(full_config);
-    auto compiled_model= std::make_shared<CompiledModel>(model,
-                                                         full_config,
-                                                         wait_executor,
-                                                         shared_from_this(),
-                                                         loaded_from_cache);
+    auto compiled_model = std::make_shared<CompiledModel>(model,
+                                                          full_config,
+                                                          wait_executor,
+                                                          shared_from_this(),
+                                                          loaded_from_cache);
     return compiled_model;
 }
 

--- a/modules/nvidia_plugin/src/ops/result.cpp
+++ b/modules/nvidia_plugin/src/ops/result.cpp
@@ -71,6 +71,16 @@ std::vector<std::string> ResultOp::GetOutputTensorName(const ov::op::v0::Result&
             name += "." + std::to_string(sub_index.value());
         }
         names.push_back(name);
+    } else {
+        // For multi-output nodes, append the output port index to each fused name
+        // to ensure uniqueness across different Result ops connected to the same node
+        auto sub_index = GetOutputTensorSubIndex(input);
+        if (sub_index.has_value()) {
+            auto suffix = "." + std::to_string(sub_index.value());
+            for (auto& name : names) {
+                name += suffix;
+            }
+        }
     }
     return names;
 }

--- a/modules/nvidia_plugin/src/ops/result.cpp
+++ b/modules/nvidia_plugin/src/ops/result.cpp
@@ -63,7 +63,16 @@ std::optional<std::size_t> ResultOp::GetOutputTensorSubIndex(const ov::Output<ov
 
 std::vector<std::string> ResultOp::GetOutputTensorName(const ov::op::v0::Result& node) {
     const auto& input = node.input_value(0);
-    return ov::getFusedNamesVector(input.get_node()->shared_from_this());
+    auto names = ov::getFusedNamesVector(input.get_node()->shared_from_this());
+    if (names.empty()) {
+        auto name = input.get_node()->get_friendly_name();
+        auto sub_index = GetOutputTensorSubIndex(input);
+        if (sub_index.has_value()) {
+            name += "." + std::to_string(sub_index.value());
+        }
+        names.push_back(name);
+    }
+    return names;
 }
 
 void ResultOp::Capture(InferenceRequestContext& context,


### PR DESCRIPTION
# Description
Fixed issue that 'cause bunch of crashed functional tests related to fused names