### PR TITLE
Add modular third-party license checks

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,24 @@
+license-check: true
+vulnerability-check: true
+comment-summary-in-pr: never
+fail-on-severity: low
+
+fail-on-scopes:
+  - runtime
+  - development
+  - unknown
+
+allow-licenses:
+  - Apache-2.0
+  - MIT
+  - BSD-2-Clause
+  - BSD-3-Clause
+  - ISC
+  - Zlib
+  - 0BSD
+  - CC0-1.0
+  - Python-2.0
+  - PSF-2.0
+
+# Add dependency-specific exceptions only after legal/maintainer review.
+allow-dependencies-licenses: []

--- a/.github/license-policy/skywalking-ollama-openvino-macapp.yml
+++ b/.github/license-policy/skywalking-ollama-openvino-macapp.yml
@@ -1,0 +1,9 @@
+license:
+  spdx-id: Apache-2.0
+
+dependency:
+  files:
+    - modules/ollama_openvino/macapp/package.json
+
+  licenses: []
+  excludes: []

--- a/.github/license-policy/skywalking-ollama-openvino.yml
+++ b/.github/license-policy/skywalking-ollama-openvino.yml
@@ -1,0 +1,9 @@
+license:
+  spdx-id: Apache-2.0
+
+dependency:
+  files:
+    - modules/ollama_openvino/go.mod
+
+  licenses: []
+  excludes: []

--- a/.github/license-policy/skywalking-openvino-langchain-sample.yml
+++ b/.github/license-policy/skywalking-openvino-langchain-sample.yml
@@ -1,0 +1,9 @@
+license:
+  spdx-id: Apache-2.0
+
+dependency:
+  files:
+    - modules/openvino-langchain/sample/package.json
+
+  licenses: []
+  excludes: []

--- a/.github/license-policy/skywalking-openvino-langchain.yml
+++ b/.github/license-policy/skywalking-openvino-langchain.yml
@@ -1,0 +1,9 @@
+license:
+  spdx-id: Apache-2.0
+
+dependency:
+  files:
+    - modules/openvino-langchain/package.json
+
+  licenses: []
+  excludes: []

