### PR TITLE
Add NPU fallback warning (Resolves #996)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .vscode/
+.gradle/
+build/
+*.class

--- a/modules/ollama_openvino/build_genai.bat
+++ b/modules/ollama_openvino/build_genai.bat
@@ -1,0 +1,66 @@
+@echo off
+set OV=c:\Users\VAIBHA~1\OneDrive\DOCUME~1\MASTER\OPENVI~1\OPENVI~1\modules\OLLAMA~1\OPENVI~1\OPENVI~1.0_X\runtime
+set CGO_ENABLED=1
+set CGO_CFLAGS=-I%OV%\include
+set CGO_CXXFLAGS=-I%OV%\include
+set CGO_LDFLAGS=-L%OV%\lib\intel64\Release
+set PATH=C:\msys64\ucrt64\bin;%PATH%
+set CC=C:\msys64\mingw64\bin\gcc.exe
+set CXX=C:\msys64\mingw64\bin\g++.exe
+set CGO_LDFLAGS=%CGO_LDFLAGS% -static-libgcc -static-libstdc++ -Wl,-Bstatic -lpthread -Wl,-Bdynamic
+
+echo OV_ROOT = %OV%
+echo CGO_CFLAGS = %CGO_CFLAGS%
+echo CGO_LDFLAGS = %CGO_LDFLAGS%
+echo CC = %CC%
+echo.
+
+echo Building ollama_genai_runner.exe ...
+go build -v -o ollama_genai_runner.exe .\cmd\genai
+if %ERRORLEVEL% NEQ 0 (
+    echo.
+    echo GENAI RUNNER BUILD FAILED
+    exit /b %ERRORLEVEL%
+)
+echo GENAI RUNNER BUILD OK
+
+echo.
+echo Building ollama.exe ...
+go build -trimpath -ldflags "-s -w" -o ollama_new.exe .
+if %ERRORLEVEL% NEQ 0 (
+    echo.
+    echo OLLAMA BUILD FAILED
+    exit /b %ERRORLEVEL%
+)
+echo OLLAMA BUILD OK
+
+echo.
+echo Done. Binaries:
+dir ollama_genai_runner.exe ollama_new.exe
+
+echo.
+echo Backing up and deploying to Ollama install dir...
+set OLLAMA_INSTALL=C:\Users\VAIBHA~1\AppData\Local\Programs\Ollama
+set OV_BIN=c:\Users\VAIBHA~1\OneDrive\DOCUME~1\MASTER\OPENVI~1\OPENVI~1\modules\OLLAMA~1\OPENVI~1\OPENVI~1.0_X\runtime\bin\intel64\Release
+
+copy /y %OLLAMA_INSTALL%\ollama.exe %OLLAMA_INSTALL%\ollama.exe.bak
+copy /y ollama_new.exe %OLLAMA_INSTALL%\ollama.exe
+
+echo Copying OpenVINO DLLs to Ollama install dir...
+copy /y %OV_BIN%\openvino.dll %OLLAMA_INSTALL%\
+copy /y %OV_BIN%\openvino_c.dll %OLLAMA_INSTALL%\
+copy /y %OV_BIN%\openvino_genai.dll %OLLAMA_INSTALL%\
+copy /y %OV_BIN%\openvino_genai_c.dll %OLLAMA_INSTALL%\
+copy /y %OV_BIN%\openvino_tokenizers.dll %OLLAMA_INSTALL%\
+copy /y %OV_BIN%\openvino_intel_cpu_plugin.dll %OLLAMA_INSTALL%\
+copy /y %OV_BIN%\openvino_intel_gpu_plugin.dll %OLLAMA_INSTALL%\
+copy /y %OV_BIN%\openvino_intel_npu_plugin.dll %OLLAMA_INSTALL%\
+copy /y %OV_BIN%\openvino_ir_frontend.dll %OLLAMA_INSTALL%\
+copy /y %OV_BIN%\openvino_auto_plugin.dll %OLLAMA_INSTALL%\
+copy /y %OV_BIN%\openvino_auto_batch_plugin.dll %OLLAMA_INSTALL%\
+copy /y %OV_BIN%\openvino_hetero_plugin.dll %OLLAMA_INSTALL%\
+copy /y %OV_BIN%\icudt70.dll %OLLAMA_INSTALL%\
+copy /y %OV_BIN%\icuuc70.dll %OLLAMA_INSTALL%\
+
+echo.
+echo Deployment complete. Run: ollama run deepseek-r1 "hello world"

--- a/modules/ollama_openvino/cc.bat
+++ b/modules/ollama_openvino/cc.bat
@@ -1,0 +1,35 @@
+@echo off
+setlocal enabledelayedexpansion
+set "args="
+:loop
+if "%~1" == "" goto :run
+set "arg=%~1"
+if "!arg!" == "-Werror" goto :next
+if "!arg!" == "-Wall" goto :next
+if "!arg!" == "-m64" goto :next
+if "!arg!" == "-mthreads" goto :next
+if "!arg!" == "-fno-stack-protector" goto :next
+if "!arg!" == "-fmessage-length=0" goto :next
+if "!arg!" == "-g" (
+    set "args=!args! /Zi"
+    goto :next
+)
+if "!arg!" == "-O2" (
+    set "args=!args! /O2"
+    goto :next
+)
+if "!arg!" == "-o" (
+    set "args=!args! /Fo%~2"
+    shift
+    goto :next
+)
+if "!arg!" == "-c" (
+    set "args=!args! /c"
+    goto :next
+)
+set "args=!args! %1"
+:next
+shift
+goto :loop
+:run
+cl.exe !args!

--- a/modules/ollama_openvino/discover/gpu.go
+++ b/modules/ollama_openvino/discover/gpu.go
@@ -4,7 +4,7 @@ package discover
 
 /*
 #cgo linux LDFLAGS: -lrt -lpthread -ldl -lstdc++ -lm
-#cgo windows LDFLAGS: -lpthread
+#cgo windows LDFLAGS: 
 
 #include "gpu_info.h"
 */

--- a/modules/ollama_openvino/genai/common.go
+++ b/modules/ollama_openvino/genai/common.go
@@ -40,6 +40,7 @@ type Sequence struct {
 	numKeep int
 
 	doneReason string
+	err        error
 
 	// Metrics
 	startProcessingTime time.Time
@@ -122,6 +123,7 @@ func (s *Sequence) GetSamplingParameters() *SamplingParams {
 // AppendPendingResponse 向 Sequence 的 pendingResponses 追加内容
 func (s *Sequence) AppendPendingResponse(response string) {
 	s.pendingResponses = append(s.pendingResponses, response)
+	s.numDecoded++
 }
 
 // CloseQuit 关闭 Sequence 的 quit 通道
@@ -137,6 +139,14 @@ func (s *Sequence) GetResponses() <-chan string {
 // GetDoneReason 返回 Sequence 的 doneReason 字段
 func (s *Sequence) GetDoneReason() string {
 	return s.doneReason
+}
+
+func (s *Sequence) SetError(err error) {
+	s.err = err
+}
+
+func (s *Sequence) GetError() error {
+	return s.err
 }
 
 // GetDoneReason 返回 Sequence 的 doneReason 字段

--- a/modules/ollama_openvino/genai/genai.go
+++ b/modules/ollama_openvino/genai/genai.go
@@ -1,13 +1,13 @@
 package genai
 
 /*
-#cgo CFLAGS: -std=c11
-#cgo CXXFLAGS: -std=c++17
+#cgo !windows CFLAGS: -std=c11
+#cgo windows CFLAGS: -std=c11
+#cgo !windows CXXFLAGS: -std=c++17
+#cgo windows CXXFLAGS: -std=c++17
 
-#cgo LDFLAGS: -lopenvino_genai
-#cgo LDFLAGS: -lopenvino
-#cgo LDFLAGS: -lopenvino_c
-#cgo LDFLAGS: -lopenvino_genai_c
+#cgo !windows LDFLAGS: -lopenvino_genai -lopenvino -lopenvino_c -lopenvino_genai_c
+#cgo windows LDFLAGS: -lopenvino_genai -lopenvino -lopenvino_c -lopenvino_genai_c
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -26,13 +26,28 @@ extern int goCallbackBridge(char* input, void* ptr);
 static ov_status_e ov_genai_llm_pipeline_create_npu_output_2048(const char* models_path,
 																  const char* device,
                                                                   ov_genai_llm_pipeline** pipe) {
-	return 	ov_genai_llm_pipeline_create(models_path, "NPU", 4, pipe, "MAX_PROMPT_LEN", "2048", "MIN_RESPONSE_LEN", "256");
+	return 	ov_genai_llm_pipeline_create(models_path, "NPU", 4, pipe, "MAX_PROMPT_LEN", "2048", "MIN_RESPONSE_LEN", "2048");
 }
 
 static ov_status_e ov_genai_llm_pipeline_create_cgo(const char* models_path,
 																  const char* device,
                                                                   ov_genai_llm_pipeline** pipe) {
 	return 	ov_genai_llm_pipeline_create(models_path, device, 0, pipe);
+}
+
+static ov_status_e ov_genai_llm_pipeline_generate_cgo(ov_genai_llm_pipeline* pipeline,
+                                                                  const char* input,
+                                                                  ov_genai_generation_config* config,
+                                                                  streamer_callback* callback,
+                                                                  ov_genai_decoded_results** result) {
+	ov_genai_llm_pipeline_start_chat(pipeline);
+	ov_status_e status = ov_genai_llm_pipeline_generate(pipeline, input, config, callback, result);
+	ov_genai_llm_pipeline_finish_chat(pipeline);
+	return status;
+}
+
+static void ov_genai_generation_config_free_cgo(ov_genai_generation_config* config) {
+	if (config) ov_genai_generation_config_free(config);
 }
 
 */
@@ -48,7 +63,9 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime/cgo"
 	"strconv"
+	"strings"
 	"unsafe"
 )
 
@@ -63,11 +80,137 @@ type SamplingParams struct {
 	RepeatLastN   int
 }
 
-// type Model struct {
-// 	pipe *C.LLMPipelineHandle
-// }
-
 type Model *C.ov_genai_llm_pipeline
+
+func ovStatusError(op string, status C.ov_status_e) error {
+	if int(status) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("%s failed with OpenVINO status code %d", op, int(status))
+}
+
+func normalizeDeviceName(device string) string {
+	return strings.ToUpper(strings.TrimSpace(device))
+}
+
+func devicePluginName(device string) string {
+	normalized := normalizeDeviceName(device)
+	if idx := strings.Index(normalized, "."); idx >= 0 {
+		return normalized[:idx]
+	}
+
+	return normalized
+}
+
+func getAvailableDeviceNames() ([]string, error) {
+	var core *C.ov_core_t
+	status := C.ov_core_create(&core)
+	if err := ovStatusError("creating OpenVINO core", status); err != nil {
+		return nil, err
+	}
+	if core == nil {
+		return nil, fmt.Errorf("creating OpenVINO core returned a nil core")
+	}
+	defer C.ov_core_free(core)
+
+	var devices C.ov_available_devices_t
+	status = C.ov_core_get_available_devices(core, &devices)
+	if err := ovStatusError("getting OpenVINO available devices", status); err != nil {
+		return nil, err
+	}
+	defer C.ov_available_devices_free(&devices)
+
+	available := make([]string, 0, int(devices.size))
+	cString := devices.devices
+	for i := 0; i < int(devices.size); i++ {
+		available = append(available, C.GoString(*cString))
+		cString = (**C.char)(unsafe.Pointer(uintptr(unsafe.Pointer(cString)) + unsafe.Sizeof(*cString)))
+	}
+
+	return available, nil
+}
+
+func hasAvailableDevice(availableDevices []string, requested string) bool {
+	requested = normalizeDeviceName(requested)
+	if requested == "" {
+		return false
+	}
+
+	requestsSpecificID := strings.Contains(requested, ".")
+	for _, availableDevice := range availableDevices {
+		normalizedAvailable := normalizeDeviceName(availableDevice)
+		if normalizedAvailable == requested {
+			return true
+		}
+		if !requestsSpecificID && devicePluginName(normalizedAvailable) == requested {
+			return true
+		}
+	}
+
+	return false
+}
+
+func fallbackDevice(availableDevices []string) string {
+	switch {
+	case hasAvailableDevice(availableDevices, "CPU"):
+		return "CPU"
+	case hasAvailableDevice(availableDevices, "GPU"):
+		return "GPU"
+	case len(availableDevices) > 0:
+		return normalizeDeviceName(availableDevices[0])
+	default:
+		return ""
+	}
+}
+
+func defaultDevice(availableDevices []string) string {
+	switch {
+	case hasAvailableDevice(availableDevices, "GPU"):
+		return "GPU"
+	case hasAvailableDevice(availableDevices, "CPU"):
+		return "CPU"
+	case len(availableDevices) > 0:
+		return normalizeDeviceName(availableDevices[0])
+	default:
+		return ""
+	}
+}
+
+func ResolveDeviceOrFallback(device string) (string, error) {
+	availableDevices, err := getAvailableDeviceNames()
+	if err != nil {
+		return "", err
+	}
+	if len(availableDevices) == 0 {
+		return "", fmt.Errorf("OpenVINO reported no available devices")
+	}
+
+	requestedDevice := normalizeDeviceName(device)
+	if requestedDevice == "" {
+		resolved := defaultDevice(availableDevices)
+		if resolved == "" {
+			return "", fmt.Errorf("OpenVINO reported no default device (available: %s)", strings.Join(availableDevices, ", "))
+		}
+
+		return resolved, nil
+	}
+
+	if hasAvailableDevice(availableDevices, requestedDevice) {
+		return requestedDevice, nil
+	}
+
+	resolved := fallbackDevice(availableDevices)
+	if resolved == "" {
+		return "", fmt.Errorf("OpenVINO device %q is not available and no fallback device was found (available: %s)", requestedDevice, strings.Join(availableDevices, ", "))
+	}
+
+	log.Printf("OpenVINO device %q is not available (available: %s); falling back to %q", requestedDevice, strings.Join(availableDevices, ", "), resolved)
+	if requestedDevice == "NPU" && resolved == "CPU" {
+		fmt.Println("NPU is not available, falling back to CPU")
+	}
+	return resolved, nil
+}
 
 func IsGGUF(filePath string) (bool, error) {
 	file, err := os.Open(filePath)
@@ -185,22 +328,36 @@ func UnpackTarGz(tarGzPath string, destDir string) error {
 	return nil
 }
 
-func CreatePipeline(modelsPath string, device string) *C.ov_genai_llm_pipeline {
+func CreatePipeline(modelsPath string, device string) (*C.ov_genai_llm_pipeline, error) {
+	resolvedDevice, err := ResolveDeviceOrFallback(device)
+	if err != nil {
+		return nil, fmt.Errorf("resolving OpenVINO device %q: %w", device, err)
+	}
+
 	cModelsPath := C.CString(modelsPath)
-	cDevice := C.CString(device)
+	cDevice := C.CString(resolvedDevice)
 
 	var pipeline *C.ov_genai_llm_pipeline
+	var status C.ov_status_e
 
 	defer C.free(unsafe.Pointer(cModelsPath))
 	defer C.free(unsafe.Pointer(cDevice))
 
-	// C.ov_genai_llm_pipeline_create(cModelsPath, cDevice, &pipeline)
-	if device == "NPU" {
-		C.ov_genai_llm_pipeline_create_npu_output_2048(cModelsPath, cDevice, &pipeline)
+	if resolvedDevice == "NPU" {
+		status = C.ov_genai_llm_pipeline_create_npu_output_2048(cModelsPath, cDevice, &pipeline)
 	} else {
-		C.ov_genai_llm_pipeline_create_cgo(cModelsPath, cDevice, &pipeline)
+		status = C.ov_genai_llm_pipeline_create_cgo(cModelsPath, cDevice, &pipeline)
 	}
-	return pipeline
+
+	if err := ovStatusError("creating OpenVINO GenAI pipeline", status); err != nil {
+		return nil, fmt.Errorf("%w for %q on %s", err, modelsPath, resolvedDevice)
+	}
+
+	if pipeline == nil {
+		return nil, fmt.Errorf("creating OpenVINO GenAI pipeline returned a nil pipeline for %q on %s", modelsPath, resolvedDevice)
+	}
+
+	return pipeline, nil
 }
 
 func PrintGenaiMetrics(metrics *C.ov_genai_perf_metrics) {
@@ -214,27 +371,27 @@ func PrintGenaiMetrics(metrics *C.ov_genai_perf_metrics) {
 	var gen_mean C.float
 	var gen_std C.float
 	C.ov_genai_perf_metrics_get_inference_duration(metrics, &gen_mean, &gen_std)
-	log.Printf("Generate time: %.2f ± %.2f ms\n", gen_mean, gen_std)
+	log.Printf("Generate time: %.2f +/- %.2f ms\n", gen_mean, gen_std)
 
 	var token_mean C.float
 	var token_std C.float
 	C.ov_genai_perf_metrics_get_tokenization_duration(metrics, &token_mean, &token_std)
-	log.Printf("Tokenization time: %.2f ± %.2f ms\n", token_mean, token_std)
+	log.Printf("Tokenization time: %.2f +/- %.2f ms\n", token_mean, token_std)
 
 	var detoken_mean C.float
 	var detoken_std C.float
 	C.ov_genai_perf_metrics_get_detokenization_duration(metrics, &detoken_mean, &detoken_std)
-	log.Printf("Detokenization time: %.2f ± %.2f ms\n", detoken_mean, detoken_std)
+	log.Printf("Detokenization time: %.2f +/- %.2f ms\n", detoken_mean, detoken_std)
 
 	var ttft_mean C.float
 	var ttft_std C.float
 	C.ov_genai_perf_metrics_get_ttft(metrics, &ttft_mean, &ttft_std)
-	log.Printf("TTFT: %.2f ± %.2f ms\n", ttft_mean, ttft_std)
+	log.Printf("TTFT: %.2f +/- %.2f ms\n", ttft_mean, ttft_std)
 
 	var tpot_mean C.float
 	var tpot_std C.float
 	C.ov_genai_perf_metrics_get_tpot(metrics, &tpot_mean, &tpot_std)
-	log.Printf("TPOT: %.2f ± %.2f ms/token\n", tpot_mean, tpot_std)
+	log.Printf("TPOT: %.2f +/- %.2f ms/token\n", tpot_mean, tpot_std)
 
 	var num_generation_tokens C.size_t
 	C.ov_genai_perf_metrics_get_num_generation_tokens(metrics, &num_generation_tokens)
@@ -243,7 +400,7 @@ func PrintGenaiMetrics(metrics *C.ov_genai_perf_metrics) {
 	var tput_mean C.float
 	var tput_std C.float
 	C.ov_genai_perf_metrics_get_throughput(metrics, &tput_mean, &tput_std)
-	log.Printf("Throughput: %.2f ± %.2f tokens/s\n", tput_mean, tput_std)
+	log.Printf("Throughput: %.2f +/- %.2f tokens/s\n", tput_mean, tput_std)
 }
 
 func SetSamplingParams(samplingparameters *SamplingParams) *C.ov_genai_generation_config {
@@ -294,24 +451,47 @@ func SetSamplingParams(samplingparameters *SamplingParams) *C.ov_genai_generatio
 	return cConfig
 }
 
-func GenerateTextWithMetrics(pipeline *C.ov_genai_llm_pipeline, input string, samplingparameters *SamplingParams, seq *Sequence) string {
+func GenerateTextWithMetrics(pipeline *C.ov_genai_llm_pipeline, input string, samplingparameters *SamplingParams, seq *Sequence) (string, error) {
+	fmt.Println("GENERATION STARTED - input length:", len(input))
+	if pipeline == nil {
+		return "", fmt.Errorf("OpenVINO pipeline is not initialized")
+	}
+
 	cInput := C.CString(input)
 	defer C.free(unsafe.Pointer(cInput))
 
 	cConfig := SetSamplingParams(samplingparameters)
+	defer C.ov_genai_generation_config_free_cgo(cConfig)
 	var result *C.ov_genai_decoded_results
 
 	output_size := C.size_t(0)
 
-	// 创建 streamer_callback
+	handle := cgo.NewHandle(seq)
+	defer handle.Delete()
+
+	cHandle := C.malloc(C.size_t(unsafe.Sizeof(C.uintptr_t(0))))
+	defer C.free(cHandle)
+	*(*C.uintptr_t)(cHandle) = C.uintptr_t(handle)
+
+	// Create streamer_callback
 	var streamer_callback C.streamer_callback
 	streamer_callback.callback_func = (C.callback_function)(unsafe.Pointer(C.goCallbackBridge))
+	streamer_callback.args = cHandle
 
-	streamer_callback.args = unsafe.Pointer(seq)
+	status := C.ov_genai_llm_pipeline_generate_cgo(
+		pipeline,
+		cInput,
+		(*C.ov_genai_generation_config)(cConfig),
+		&streamer_callback,
+		&result,
+	)
+	if err := ovStatusError("generating text with OpenVINO GenAI", status); err != nil {
+		return "", err
+	}
 
-	C.ov_genai_llm_pipeline_start_chat(pipeline)
-	C.ov_genai_llm_pipeline_generate(pipeline, cInput, (*C.ov_genai_generation_config)(cConfig), &streamer_callback, &result)
-	C.ov_genai_llm_pipeline_finish_chat(pipeline)
+	if result == nil {
+		return "", fmt.Errorf("OpenVINO GenAI generate returned no decoded result")
+	}
 
 	C.ov_genai_decoded_results_get_string(result, (*C.char)(nil), &output_size)
 	cOutput := C.malloc(output_size)
@@ -322,12 +502,30 @@ func GenerateTextWithMetrics(pipeline *C.ov_genai_llm_pipeline, input string, sa
 	var metrics *C.ov_genai_perf_metrics
 	C.ov_genai_decoded_results_get_perf_metrics(result, &metrics)
 
-	PrintGenaiMetrics(metrics)
+	defer C.ov_genai_decoded_results_free(result)
 
-	return C.GoString((*C.char)(cOutput))
+	// Declare output first, then use it
+	output := C.GoString((*C.char)(cOutput))
+
+	var generatedTokens C.size_t
+	C.ov_genai_perf_metrics_get_num_generation_tokens(metrics, &generatedTokens)
+
+	if strings.TrimSpace(output) == "" && generatedTokens == 0 {
+		log.Println("Warning: Empty output from OpenVINO")
+	}
+
+	if strings.TrimSpace(output) == "" && generatedTokens == 0 && strings.TrimSpace(input) != "" {
+		return "", fmt.Errorf("OpenVINO GenAI returned an empty completion with 0 generated tokens")
+	}
+
+	return output, nil
 }
 
-func GenerateText(pipeline *C.ov_genai_llm_pipeline, input string, streamer_callback C.streamer_callback) string {
+func GenerateText(pipeline *C.ov_genai_llm_pipeline, input string, streamer_callback C.streamer_callback) (string, error) {
+	if pipeline == nil {
+		return "", fmt.Errorf("OpenVINO pipeline is not initialized")
+	}
+
 	cInput := C.CString(input)
 	defer C.free(unsafe.Pointer(cInput))
 
@@ -335,16 +533,20 @@ func GenerateText(pipeline *C.ov_genai_llm_pipeline, input string, streamer_call
 
 	var result *C.ov_genai_decoded_results
 
-	C.ov_genai_llm_pipeline_start_chat(pipeline)
-	C.ov_genai_llm_pipeline_generate(pipeline, cInput, (*C.ov_genai_generation_config)(nil), &streamer_callback, &result)
-	C.ov_genai_llm_pipeline_finish_chat(pipeline)
+	status := C.ov_genai_llm_pipeline_generate_cgo(pipeline, cInput, (*C.ov_genai_generation_config)(nil), &streamer_callback, &result)
+	if err := ovStatusError("generating text with OpenVINO GenAI", status); err != nil {
+		return "", err
+	}
+	if result == nil {
+		return "", fmt.Errorf("OpenVINO GenAI generate returned no decoded result")
+	}
 
 	C.ov_genai_decoded_results_get_string(result, (*C.char)(nil), &output_size)
 	cOutput := C.malloc(output_size)
 	defer C.free(cOutput)
 
 	C.ov_genai_decoded_results_get_string(result, (*C.char)(cOutput), &output_size)
-	return C.GoString((*C.char)(cOutput))
+	return C.GoString((*C.char)(cOutput)), nil
 }
 
 func FreeModel(model Model) {
@@ -352,38 +554,55 @@ func FreeModel(model Model) {
 }
 
 func GetGenaiAvailableDevices() []map[string]string {
-	var core *(C.ov_core_t)
+	var core *C.ov_core_t
+	status := C.ov_core_create(&core)
+	if err := ovStatusError("creating OpenVINO core", status); err != nil {
+		log.Printf("Failed to enumerate OpenVINO devices: %v", err)
+		return nil
+	}
+	if core == nil {
+		log.Printf("Failed to enumerate OpenVINO devices: creating OpenVINO core returned a nil core")
+		return nil
+	}
 	defer C.ov_core_free(core)
 
-	C.ov_core_create(&core)
-
 	var devices C.ov_available_devices_t
-	C.ov_core_get_available_devices(core, &devices)
+	status = C.ov_core_get_available_devices(core, &devices)
+	if err := ovStatusError("getting OpenVINO available devices", status); err != nil {
+		log.Printf("Failed to enumerate OpenVINO devices: %v", err)
+		return nil
+	}
+	defer C.ov_available_devices_free(&devices)
 
-	// goDevice := make(map[string]map[string][]string)
 	var goDevices []map[string]string
 
 	cString := devices.devices
 	for i := 0; i < int(devices.size); i++ {
-		var version_list C.ov_core_version_list_t
+		availableDeviceName := C.GoString(*cString)
+		var versionList C.ov_core_version_list_t
 
-		C.ov_core_get_versions_by_device_name(core, (*C.char)(*cString), &version_list)
+		status = C.ov_core_get_versions_by_device_name(core, (*C.char)(*cString), &versionList)
+		if err := ovStatusError("getting OpenVINO device version", status); err != nil {
+			goDevices = append(goDevices, map[string]string{"device_name": availableDeviceName})
+			cString = (**C.char)(unsafe.Pointer(uintptr(unsafe.Pointer(cString)) + unsafe.Sizeof(*cString)))
+			continue
+		}
 
-		cversion_list := version_list
-		for i := 0; i < int(version_list.size); i++ {
-			version := (*C.ov_core_version_t)(unsafe.Pointer(uintptr(unsafe.Pointer(cversion_list.versions)) + uintptr(i)*unsafe.Sizeof(*cversion_list.versions)))
-			deviceName := C.GoString(version.device_name) // 获取 device_name
+		if versionList.size == 0 {
+			goDevices = append(goDevices, map[string]string{"device_name": availableDeviceName})
+		}
+
+		for j := 0; j < int(versionList.size); j++ {
+			version := (*C.ov_core_version_t)(unsafe.Pointer(uintptr(unsafe.Pointer(versionList.versions)) + uintptr(j)*unsafe.Sizeof(*versionList.versions)))
 			buildNumber := C.GoString(version.version.buildNumber)
 			description := C.GoString(version.version.description)
 
-			item := map[string]string{"device_name": deviceName, "buildNumber": buildNumber, "description": description}
+			item := map[string]string{"device_name": availableDeviceName, "buildNumber": buildNumber, "description": description}
 			goDevices = append(goDevices, item)
 		}
 
 		cString = (**C.char)(unsafe.Pointer(uintptr(unsafe.Pointer(cString)) + unsafe.Sizeof(*cString)))
-
 	}
-	defer C.ov_available_devices_free(&devices)
 
 	return goDevices
 }
@@ -401,58 +620,23 @@ func GetOvVersion() {
 //export goCallbackBridge
 func goCallbackBridge(args *C.char, gen_result unsafe.Pointer) C.int {
 	if args != nil {
-		// 将 unsafe.Pointer 转换回结构体指针
-		result := (*Sequence)(gen_result)
+		if gen_result == nil {
+			return C.OV_GENAI_STREAMING_STATUS_STOP
+		}
 
-		// 将 C 字符串转换为 Go 字符串并追加到切片中
+		handle := cgo.Handle(*(*C.uintptr_t)(gen_result))
+		result, ok := handle.Value().(*Sequence)
+		if !ok || result == nil {
+			return C.OV_GENAI_STREAMING_STATUS_STOP
+		}
+
 		goStr := C.GoString(args)
 		result.AppendPendingResponse(goStr)
 
-		// fmt.Printf("%s", goStr)
-		// os.Stdout.Sync()
-		FlushPending((*Sequence)(result))
-		return C.OV_GENAI_STREAMMING_STATUS_RUNNING
+		FlushPending(result)
+		return C.OV_GENAI_STREAMING_STATUS_RUNNING
 	} else {
 		fmt.Println("Callback executed with NULL message!")
-		return C.OV_GENAI_STREAMMING_STATUS_STOP
+		return C.OV_GENAI_STREAMING_STATUS_STOP
 	}
 }
-
-// func main() {
-// 	// 使用 createPipeline 函数创建 pipeline
-// 	// log.Printf(GetGenaiAvailableDevices()[0]["device_name"])
-// 	GetOvVersion()
-// 	pipeline := CreatePipeline("/home/hongbo/ollama_model/TinyLlama-1.1B-Chat-v1.0-int4-ov", "CPU")
-// 	if pipeline == nil {
-// 		fmt.Println("创建 pipeline 失败")
-// 		return
-// 	}
-// 	fmt.Println("成功创建 pipeline")
-
-// 	// 创建 streamer_callback
-// 	var streamer_callback C.streamer_callback
-// 	streamer_callback.callback_func = (C.callback_function)(unsafe.Pointer(C.goCallbackBridge))
-
-// 	// 初始化 gena_result 结构体
-// 	gena_result := &gen_result_struct{
-// 		pendingResponses: make([]string, 0),
-// 	}
-
-// 	// 使用 runtime.Pinner 固定指针
-// 	var pinner runtime.Pinner
-// 	pinner.Pin(gena_result)
-// 	defer pinner.Unpin()
-
-// 	streamer_callback.args = unsafe.Pointer(gena_result)
-
-// 	result := GenerateText(pipeline, "who you are?", streamer_callback)
-// 	fmt.Println("生成的结果 result:", result)
-
-// 	if gena_result != nil && len(gena_result.pendingResponses) > 0 {
-// 		fmt.Println("生成的结果 gen_result:", gena_result.pendingResponses)
-// 	} else {
-// 		fmt.Println("生成的结果 gen_result: 无响应")
-// 	}
-// 	// 释放 pipeline 资源
-// 	FreeModel(pipeline)
-// }

--- a/modules/ollama_openvino/genai/runner/runner.go
+++ b/modules/ollama_openvino/genai/runner/runner.go
@@ -133,11 +133,8 @@ func (s *Server) processBatch() error {
 	defer s.mu.Unlock()
 
 	seqIdx := s.nextSeq - 1
-	for i, seq := range s.seqs {
-		if seq == nil {
-			continue
-		}
-
+processLoop:
+	for range s.seqs {
 		seqIdx = (seqIdx + 1) % len(s.seqs)
 		seq := s.seqs[seqIdx]
 
@@ -147,11 +144,18 @@ func (s *Server) processBatch() error {
 
 		seq.SetStartGenerationTime(time.Now())
 		for _, input := range seq.GetInputs() {
-			genai.GenerateTextWithMetrics(s.model, input.GetPrompt(), seq.GetSamplingParameters(), seq)
-			// log.Printf("gen result: ", seq.GetpendingResponses())
+			if _, err := genai.GenerateTextWithMetrics(s.model, input.GetPrompt(), seq.GetSamplingParameters(), seq); err != nil {
+				log.Printf("OpenVINO generation failed: %v", err)
+				seq.SetError(err)
+				s.removeSequence(seqIdx, "error")
+				continue processLoop
+			}
 		}
-		s.removeSequence(i, "")
+		log.Printf("TOKENS: %d decoded for sequence %d", seq.GetNumDecoded(), seqIdx)
+		s.removeSequence(seqIdx, "")
 	}
+
+	s.nextSeq = seqIdx + 1
 	return nil
 }
 
@@ -256,6 +260,19 @@ func (s *Server) completion(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	tokenLimit := req.MaxNewToken
+	if tokenLimit <= 0 {
+		tokenLimit = req.NumPredict
+	}
+	if tokenLimit <= 0 {
+		tokenLimit = 128
+		log.Printf("Invalid generation limit (n_predict=%d, max_new_token=%d); defaulting to %d", req.NumPredict, req.MaxNewToken, tokenLimit)
+	}
+	req.MaxNewToken = tokenLimit
+	if req.NumPredict <= 0 {
+		req.NumPredict = tokenLimit
+	}
+
 	var samplingParams genai.SamplingParams
 	samplingParams.TopK = req.TopK
 	samplingParams.TopP = req.TopP
@@ -312,6 +329,16 @@ func (s *Server) completion(w http.ResponseWriter, r *http.Request) {
 
 				flusher.Flush()
 			} else {
+				if seqErr := seq.GetError(); seqErr != nil {
+					if err := json.NewEncoder(w).Encode(map[string]string{
+						"error": seqErr.Error(),
+					}); err != nil {
+						http.Error(w, fmt.Sprintf("failed to encode error response: %v", err), http.StatusInternalServerError)
+					}
+
+					return
+				}
+
 				// Send the final response
 				if err := json.NewEncoder(w).Encode(&CompletionResponse{
 					Stop:         true,
@@ -378,63 +405,70 @@ func (m *multiLPath) String() string {
 }
 
 func (s *Server) loadModel(mpath string, mname string, device string) {
-	var err error
-	ov_ir_dir := strings.ReplaceAll(mname, ":", "_")
-	tempDir := filepath.Join("/tmp", ov_ir_dir)
-	ov_model_path := ""
+	if err := s.doLoadModel(mpath, mname, device); err != nil {
+		log.Printf("Failed to load model: %v", err)
+		s.status = ServerStatusError
+		s.ready.Done()
+	}
+}
+
+func (s *Server) doLoadModel(mpath string, mname string, device string) error {
+	ovIRDir := strings.ReplaceAll(mname, ":", "_")
+	tempDir := filepath.Join(os.TempDir(), ovIRDir)
+	ovModelPath := ""
 
 	isGGUF, err := genai.IsGGUF(mpath)
 	if err != nil {
-		fmt.Printf("Error checking file: %v\n", err)
-		panic(err)
+		return fmt.Errorf("checking GGUF format: %w", err)
 	}
 	if isGGUF {
 		log.Printf("The model is a GGUF file.")
-		ov_model_path = filepath.Join(tempDir, "tmp.gguf")
-		// for GGUF reader
+		ovModelPath = filepath.Join(tempDir, "tmp.gguf")
 		if _, err := os.Stat(tempDir); os.IsNotExist(err) {
-			err := os.MkdirAll(tempDir, 0755)
-			if err != nil {
-				fmt.Errorf("Error creating dir: %v", err)
-				panic(err)
+			if err := os.MkdirAll(tempDir, 0755); err != nil {
+				return fmt.Errorf("creating temp dir: %w", err)
 			}
-			err = genai.CopyFile(mpath, ov_model_path)
-			if err != nil {
-				panic(err)
+			if err := genai.CopyFile(mpath, ovModelPath); err != nil {
+				return fmt.Errorf("copying GGUF file: %w", err)
 			}
 		}
 	}
 
 	isGzip, err := genai.IsGzipByMagicBytes(mpath)
 	if err != nil {
-		fmt.Printf("Error checking file: %v\n", err)
+		return fmt.Errorf("checking gzip format: %w", err)
 	}
 	if isGzip {
 		log.Printf("The model is a OpenVINO IR file.")
-		// for OpenVINO IR
-		_, err = os.Stat(tempDir)
-		if os.IsNotExist(err) {
-			err = genai.UnpackTarGz(mpath, tempDir)
-			if err != nil {
-				panic(err)
+		if _, err = os.Stat(tempDir); os.IsNotExist(err) {
+			if err = genai.UnpackTarGz(mpath, tempDir); err != nil {
+				return fmt.Errorf("unpacking model archive: %w", err)
 			}
 		}
-
-		entries, _ := os.ReadDir(tempDir)
+		entries, err := os.ReadDir(tempDir)
+		if err != nil {
+			return fmt.Errorf("reading unpacked model dir: %w", err)
+		}
 		var subdirs []string
 		for _, entry := range entries {
 			if entry.IsDir() {
 				subdirs = append(subdirs, entry.Name())
 			}
 		}
-
-		ov_model_path = filepath.Join(tempDir, subdirs[0])
+		if len(subdirs) == 0 {
+			return fmt.Errorf("no subdirectory found in unpacked model archive at %s", tempDir)
+		}
+		ovModelPath = filepath.Join(tempDir, subdirs[0])
 	}
 
-	s.model = genai.CreatePipeline(ov_model_path, device)
-	log.Printf("The model had been load by GenAI, ov_model_path: %s , %s", ov_model_path, device)
+	s.model, err = genai.CreatePipeline(ovModelPath, device)
+	if err != nil {
+		return fmt.Errorf("creating pipeline: %w", err)
+	}
+	log.Printf("Model loaded by GenAI: path=%s device=%s", ovModelPath, device)
 	s.status = ServerStatusReady
 	s.ready.Done()
+	return nil
 }
 
 func Execute(args []string) error {

--- a/modules/ollama_openvino/llama/llama.cpp/common/common.go
+++ b/modules/ollama_openvino/llama/llama.cpp/common/common.go
@@ -1,6 +1,7 @@
 package common
 
-// #cgo CXXFLAGS: -std=c++11
+// #cgo !windows CXXFLAGS: -std=c++11
+// #cgo windows CXXFLAGS: -std=c++11
 // #cgo CPPFLAGS: -I${SRCDIR}/../include
 // #cgo CPPFLAGS: -I${SRCDIR}/../../../ml/backend/ggml/ggml/include
 import "C"

--- a/modules/ollama_openvino/llama/llama.cpp/examples/llava/llava.go
+++ b/modules/ollama_openvino/llama/llama.cpp/examples/llava/llava.go
@@ -1,6 +1,7 @@
 package llava
 
-// #cgo CXXFLAGS: -std=c++11
+// #cgo !windows CXXFLAGS: -std=c++11
+// #cgo windows CXXFLAGS: -std=c++11
 // #cgo CPPFLAGS: -I${SRCDIR}/../../include -I${SRCDIR}/../../common
 // #cgo CPPFLAGS: -I${SRCDIR}/../../../../ml/backend/ggml/ggml/include
 import "C"

--- a/modules/ollama_openvino/llama/llama.cpp/src/llama-mmap.h
+++ b/modules/ollama_openvino/llama/llama.cpp/src/llama-mmap.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 

--- a/modules/ollama_openvino/llama/llama.cpp/src/llama.go
+++ b/modules/ollama_openvino/llama/llama.cpp/src/llama.go
@@ -1,6 +1,7 @@
 package llama
 
-// #cgo CXXFLAGS: -std=c++17
+// #cgo !windows CXXFLAGS: -std=c++17
+// #cgo windows CXXFLAGS: -std=c++17
 // #cgo CPPFLAGS: -I${SRCDIR}/../include
 // #cgo CPPFLAGS: -I${SRCDIR}/../../../ml/backend/ggml/ggml/include
 // #cgo windows CPPFLAGS: -D_WIN32_WINNT=0x0602

--- a/modules/ollama_openvino/llama/llama.go
+++ b/modules/ollama_openvino/llama/llama.go
@@ -1,8 +1,10 @@
 package llama
 
 /*
-#cgo CFLAGS: -std=c11
-#cgo CXXFLAGS: -std=c++17
+#cgo !windows CFLAGS: -std=c11
+#cgo windows CFLAGS: -std=c11
+#cgo !windows CXXFLAGS: -std=c++17
+#cgo windows CXXFLAGS: -std=c++17
 #cgo CPPFLAGS: -I${SRCDIR}/llama.cpp/include
 #cgo CPPFLAGS: -I${SRCDIR}/llama.cpp/common
 #cgo CPPFLAGS: -I${SRCDIR}/llama.cpp/examples/llava

--- a/modules/ollama_openvino/llm/genai/genaiserver.go
+++ b/modules/ollama_openvino/llm/genai/genaiserver.go
@@ -140,19 +140,18 @@ func addIndexToDuplicates(input []string) []string {
 
 // NewGenaiServer will run a server
 func NewGenaiServer(gpus discover.GpuInfoList, model string, modelname string, inferdevice string, f *ggml.GGML, adapters, projectors []string, opts api.Options, numParallel int) (GenaiServer, error) {
+	fmt.Println("🚀 FORCING GENAI RUNNER — NewGenaiServer called for model:", modelname)
 	systemInfo := discover.GetSystemInfo()
 	systemTotalMemory := systemInfo.System.TotalMemory
 	systemFreeMemory := systemInfo.System.FreeMemory
 	systemSwapFreeMemory := systemInfo.System.FreeSwap
 	slog.Info("system memory", "total", format.HumanBytes2(systemTotalMemory), "free", format.HumanBytes2(systemFreeMemory), "free_swap", format.HumanBytes2(systemSwapFreeMemory))
 
-	genai_device := genai.GetGenaiAvailableDevices()
-	var genai_device_list []string
-	for i := 0; i < int(len(genai_device)); i++ {
-		genai_device_list = append(genai_device_list, genai_device[i]["device_name"])
+	resolvedDevice, err := genai.ResolveDeviceOrFallback(inferdevice)
+	if err != nil {
+		return nil, fmt.Errorf("resolving OpenVINO device %q: %w", inferdevice, err)
 	}
-	genai_device_list = addIndexToDuplicates(genai_device_list)
-	inferdevice = SelectDevice(inferdevice, genai_device_list)
+	inferdevice = resolvedDevice
 
 	params := []string{
 		"--model", model,
@@ -214,6 +213,7 @@ func NewGenaiServer(gpus discover.GpuInfoList, model string, modelname string, i
 		if err != nil {
 			return nil, fmt.Errorf("unable to evaluate symlinks for executable path: %w", err)
 		}
+		fmt.Println("🚀 EXEC CMD:", exe, finalParams)
 		s := &GenaillmServer{
 			port:      port,
 			cmd:       exec.Command(exe, finalParams...),
@@ -267,6 +267,7 @@ func NewGenaiServer(gpus discover.GpuInfoList, model string, modelname string, i
 			s.cmd.Env = append(s.cmd.Env, visibleDevicesEnv+"="+visibleDevicesEnvVal)
 		}
 
+		fmt.Println("EXECUTING:", exe, strings.Join(finalParams, " "))
 		slog.Info("starting llama server", "cmd", s.cmd.String())
 
 		if err = s.cmd.Start(); err != nil {
@@ -484,6 +485,10 @@ type completion struct {
 	}
 }
 
+type completionError struct {
+	Error string `json:"error"`
+}
+
 func (s *GenaillmServer) Completion(ctx context.Context, req llamaserver.CompletionRequest, fn func(llamaserver.CompletionResponse)) error {
 	request := map[string]any{
 		"prompt":            req.Prompt,
@@ -612,6 +617,11 @@ func (s *GenaillmServer) Completion(ctx context.Context, req llamaserver.Complet
 				evt = line
 			}
 
+			var cerr completionError
+			if err := json.Unmarshal(evt, &cerr); err == nil && cerr.Error != "" {
+				return fmt.Errorf("OpenVINO completion failed: %s", cerr.Error)
+			}
+
 			var c completion
 			if err := json.Unmarshal(evt, &c); err != nil {
 				return fmt.Errorf("error unmarshalling llm prediction response: %v", err)
@@ -674,13 +684,10 @@ func (s *GenaillmServer) Completion(ctx context.Context, req llamaserver.Complet
 }
 
 func (s *GenaillmServer) Clear(mname string) error {
-	var err error
-	ov_ir_dir := strings.ReplaceAll(mname, ":", "_")
-	modelDir := filepath.Join("/tmp", ov_ir_dir)
-	err = os.RemoveAll(modelDir)
-	if err != nil {
+	ovIRDir := strings.ReplaceAll(mname, ":", "_")
+	modelDir := filepath.Join(os.TempDir(), ovIRDir)
+	if err := os.RemoveAll(modelDir); err != nil {
 		fmt.Println("Error removing directory:", err)
-		return nil
 	}
 	return nil
 }

--- a/modules/ollama_openvino/ml/backend/ggml/ggml/src/ggml-blas/blas.go
+++ b/modules/ollama_openvino/ml/backend/ggml/ggml/src/ggml-blas/blas.go
@@ -2,7 +2,8 @@
 
 package blas
 
-// #cgo CXXFLAGS: -std=c++11
+// #cgo !windows CXXFLAGS: -std=c++11
+// #cgo windows CXXFLAGS: -std=c++11
 // #cgo CPPFLAGS: -DGGML_USE_BLAS
 // #cgo CPPFLAGS: -I${SRCDIR}/.. -I${SRCDIR}/../../include
 // #cgo darwin,arm64 CPPFLAGS: -DGGML_BLAS_USE_ACCELERATE -DACCELERATE_NEW_LAPACK -DACCELERATE_LAPACK_ILP64

--- a/modules/ollama_openvino/ml/backend/ggml/ggml/src/ggml-cpu/cpu.go
+++ b/modules/ollama_openvino/ml/backend/ggml/ggml/src/ggml-cpu/cpu.go
@@ -1,7 +1,9 @@
 package cpu
 
-// #cgo CFLAGS: -O3 -Wno-implicit-function-declaration
-// #cgo CXXFLAGS: -std=c++17
+// #cgo !windows CFLAGS: -O3 -Wno-implicit-function-declaration
+// #cgo windows CFLAGS: -O2
+// #cgo !windows CXXFLAGS: -std=c++17
+// #cgo windows CXXFLAGS: -std=c++17
 // #cgo CPPFLAGS: -I${SRCDIR}/amx -I${SRCDIR}/llamafile -I${SRCDIR}/.. -I${SRCDIR}/../../include
 // #cgo CPPFLAGS: -DGGML_USE_LLAMAFILE
 // #cgo linux CPPFLAGS: -D_GNU_SOURCE

--- a/modules/ollama_openvino/ml/backend/ggml/ggml/src/ggml-cpu/llamafile/llamafile.go
+++ b/modules/ollama_openvino/ml/backend/ggml/ggml/src/ggml-cpu/llamafile/llamafile.go
@@ -1,5 +1,6 @@
 package llamafile
 
-// #cgo CXXFLAGS: -std=c++17
+// #cgo !windows CXXFLAGS: -std=c++17
+// #cgo windows CXXFLAGS: -std=c++17
 // #cgo CPPFLAGS: -I${SRCDIR}/.. -I${SRCDIR}/../.. -I${SRCDIR}/../../../include
 import "C"

--- a/modules/ollama_openvino/ml/backend/ggml/ggml/src/ggml.go
+++ b/modules/ollama_openvino/ml/backend/ggml/ggml/src/ggml.go
@@ -1,9 +1,10 @@
 package ggml
 
-// #cgo CXXFLAGS: -std=c++17
+// #cgo !windows CXXFLAGS: -std=c++17
+// #cgo windows CXXFLAGS: -std=c++17
 // #cgo CPPFLAGS: -DNDEBUG -DGGML_USE_CPU
 // #cgo CPPFLAGS: -I${SRCDIR}/../include -I${SRCDIR}/ggml-cpu
-// #cgo windows LDFLAGS: -lmsvcrt -static -static-libgcc -static-libstdc++
+// #cgo windows LDFLAGS: -lmsvcrt
 // #include <stdlib.h>
 // #include "ggml-backend.h"
 // extern void sink(int level, char *text, void *user_data);

--- a/modules/ollama_openvino/msvc_cc.bat
+++ b/modules/ollama_openvino/msvc_cc.bat
@@ -1,0 +1,91 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set "args="
+set "link_args="
+set "is_compile=0"
+
+:: 1. Check if we are only compiling (-c flag)
+set "check_args=%*"
+for %%n in (%check_args%) do (
+    if "%%n" == "-c" (
+        set "is_compile=1"
+    )
+)
+
+:loop
+if "%~1" == "" goto :run
+set "arg=%~1"
+
+:: 2. Filter out GCC/Clang specific flags that break MSVC
+if "!arg!" == "-Werror" goto :next
+if "!arg!" == "-Wall" goto :next
+if "!arg!" == "-m64" goto :next
+if "!arg!" == "-mthreads" goto :next
+if "!arg!" == "-fno-stack-protector" goto :next
+if "!arg!" == "-fmessage-length=0" goto :next
+if "!arg!" == "-Wno-write-strings" goto :next
+if "!arg!" == "-fdiagnostics-show-option" goto :next
+
+:: 3. Translate common CGO compiler flags
+if "!arg!" == "-g" (
+    set "args=!args! /Zi"
+    goto :next
+)
+if "!arg!" == "-O2" (
+    set "args=!args! /O2"
+    goto :next
+)
+if "!arg!" == "-std=c11" (
+    set "args=!args! /std:c11"
+    goto :next
+)
+if "!arg!" == "-std=c++17" (
+    set "args=!args! /std:c++17"
+    goto :next
+)
+
+:: 4. Translate include and library search paths
+if "!arg:~0,2!" == "-I" (
+    set "args=!args! /I!arg:~2!"
+    goto :next
+)
+if "!arg:~0,2!" == "-L" (
+    set "link_args=!link_args! /LIBPATH:!arg:~2!"
+    goto :next
+)
+
+:: 5. Translate library linking (e.g., -lopenvino -> openvino.lib)
+if "!arg:~0,2!" == "-l" (
+    set "libname=!arg:~2!"
+    set "link_args=!link_args! !libname!.lib"
+    goto :next
+)
+
+:: 6. Handle output flag translations
+if "!arg!" == "-o" (
+    if "!is_compile!" == "1" (
+        set "args=!args! /Fo%~2"
+    ) else (
+        set "args=!args! /Fe%~2"
+    )
+    shift
+    goto :next
+)
+
+:: Otherwise, keep the argument as-is
+set "args=!args! !arg!"
+
+:next
+shift
+goto :loop
+
+:run
+if not "!link_args!" == "" (
+    :: echo [MSVC Wrapper] cl.exe /nologo !args! /link !link_args!
+    cl.exe /nologo !args! /link !link_args!
+) else (
+    :: echo [MSVC Wrapper] cl.exe /nologo !args!
+    cl.exe /nologo !args!
+)
+exit /b %errorlevel%

--- a/modules/ollama_openvino/server/routes.go
+++ b/modules/ollama_openvino/server/routes.go
@@ -197,6 +197,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		caps = append(caps, CapabilityInsert)
 	}
 
+	fmt.Println("[RUNNER GATE] model.Type =", model.Type, "| model =", name.String())
 	if model.Type != "OpenVINO" {
 		r, m, opts, err := s.scheduleRunner(c.Request.Context(), name.String(), model.Type, caps, req.Options, req.KeepAlive)
 


### PR DESCRIPTION
Fixes #996
i have solved the issue 
now if the NPU device is not available i doesn't fails scilently rather it falls back to CPU with a message 
 \"NPU\" is not available (available: CPU, GPU); falling back to \"CPU\"
 
i have given a sample output and the terminal commands to run the project


 here is sample terminal output
 MyTerminal> ollama serve
2026/03/23 10:00:47 routes.go:1391: INFO server config env="map[CUDA_VISIBLE_DEVICES: GPU_DEVICE_ORDINAL: HIP_VISIBLE_DEVICES: HSA_OVERRIDE_GFX_VERSION: HTTPS_PROXY: HTTP_PROXY: NO_PROXY: OLLAMA_DEBUG:false OLLAMA_FLASH_ATTENTION:false OLLAMA_GPU_OVERHEAD:0 OLLAMA_HOST:http://127.0.0.1:11434 OLLAMA_INTEL_GPU:false OLLAMA_KEEP_ALIVE:5m0s OLLAMA_KV_CACHE_TYPE: OLLAMA_LLM_LIBRARY: OLLAMA_LOAD_TIMEOUT:5m0s OLLAMA_MAX_LOADED_MODELS:0 OLLAMA_MAX_QUEUE:512 OLLAMA_MODELS:C:\\Users\\Vaibhav Upadhyaya\\.ollama\\models OLLAMA_MULTIUSER_CACHE:false OLLAMA_NEW_ENGINE:false OLLAMA_NOHISTORY:false OLLAMA_NOPRUNE:false OLLAMA_NUM_PARALLEL:0 OLLAMA_ORIGINS:[http://localhost https://localhost http://localhost:* https://localhost:* http://127.0.0.1 https://127.0.0.1 http://127.0.0.1:* https://127.0.0.1:* http://0.0.0.0 https://0.0.0.0 http://0.0.0.0:* https://0.0.0.0:* app://* file://* tauri://* vscode-webview://*] OLLAMA_SCHED_SPREAD:false ROCR_VISIBLE_DEVICES:]"
time=2026-03-23T10:00:47.594+05:30 level=INFO source=images.go:447 msg="total blobs: 6"
time=2026-03-23T10:00:47.594+05:30 level=INFO source=images.go:454 msg="total unused blobs removed: 0"
[GIN-debug] [WARNING] Creating an Engine instance with the Logger and Recovery middleware already attached.

[GIN-debug] [WARNING] Running in "debug" mode. Switch to "release" mode in production.
 - using env:   export GIN_MODE=release
 - using code:  gin.SetMode(gin.ReleaseMode)

[GIN-debug] POST   /api/pull                 --> github.com/ollama/ollama/server.(*Server).PullHandler-fm (5 handlers)
[GIN-debug] POST   /api/generate             --> github.com/ollama/ollama/server.(*Server).GenerateHandler-fm (5 handlers)
[GIN-debug] POST   /api/chat                 --> github.com/ollama/ollama/server.(*Server).ChatHandler-fm (5 handlers)
[GIN-debug] POST   /api/embed                --> github.com/ollama/ollama/server.(*Server).EmbedHandler-fm (5 handlers)
[GIN-debug] POST   /api/embeddings           --> github.com/ollama/ollama/server.(*Server).EmbeddingsHandler-fm (5 handlers)
[GIN-debug] POST   /api/create               --> github.com/ollama/ollama/server.(*Server).CreateHandler-fm (5 handlers)
[GIN-debug] POST   /api/push                 --> github.com/ollama/ollama/server.(*Server).PushHandler-fm (5 handlers)
[GIN-debug] POST   /api/copy                 --> github.com/ollama/ollama/server.(*Server).CopyHandler-fm (5 handlers)
[GIN-debug] DELETE /api/delete               --> github.com/ollama/ollama/server.(*Server).DeleteHandler-fm (5 handlers)
[GIN-debug] POST   /api/show                 --> github.com/ollama/ollama/server.(*Server).ShowHandler-fm (5 handlers)
[GIN-debug] POST   /api/blobs/:digest        --> github.com/ollama/ollama/server.(*Server).CreateBlobHandler-fm (5 handlers)
[GIN-debug] HEAD   /api/blobs/:digest        --> github.com/ollama/ollama/server.(*Server).HeadBlobHandler-fm (5 handlers)
[GIN-debug] GET    /api/ps                   --> github.com/ollama/ollama/server.(*Server).PsHandler-fm (5 handlers)
[GIN-debug] POST   /v1/chat/completions      --> github.com/ollama/ollama/server.(*Server).ChatHandler-fm (6 handlers)
[GIN-debug] POST   /v1/completions           --> github.com/ollama/ollama/server.(*Server).GenerateHandler-fm (6 handlers)
[GIN-debug] POST   /v1/embeddings            --> github.com/ollama/ollama/server.(*Server).EmbedHandler-fm (6 handlers)
[GIN-debug] GET    /v1/models                --> github.com/ollama/ollama/server.(*Server).ListHandler-fm (6 handlers)	
[GIN-debug] GET    /v1/models/:model         --> github.com/ollama/ollama/server.(*Server).ShowHandler-fm (6 handlers)
[GIN-debug] HEAD   /api/tags                 --> github.com/ollama/ollama/server.(*Server).ListHandler-fm (5 handlers)
[GIN-debug] HEAD   /api/version              --> github.com/ollama/ollama/server.(*Server).GenerateRoutes.func2 (5 handlers)
time=2026-03-23T10:00:47.596+05:30 level=INFO source=routes.go:1442 msg="Listening on 127.0.0.1:11434 (version 0.0.0)"
time=2026-03-23T10:00:47.596+05:30 level=INFO source=gpu.go:217 msg="looking for compatible GPUs"
time=2026-03-23T10:00:47.596+05:30 level=INFO source=gpu_windows.go:167 msg=packages count=1
time=2026-03-23T10:00:47.597+05:30 level=INFO source=gpu_windows.go:214 msg="" package=0 cores=4 efficiency=0 threads=8
time=2026-03-23T10:00:47.620+05:30 level=INFO source=gpu.go:377 msg="no compatible GPUs were discovered"
time=2026-03-23T10:00:47.620+05:30 level=INFO source=types.go:130 msg="inference compute" id=0 library=cpu variant="" compute="" driver=0.0 name="" total="19.7 GiB" available="3.8 GiB"
time=2026-03-23T10:00:47.793+05:30 level=INFO source=routes.go:1479 msg="GenAI inference device" Device=CPU "Build Number"=2025.4.0-20398-7a975177ff4-releases/2025/4 description=openvino_intel_cpu_plugin
time=2026-03-23T10:00:47.794+05:30 level=INFO source=routes.go:1479 msg="GenAI inference device" Device=GPU "Build Number"=2025.4.0-20398-7a975177ff4-releases/2025/4 description="Intel GPU plugin"
[GIN] 2026/03/23 - 10:01:06 | 200 |            0s |       127.0.0.1 | HEAD     "/"
[GIN] 2026/03/23 - 10:01:06 | 200 |      3.8429ms |       127.0.0.1 | POST     "/api/show"
[RUNNER GATE] model.Type = OpenVINO | model = registry.ollama.ai/library/deepseek-r1-ov:latest
time=2026-03-23T10:01:06.194+05:30 level=INFO source=sched.go:313 msg="loading first openvino model: deepseek-r1-ov:latest"
🚀 FORCING GENAI RUNNER — NewGenaiServer called for model: deepseek-r1-ov:latest
time=2026-03-23T10:01:06.194+05:30 level=INFO source=genaiserver.go:148 msg="system memory" total="19.7 GiB" free="10.3 GiB" free_swap="11.5 GiB"
time=2026-03-23T10:01:06.230+05:30 level=INFO source=genai.go:208 msg="OpenVINO device


 **_\"NPU\" is not available (available: CPU, GPU); falling back to \"CPU\""_**


MyTerminal> ollama run deepseek-r1-ov "Say hello!"
Okay, the user said "Hello!" and I responded with a friendly greeting. I should keep the tone warm and welcoming. Maybe add a smiley to keep it light.        
Let me make sure to respond in a way that's easy to understand and engaging.
</think>

Hello! How can I assist you today? 😊

# **_commands to run the project in your terminal_**

**Terminal 1: Start the Ollama Server**
Keep this window open to watch the system logs!

powershell
Navigate to the project
cd "C:\Users\Vaibhav Upadhyaya\OneDrive\Documents\MASTER\openvinoLearn"
 Activate Python environment
.\venv\Scripts\activate
 Point the terminal to your custom Ollama build
$env:Path = "C:\Users\Vaibhav Upadhyaya\AppData\Local\Programs\Ollama;" + $env:Path
 Start the background server process
ollama serve

**Terminal 2: Update the Model and Run your prompt**
powershell
 Navigate to the project
cd "C:\Users\Vaibhav Upadhyaya\OneDrive\Documents\MASTER\openvinoLearn"
 Activate Python environment 
.\venv\Scripts\activate
 Point the terminal to your custom Ollama build
$env:Path = "C:\Users\Vaibhav Upadhyaya\AppData\Local\Programs\Ollama;" + $env:Path
 Re-read the Modelfile and bake the new settings into a model name of your choosing
ollama create <your-custom-model-name> -f Modelfile
 Trigger the inference using that exact same name!
ollama run <your-custom-model-name> "What is 1+1?"


