### PR TITLE
[openvino-langchain] Bump OpenVINO version up to 2026.0 and latest langchain-core

### DIFF
--- a/modules/openvino-langchain/package-lock.json
+++ b/modules/openvino-langchain/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "openvino-langchain",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openvino-langchain",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "Apache-2.0",
       "dependencies": {
-        "openvino-genai-node": "^2025.3.0",
-        "openvino-node": "^2025.3.0",
-        "openvino-tokenizers-node": "^2025.3.0"
+        "openvino-genai-node": "^2026.0.0",
+        "openvino-node": "^2026.0.0",
+        "openvino-tokenizers-node": "^2026.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
@@ -31,7 +31,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "@langchain/core": ">=0.3.17 <0.4.0"
+        "@langchain/core": "^1.1.36"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -534,7 +534,8 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
       "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
@@ -781,9 +782,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1275,27 +1276,26 @@
       }
     },
     "node_modules/@langchain/core": {
-      "version": "0.3.78",
-      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.78.tgz",
-      "integrity": "sha512-Nn0x9erQlK3zgtRU1Z8NUjLuyW0gzdclMsvLQ6wwLeDqV91pE+YKl6uQb+L2NUDs4F0N7c2Zncgz46HxrvPzuA==",
+      "version": "1.1.36",
+      "resolved": "https://registry.npmjs.org/@langchain/core/-/core-1.1.36.tgz",
+      "integrity": "sha512-9NWsdzU3uZD13lJwunXK0t6SIwew+UwcbHggW5yUdaiMmzKeNkDpp1lRD6p49N8+D0Vv4qmQBEKB4Ukh2jfnvw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
+        "@standard-schema/spec": "^1.1.0",
         "ansi-styles": "^5.0.0",
         "camelcase": "6",
         "decamelize": "1.2.0",
         "js-tiktoken": "^1.0.12",
-        "langsmith": "^0.3.67",
+        "langsmith": ">=0.5.0 <1.0.0",
         "mustache": "^4.2.0",
         "p-queue": "^6.6.2",
-        "p-retry": "4",
-        "uuid": "^10.0.0",
-        "zod": "^3.25.32",
-        "zod-to-json-schema": "^3.22.3"
+        "uuid": "^11.1.0",
+        "zod": "^3.25.76 || ^4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1363,6 +1363,13 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@swc/core": {
       "version": "1.13.5",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.13.5.tgz",
@@ -1416,6 +1423,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1433,6 +1441,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1450,6 +1459,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1467,6 +1477,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1484,6 +1495,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1501,6 +1513,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1518,6 +1531,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1535,6 +1549,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1552,6 +1567,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1569,6 +1585,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -1604,6 +1621,7 @@
       "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"
       }
@@ -1721,12 +1739,6 @@
         "undici-types": "~6.21.0"
       }
     },
-    "node_modules/@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
-      "license": "MIT"
-    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -1738,7 +1750,8 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -1803,7 +1816,6 @@
       "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.45.0",
         "@typescript-eslint/types": "8.45.0",
@@ -1949,9 +1961,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1959,13 +1971,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2035,7 +2047,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2072,9 +2083,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2385,7 +2396,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.9",
@@ -2398,9 +2410,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2450,7 +2462,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -2541,6 +2552,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2557,6 +2569,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -2638,6 +2651,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2650,6 +2664,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/concat-map": {
@@ -2660,12 +2675,13 @@
       "license": "MIT"
     },
     "node_modules/console-table-printer": {
-      "version": "2.14.6",
-      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.14.6.tgz",
-      "integrity": "sha512-MCBl5HNVaFuuHW6FGbL/4fB7N/ormCy+tQ+sxTrF6QtSbSNETvPuOVbkJBhzDgYhvjWGrTma4eYJa37ZuoQsPw==",
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.15.0.tgz",
+      "integrity": "sha512-SrhBq4hYVjLCkBVOWaTzceJalvn5K1Zq5aQA6wXC/cYjI3frKWNPEMK3sZsJfNNQApvCQmgBcc13ZKmFj8qExw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "simple-wcswidth": "^1.0.1"
+        "simple-wcswidth": "^1.1.2"
       }
     },
     "node_modules/convert-source-map": {
@@ -2740,6 +2756,7 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2896,7 +2913,6 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3064,7 +3080,8 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/events-universal": {
       "version": "1.0.1",
@@ -3260,9 +3277,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -3421,9 +3438,9 @@
       }
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3446,6 +3463,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3776,7 +3794,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -4360,7 +4377,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -4370,6 +4386,7 @@
       "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.21.tgz",
       "integrity": "sha512-biOj/6M5qdgx5TKjDnFT1ymSpM5tbd3ylwDtrQvFQSu0Z7bBYko2dF+W/aUkXUPuk6IVpRxk/3Q2sHOzGlS36g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.5.1"
       }
