### PR TITLE
[JAVA_API] Fix wrapper close bug

### DIFF
--- a/modules/java_api/src/main/java/org/intel/openvino/Wrapper.java
+++ b/modules/java_api/src/main/java/org/intel/openvino/Wrapper.java
@@ -27,7 +27,7 @@ public class Wrapper implements AutoCloseable {
 
     @Override
     public void close() {
-        if (!closed.compareAndSet(false, true)) {
+        if (closed.compareAndSet(false, true)) {
             delete(nativeObj);
         }
     }


### PR DESCRIPTION
Corrects the logic in `Wrapper.close()` to ensure that the native resource is released.
Without this fix, no memory is being released when close is called once.