--- a/.github/workflows/third_party_licenses.yml
+++ b/.github/workflows/third_party_licenses.yml
@@ -1,0 +1,265 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+name: Third Party Licenses
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - 'releases/**'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  ollama-openvino-go:
+    name: Licenses / ollama_openvino / Go
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Check Go dependency licenses
+        uses: apache/skywalking-eyes/dependency@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
+        with:
+          config: .github/license-policy/skywalking-ollama-openvino.yml
+          mode: check
+
+  openvino-langchain-npm:
+    name: Licenses / openvino-langchain / NPM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Check NPM dependency licenses
+        uses: apache/skywalking-eyes/dependency@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
+        with:
+          config: .github/license-policy/skywalking-openvino-langchain.yml
+          mode: check
+
+  openvino-langchain-sample-npm:
+    name: Licenses / openvino-langchain sample / NPM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Check NPM dependency licenses
+        uses: apache/skywalking-eyes/dependency@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
+        with:
+          config: .github/license-policy/skywalking-openvino-langchain-sample.yml
+          mode: check
+
+  ollama-openvino-macapp-npm:
+    name: Licenses / ollama_openvino macapp / NPM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Check NPM dependency licenses
+        uses: apache/skywalking-eyes/dependency@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
+        with:
+          config: .github/license-policy/skywalking-ollama-openvino-macapp.yml
+          mode: check
+
+  pointpillars-python:
+    name: Licenses / pointPillars / Python
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.10'
+
+      - name: Resolve Python dependencies
+        working-directory: modules/3d/pointPillars
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip freeze > requirements-all.txt
+
+      - name: Check Python dependency licenses
+        id: license_check
+        uses: pilosus/action-pip-license-checker@e909b0226ff49d3235c99c4585bc617f49fff16a # v3.1.0
+        with:
+          requirements: modules/3d/pointPillars/requirements-all.txt
+          fail: StrongCopyleft,NetworkCopyleft,Other,Error
+          fails-only: true
+          totals: true
+          headers: true
+          verbose: 1
+
+      - name: Print Python license report
+        if: ${{ always() }}
+        env:
+          REPORT: ${{ steps.license_check.outputs.report }}
+        run: printf '%s\n' "$REPORT"
+
+  cdpn-python:
+    name: Licenses / CDPN / Python
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+
+      - name: Resolve Python dependencies
+        working-directory: modules/3d/CDPN
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip freeze > requirements-all.txt
+
+      - name: Check Python dependency licenses
+        id: license_check
+        uses: pilosus/action-pip-license-checker@e909b0226ff49d3235c99c4585bc617f49fff16a # v3.1.0
+        with:
+          requirements: modules/3d/CDPN/requirements-all.txt
+          fail: StrongCopyleft,NetworkCopyleft,Other,Error
+          fails-only: true
+          totals: true
+          headers: true
+          verbose: 1
+
+      - name: Print Python license report
+        if: ${{ always() }}
+        env:
+          REPORT: ${{ steps.license_check.outputs.report }}
+        run: printf '%s\n' "$REPORT"
+
+  openvino-bevfusion-python:
+    name: Licenses / openvino_bevfusion / Python
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.10'
+
+      - name: Resolve Python dependencies
+        working-directory: modules/openvino_bevfusion
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          python -m pip freeze > requirements-all.txt
+
+      - name: Check Python dependency licenses
+        id: license_check
+        uses: pilosus/action-pip-license-checker@e909b0226ff49d3235c99c4585bc617f49fff16a # v3.1.0
+        with:
+          requirements: modules/openvino_bevfusion/requirements-all.txt
+          fail: StrongCopyleft,NetworkCopyleft,Other,Error
+          fails-only: true
+          totals: true
+          headers: true
+          verbose: 1
+
+      - name: Print Python license report
+        if: ${{ always() }}
+        env:
+          REPORT: ${{ steps.license_check.outputs.report }}
+        run: printf '%s\n' "$REPORT"
+
+  custom-operations-python:
+    name: Licenses / custom_operations / Python
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.10'
+
+      - name: Resolve Python dependencies
+        working-directory: modules/custom_operations
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r tests/requirements.txt
+          python -m pip freeze > requirements-all.txt
+
+      - name: Check Python dependency licenses
+        id: license_check
+        uses: pilosus/action-pip-license-checker@e909b0226ff49d3235c99c4585bc617f49fff16a # v3.1.0
+        with:
+          requirements: modules/custom_operations/requirements-all.txt
+          fail: StrongCopyleft,NetworkCopyleft,Other,Error
+          fails-only: true
+          totals: true
+          headers: true
+          verbose: 1
+
+      - name: Print Python license report
+        if: ${{ always() }}
+        env:
+          REPORT: ${{ steps.license_check.outputs.report }}
+        run: printf '%s\n' "$REPORT"
+
+  nvidia-plugin-python:
+    name: Licenses / nvidia_plugin / Python
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.10'
+
+      - name: Resolve Python dependencies
+        working-directory: modules/nvidia_plugin
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r tests/functional/shared_tests_instances/single_layer_tests/generator/requirements.txt
+          python -m pip install -r utils/shape-extractor/requirements.txt
+          python -m pip install -r wheel/requirements.txt
+          python -m pip install -r wheel/requirements-dev.txt
+          python -m pip freeze > requirements-all.txt
+
+      - name: Check Python dependency licenses
+        id: license_check
+        uses: pilosus/action-pip-license-checker@e909b0226ff49d3235c99c4585bc617f49fff16a # v3.1.0
+        with:
+          requirements: modules/nvidia_plugin/requirements-all.txt
+          fail: StrongCopyleft,NetworkCopyleft,Other,Error
+          fails-only: true
+          totals: true
+          headers: true
+          verbose: 1
+
+      - name: Print Python license report
+        if: ${{ always() }}
+        env:
+          REPORT: ${{ steps.license_check.outputs.report }}
+        run: printf '%s\n' "$REPORT"
+
+  dependency-review:
+    name: Licenses / PR dependency review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          config-file: ./.github/dependency-review-config.yml