@@ -4382,9 +4399,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4476,16 +4493,16 @@
       }
     },
     "node_modules/langsmith": {
-      "version": "0.3.71",
-      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.71.tgz",
-      "integrity": "sha512-xl00JZso7J3OaurUQ+seT2qRJ34OGZXYAvCYj3vNC3TB+JOcdcYZ1uLvENqOloKB8VCiADh1eZ0FG3Cj/cy2FQ==",
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.5.15.tgz",
+      "integrity": "sha512-S20JnYmIgqGBjA/WEn12ZZJjqd03O5wd8K9KgGBvsKXQBn0bYuFrr1w20L37PpcMmX3/cftpgJ6g2y8KoEmHLw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/uuid": "^10.0.0",
-        "chalk": "^4.1.2",
+        "chalk": "^5.6.2",
         "console-table-printer": "^2.12.1",
         "p-queue": "^6.6.2",
-        "p-retry": "4",
         "semver": "^7.6.3",
         "uuid": "^10.0.0"
       },
@@ -4493,7 +4510,8 @@
         "@opentelemetry/api": "*",
         "@opentelemetry/exporter-trace-otlp-proto": "*",
         "@opentelemetry/sdk-trace-base": "*",
-        "openai": "*"
+        "openai": "*",
+        "ws": ">=7"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
@@ -4507,19 +4525,50 @@
         },
         "openai": {
           "optional": true
+        },
+        "ws": {
+          "optional": true
         }
       }
     },
+    "node_modules/langsmith/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/langsmith/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/langsmith/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/leven": {
@@ -4681,9 +4730,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4714,6 +4763,7 @@
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "mustache": "bin/mustache"
       }
@@ -4795,9 +4845,9 @@
       }
     },
     "node_modules/openvino-genai-node": {
-      "version": "2025.3.0",
-      "resolved": "https://registry.npmjs.org/openvino-genai-node/-/openvino-genai-node-2025.3.0.tgz",
-      "integrity": "sha512-/kiwsv/Mt05u2dHgN8JxZaEinrnVahrG6lu71MpwL7iAjhnpErFaS17dFf0ulNWLdL6HXtFMj/HsVB/dCBpQIQ==",
+      "version": "2026.0.0",
+      "resolved": "https://registry.npmjs.org/openvino-genai-node/-/openvino-genai-node-2026.0.0.tgz",
+      "integrity": "sha512-o1XcqcTI9hk345ieCW9+RhpGJoPgJ09y8JEwy6V1pNIm9VMb3Of3swn0O67tm3O1P4IYAZ77/Ul/KD8c+j5Gcw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "os": [
@@ -4806,16 +4856,16 @@
         "win32"
       ],
       "dependencies": {
-        "openvino-node": "2025.3.0"
+        "openvino-node": "2026.0.0"
       },
       "engines": {
         "node": ">=21.0.0"
       }
     },
     "node_modules/openvino-node": {
-      "version": "2025.3.0",
-      "resolved": "https://registry.npmjs.org/openvino-node/-/openvino-node-2025.3.0.tgz",
-      "integrity": "sha512-3k4u3AePCoWV35wY4lZUhVkYOuilxatMbdDyug+dmpWBJGwgdrlBQciU/S8UvRGnJ1Opo8CnGnXRzaKKb6qnrA==",
+      "version": "2026.0.0",
+      "resolved": "https://registry.npmjs.org/openvino-node/-/openvino-node-2026.0.0.tgz",
+      "integrity": "sha512-1+tuyDNqWFR8MmNPDkSsd0TGrfJ61Iu5TD0g5xlvehQwd3EVi90ZhCJy4vWx0mcHoYAVTJmH0ZBDCpkEwKbknw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "os": [
@@ -4826,16 +4876,16 @@
       "dependencies": {
         "gunzip-maybe": "^1.4.2",
         "https-proxy-agent": "^7.0.2",
-        "tar-fs": "^3.0.9"
+        "tar-fs": "^3.1.1"
       },
       "engines": {
         "node": ">=21.0.0"
       }
     },
     "node_modules/openvino-tokenizers-node": {
-      "version": "2025.3.0",
-      "resolved": "https://registry.npmjs.org/openvino-tokenizers-node/-/openvino-tokenizers-node-2025.3.0.tgz",
-      "integrity": "sha512-LsvNBYClwdasK1pJEIQuJCHrDJd7PRniwjpnkHWcgjUQ09OH3L09k5jrbXG8xxgqX2rXgKn0fLXvhREs8763cQ==",
+      "version": "2026.0.0",
+      "resolved": "https://registry.npmjs.org/openvino-tokenizers-node/-/openvino-tokenizers-node-2026.0.0.tgz",
+      "integrity": "sha512-Df9shdqii8m0OgYKaODpI6hbYrWStu0uG8t3t1+7Rz2ORzP7ulSwhceeMXRpNaxvJrhQv5RdaRjO6usuMoS6jQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "os": [
@@ -4845,7 +4895,7 @@
       ],
       "dependencies": {
         "adm-zip": "^0.5.16",
-        "openvino-node": "2025.3.0"
+        "openvino-node": "2026.0.0"
       }
     },
     "node_modules/optionator": {
@@ -4871,6 +4921,7 @@
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -4912,6 +4963,7 @@
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
       "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "eventemitter3": "^4.0.4",
         "p-timeout": "^3.2.0"
@@ -4923,24 +4975,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-retry": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
-      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/retry": "0.12.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/p-timeout": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
       "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "p-finally": "^1.0.0"
       },