### PR DESCRIPTION
## Summary

- Added a new `Third Party Licenses` workflow with separate module/ecosystem jobs instead of one monolithic check.
- Added module-scoped SkyWalking Eyes dependency configs for Go/NPM checks.
- Added Dependency Review configuration for PR dependency/license and vulnerability changes.
- Covered the new CDPN Python requirements added on current `master`.
- Used only Apache-2.0 or MIT licensed Marketplace actions:
  - `apache/skywalking-eyes/dependency` is Apache-2.0 licensed.
  - `pilosus/action-pip-license-checker` is MIT licensed.
  - `actions/dependency-review-action`, `actions/checkout`, and `actions/setup-python` are MIT licensed.
- Pinned all workflow actions to exact commit SHAs with release comments.
- Kept all jobs read-only, with no PR comments, no auto-fix mode, and no committed generated reports.

## Checked manifests

SkyWalking Eyes dependency checks:

- `modules/ollama_openvino/go.mod`
- `modules/openvino-langchain/package.json`
- `modules/openvino-langchain/sample/package.json`
- `modules/ollama_openvino/macapp/package.json`

Python requirements checks with transitive dependency coverage via `pip install` + `pip freeze`:

- `modules/3d/CDPN/requirements.txt`
- `modules/3d/pointPillars/requirements.txt`
- `modules/openvino_bevfusion/requirements.txt`
- `modules/custom_operations/tests/requirements.txt`
- `modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/generator/requirements.txt`
- `modules/nvidia_plugin/utils/shape-extractor/requirements.txt`
- `modules/nvidia_plugin/wheel/requirements.txt`
- `modules/nvidia_plugin/wheel/requirements-dev.txt`

Dependency Review PR gate:

- Covers dependency/license/vulnerability changes visible to GitHub Dependency Review, including NPM lockfile changes such as `modules/openvino-langchain/package-lock.json`, `modules/openvino-langchain/sample/package-lock.json`, and `modules/ollama_openvino/macapp/package-lock.json`.

## Unsupported or partial coverage

- `modules/java_api/build.gradle` and `modules/java_api/settings.gradle`: Gradle dependencies are covered only by the global Dependency Review PR gate unless a dedicated Gradle license report integration is added.
- Additional Gradle manifests have the same limitation:
  - `modules/android_demos/coco_detection_android_demo/app/build.gradle`
  - `modules/android_demos/coco_detection_android_demo/build.gradle`
  - `modules/android_demos/coco_detection_android_demo/settings.gradle`
  - `modules/java_api/samples/face_detection_java_sample/build.gradle`
  - `modules/java_api/samples/face_detection_java_sample/settings.gradle`
  - `modules/java_api/samples/face_detection_kotlin_sample/build.gradle`
  - `modules/java_api/samples/face_detection_kotlin_sample/settings.gradle`
  - `modules/java_api/samples/hello_query_device/build.gradle`
  - `modules/java_api/samples/hello_query_device/settings.gradle`
- `setup.py` manifests are not directly scanned by the selected Marketplace actions in this PR:
  - `modules/3d/pointPillars/setup.py`
  - `modules/genai_optimizations/setup.py`
  - `modules/nvidia_plugin/wheel/setup.py`
  - `modules/openvino_training_kit/setup.py`
  - `modules/token_merging/setup.py`
- No `3rdparty`/`thirdparty` directory was found under `modules/3d/CDPN`.
- `third-party-programs.txt` is not regenerated or validated by this workflow.

## License exceptions

- No dependency-specific license exceptions were added.
- SkyWalking `licenses` and `excludes` lists are empty.
- Dependency Review `allow-dependencies-licenses` is empty.

## Validation

- `actionlint .github/workflows/third_party_licenses.yml` passes.
- YAML parsing passes for the new workflow and config files.
- `license-eye -c .github/license-policy/skywalking-*.yml dependency check` accepts all SkyWalking dependency configs locally.