@@ -5052,9 +5092,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5353,15 +5393,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -5447,7 +5478,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
       "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -5622,6 +5654,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -5866,7 +5899,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5968,16 +6000,17 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
-      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -6161,22 +6194,13 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.24.6",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
-      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
-      "license": "ISC",
-      "peerDependencies": {
-        "zod": "^3.24.1"
       }
     }
   }

--- a/modules/openvino-langchain/package-lock.json
+++ b/modules/openvino-langchain/package-lock.json
@@ -28,7 +28,7 @@
         "typescript-eslint": "^8.26.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "peerDependencies": {
         "@langchain/core": "^1.1.36"

--- a/modules/openvino-langchain/package.json
+++ b/modules/openvino-langchain/package.json
@@ -4,7 +4,7 @@
   "description": "OpenVINO Generative AI integration for LangChain.js",
   "type": "module",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/modules/openvino-langchain/package.json
+++ b/modules/openvino-langchain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openvino-langchain",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "OpenVINO Generative AI integration for LangChain.js",
   "type": "module",
   "engines": {
@@ -23,12 +23,12 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "openvino-genai-node": "^2025.3.0",
-    "openvino-node": "^2025.3.0",
-    "openvino-tokenizers-node": "^2025.3.0"
+    "openvino-genai-node": "^2026.0.0",
+    "openvino-node": "^2026.0.0",
+    "openvino-tokenizers-node": "^2026.0.0"
   },
   "peerDependencies": {
-    "@langchain/core": ">=0.3.17 <0.4.0"
+    "@langchain/core": "^1.1.36"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",

--- a/modules/openvino-langchain/src/chat_models.ts
+++ b/modules/openvino-langchain/src/chat_models.ts
@@ -139,8 +139,6 @@ export class ChatOpenVINO
 
     // generation option setup
     const generateOptions: GenerationConfig = { ...this.generateOptions };
-    // to avoid a warning about result type
-    generateOptions['return_decoded_results'] = true;
     if (options.stop) {
       const set = new Set(options.stop);
       generateOptions['stop_strings'] = set;

--- a/modules/openvino-langchain/src/llms.ts
+++ b/modules/openvino-langchain/src/llms.ts
@@ -58,8 +58,6 @@ export class OpenVINO extends LLM {
 
     // generation option setup
     const generateOptions: GenerationConfig = { ...this.generateOptions };
-    // to avoid a warning about result type
-    generateOptions['return_decoded_results'] = true;
     if (options.stop) {
       const set = new Set(options.stop);
       generateOptions.stop_strings = set;

--- a/modules/openvino-langchain/src/prompt_parser.ts
+++ b/modules/openvino-langchain/src/prompt_parser.ts
@@ -154,6 +154,7 @@ For each function call, return a json object with function name and ` +
             name: toolCall.name,
             args: toolCall.arguments,
             type: 'tool_call',
+            id: toolCall.id ?? `call_${toolCalls.length}`,
           });
         } catch(error: any) {
           // Ignore errors and continue


### PR DESCRIPTION
These changes enable the use of the OpenVINO LangChain JS adapter with the latest versions of OpenVINO and langchain-core. Lagacy keys in GenerationConfig have been removed, and the tool parsing has been updated to ensure correct operation with the new langchain-core.

The changes have been tested with the following models:
MODEL_PATH=Qwen2.5-0.5B-Instruct
INSTRUCT_MODEL_PATH=Qwen2.5-7B-Instruct
EMBEDDING_MODEL_PATH=bge-small-en-v1.5

CVS-183677