### PR TITLE
Update Ubuntu references to 22.04

### DIFF
--- a/.github/workflows/llama_cpp_plugin_build_and_test.yml
+++ b/.github/workflows/llama_cpp_plugin_build_and_test.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Prepare test data - convert test model files
         run: |
           python3 -m pip install -r llama.cpp/requirements/requirements-convert_hf_to_gguf.txt
-          huggingface-cli download gpt2 model.safetensors tokenizer.json tokenizer_config.json vocab.json config.json merges.txt --local-dir hf_gpt2
+          hf download gpt2 model.safetensors tokenizer.json tokenizer_config.json vocab.json config.json merges.txt --local-dir hf_gpt2
           mkdir -p ${{ github.workspace }}/test_data
           python3 llama.cpp/convert_hf_to_gguf.py hf_gpt2 --outtype f32 --outfile ${{ github.workspace }}/test_data/gpt2.gguf
 

--- a/.github/workflows/llama_cpp_plugin_build_and_test.yml
+++ b/.github/workflows/llama_cpp_plugin_build_and_test.yml
@@ -57,6 +57,7 @@ jobs:
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
         with:
           repository: ggerganov/llama.cpp
+          ref: b2417
           path: llama.cpp
 
       - uses: actions/setup-python@v4
@@ -65,26 +66,10 @@ jobs:
 
       - name: Prepare test data - convert test model files
         run: |
-          # Current llama.cpp GPT-2 converter incorrectly maps attention bias buffers.
-          python3 - <<'PY'
-          from pathlib import Path
-
-          path = Path("llama.cpp/conversion/gpt2.py")
-          text = path.read_text()
-          old = '''        if name.endswith((".attn.bias", ".attn.masked_bias")):
-                      yield from super().modify_tensors(data_torch, name, bid)
-                      return
-          '''
-          new = '''        if name.endswith((".attn.bias", ".attn.masked_bias")):
-                      return
-          '''
-          if old in text:
-              path.write_text(text.replace(old, new, 1))
-          PY
-          python3 -m pip install -r llama.cpp/requirements/requirements-convert_hf_to_gguf.txt
+          python3 -m pip install -r llama.cpp/requirements/requirements-convert-hf-to-gguf.txt transformers==4.39.3
           hf download gpt2 model.safetensors tokenizer.json tokenizer_config.json vocab.json config.json merges.txt --local-dir hf_gpt2
           mkdir -p ${{ github.workspace }}/test_data
-          python3 llama.cpp/convert_hf_to_gguf.py hf_gpt2 --outtype f32 --outfile ${{ github.workspace }}/test_data/gpt2.gguf
+          python3 llama.cpp/convert-hf-to-gguf.py hf_gpt2 --outtype f32 --outfile ${{ github.workspace }}/test_data/gpt2.gguf
 
       - name: Install libtbb2
         run: |

--- a/.github/workflows/llama_cpp_plugin_build_and_test.yml
+++ b/.github/workflows/llama_cpp_plugin_build_and_test.yml
@@ -9,8 +9,8 @@ on:
 permissions: read-all
 
 jobs:
-  build_ubuntu20:
-    runs-on: ubuntu-20.04
+  build_ubuntu22:
+    runs-on: ubuntu-22.04
     steps:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@d06b37b47cfd043ec794ffa3e40e0b6b5858a7ec # v1.14.2
@@ -43,9 +43,9 @@ jobs:
           name: build_artifacts
           path: ${{ github.workspace }}/openvino/bin/intel64/Release/
 
-  test_ubuntu20:
-    needs: build_ubuntu20
-    runs-on: ubuntu-20.04
+  test_ubuntu22:
+    needs: build_ubuntu22
+    runs-on: ubuntu-22.04
     steps:
       - name: Download build artifacts
         uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7

--- a/.github/workflows/llama_cpp_plugin_build_and_test.yml
+++ b/.github/workflows/llama_cpp_plugin_build_and_test.yml
@@ -65,6 +65,22 @@ jobs:
 
       - name: Prepare test data - convert test model files
         run: |
+          # Current llama.cpp GPT-2 converter incorrectly maps attention bias buffers.
+          python3 - <<'PY'
+          from pathlib import Path
+
+          path = Path("llama.cpp/conversion/gpt2.py")
+          text = path.read_text()
+          old = '''        if name.endswith((".attn.bias", ".attn.masked_bias")):
+                      yield from super().modify_tensors(data_torch, name, bid)
+                      return
+          '''
+          new = '''        if name.endswith((".attn.bias", ".attn.masked_bias")):
+                      return
+          '''
+          if old in text:
+              path.write_text(text.replace(old, new, 1))
+          PY
           python3 -m pip install -r llama.cpp/requirements/requirements-convert_hf_to_gguf.txt
           hf download gpt2 model.safetensors tokenizer.json tokenizer_config.json vocab.json config.json merges.txt --local-dir hf_gpt2
           mkdir -p ${{ github.workspace }}/test_data

--- a/.github/workflows/llama_cpp_plugin_build_and_test.yml
+++ b/.github/workflows/llama_cpp_plugin_build_and_test.yml
@@ -10,7 +10,7 @@ permissions: read-all
 
 jobs:
   build_ubuntu20:
-    runs-on: ubuntu-20.04-8-cores
+    runs-on: ubuntu-20.04
     steps:
       - name: Setup cmake
         uses: jwlawson/actions-setup-cmake@d06b37b47cfd043ec794ffa3e40e0b6b5858a7ec # v1.14.2

--- a/.github/workflows/ollama_openvino_build_and_test.yml
+++ b/.github/workflows/ollama_openvino_build_and_test.yml
@@ -1,13 +1,13 @@
 name: ollama_openvino_build_and_test
- 
+
 on:
   pull_request:
     paths:
       - 'modules/ollama_openvino/**'
       - '.github/workflows/ollama_openvino_build_and_test'
- 
+
 permissions: read-all
- 
+
 jobs:
   test_ubuntu22:
     runs-on: ubuntu-22.04
@@ -20,24 +20,24 @@ jobs:
           sparse-checkout: |
             modules/ollama_openvino
           sparse-checkout-cone-mode: true
- 
+
       - name: Setup python env
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
- 
+
       - name: Install go
         run: |
           wget https://go.dev/dl/go1.24.1.linux-amd64.tar.gz
           mkdir -p go
           tar xvzf go1.24.1.linux-amd64.tar.gz
-     
+
       - name: Download model
         run: |
           pip install -U huggingface_hub
-          huggingface-cli download --resume-download OpenVINO/TinyLlama-1.1B-Chat-v1.0-int4-ov  --local-dir  TinyLlama-1.1B-Chat-v1.0-int4-ov --local-dir-use-symlinks False
+          hf download OpenVINO/TinyLlama-1.1B-Chat-v1.0-int4-ov --local-dir TinyLlama-1.1B-Chat-v1.0-int4-ov
           tar -zcvf TinyLlama-1.1B-Chat-v1.0-int4-ov.tar.gz TinyLlama-1.1B-Chat-v1.0-int4-ov
- 
+
       - name: Install openvino_genai and init go env and build ollama_openvino
         run: |
           wget https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/nightly/2025.3.0.0.dev20250630/openvino_genai_ubuntu22_2025.3.0.0.dev20250630_x86_64.tar.gz
@@ -56,7 +56,7 @@ jobs:
           go build -o ollama
           mkdir -p bin
           cp ollama ./bin
- 
+
       - name: Create ollama model and test generate
         run: |
           export PATH=$PATH:${{ github.workspace }}/openvino_contrib/modules/ollama_openvino/bin
@@ -70,4 +70,4 @@ jobs:
           tmux new-session -d -s runsession 'ollama run TinyLlama-1.1B-Chat-v1.0-int4-ov:v1 "Who are you? Please give a brief answer" > output.txt'
           sleep 60
           cat output.txt
- 
+

--- a/.github/workflows/ollama_openvino_build_and_test.yml
+++ b/.github/workflows/ollama_openvino_build_and_test.yml
@@ -40,9 +40,9 @@ jobs:
 
       - name: Install openvino_genai and init go env and build ollama_openvino
         run: |
-          wget https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/nightly/2025.3.0.0.dev20250630/openvino_genai_ubuntu22_2025.3.0.0.dev20250630_x86_64.tar.gz
-          tar -xzf openvino_genai_ubuntu22_2025.3.0.0.dev20250630_x86_64.tar.gz
-          source openvino_genai_ubuntu22_2025.3.0.0.dev20250630_x86_64/setupvars.sh
+          wget https://storage.openvinotoolkit.org/repositories/openvino_genai/packages/2025.3/linux/openvino_genai_ubuntu22_2025.3.0.0_x86_64.tar.gz
+          tar -xzf openvino_genai_ubuntu22_2025.3.0.0_x86_64.tar.gz
+          source openvino_genai_ubuntu22_2025.3.0.0_x86_64/setupvars.sh
           printenv OpenVINO_DIR
           chmod +x ./
           export LD_LIBRARY_PATH=${{ github.workspace }}/go/bin:$LD_LIBRARY_PATH
@@ -60,7 +60,7 @@ jobs:
       - name: Create ollama model and test generate
         run: |
           export PATH=$PATH:${{ github.workspace }}/openvino_contrib/modules/ollama_openvino/bin
-          source openvino_genai_ubuntu22_2025.3.0.0.dev20250630_x86_64/setupvars.sh
+          source openvino_genai_ubuntu22_2025.3.0.0_x86_64/setupvars.sh
           export GODEBUG=cgocheck=0
           echo -e 'FROM TinyLlama-1.1B-Chat-v1.0-int4-ov.tar.gz\nModelType "OpenVINO"\nInferDevice "GPU"' > Modelfile
           ollama serve &
@@ -70,4 +70,3 @@ jobs:
           tmux new-session -d -s runsession 'ollama run TinyLlama-1.1B-Chat-v1.0-int4-ov:v1 "Who are you? Please give a brief answer" > output.txt'
           sleep 60
           cat output.txt
-

--- a/.github/workflows/ollama_openvino_build_and_test.yml
+++ b/.github/workflows/ollama_openvino_build_and_test.yml
@@ -35,7 +35,17 @@ jobs:
       - name: Download model
         run: |
           pip install -U huggingface_hub
-          hf download OpenVINO/TinyLlama-1.1B-Chat-v1.0-int4-ov --local-dir TinyLlama-1.1B-Chat-v1.0-int4-ov
+          for attempt in 1 2 3 4 5; do
+            if hf download OpenVINO/TinyLlama-1.1B-Chat-v1.0-int4-ov --local-dir TinyLlama-1.1B-Chat-v1.0-int4-ov --max-workers 1; then
+              break
+            fi
+            if [ "$attempt" = 5 ]; then
+              exit 1
+            fi
+            sleep_seconds=$((attempt * 60))
+            echo "Model download failed; retrying in ${sleep_seconds}s"
+            sleep "${sleep_seconds}"
+          done
           tar -zcvf TinyLlama-1.1B-Chat-v1.0-int4-ov.tar.gz TinyLlama-1.1B-Chat-v1.0-int4-ov
 
       - name: Install openvino_genai and init go env and build ollama_openvino

--- a/modules/llama_cpp_plugin/include/plugin.hpp
+++ b/modules/llama_cpp_plugin/include/plugin.hpp
@@ -4,6 +4,8 @@
 #ifndef LLAMA_CPP_PLUGIN_HPP
 #define LLAMA_CPP_PLUGIN_HPP
 
+#include <filesystem>
+
 #include "openvino/runtime/iplugin.hpp"
 
 namespace ov {
@@ -30,10 +32,17 @@ public:
     virtual std::shared_ptr<ov::ICompiledModel> import_model(std::istream& model,
                                                              const ov::AnyMap& properties) const override;
 
-    virtual std::shared_ptr<ov::ICompiledModel> compile_model(const std::string& fname,
+    virtual std::shared_ptr<ov::ICompiledModel> compile_model(const std::filesystem::path& fname,
                                                               const ov::AnyMap& properties) const override;
 
     virtual std::shared_ptr<ov::ICompiledModel> import_model(std::istream& model,
+                                                             const ov::SoPtr<ov::IRemoteContext>& context,
+                                                             const ov::AnyMap& properties) const override;
+
+    virtual std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
+                                                             const ov::AnyMap& properties) const override;
+
+    virtual std::shared_ptr<ov::ICompiledModel> import_model(const ov::Tensor& model,
                                                              const ov::SoPtr<ov::IRemoteContext>& context,
                                                              const ov::AnyMap& properties) const override;
 

--- a/modules/llama_cpp_plugin/src/plugin.cpp
+++ b/modules/llama_cpp_plugin/src/plugin.cpp
@@ -54,6 +54,7 @@ void LlamaCppPlugin::set_property(const ov::AnyMap& properties) {
             int num_threads = map_entry.second.as<int>();
             OPENVINO_ASSERT(num_threads >= 0, "INFERENCE_NUM_THREADS cannot be negative");
             m_num_threads = num_threads;
+            continue;
         }
         OPENVINO_THROW_NOT_IMPLEMENTED("llama_cpp_plugin: setting property ", map_entry.first, "not implemented");
     }

--- a/modules/llama_cpp_plugin/src/plugin.cpp
+++ b/modules/llama_cpp_plugin/src/plugin.cpp
@@ -9,6 +9,8 @@
 #include "openvino/op/constant.hpp"
 #include "openvino/runtime/internal_properties.hpp"
 #include "openvino/util/log.hpp"
+#include "openvino/runtime/shared_buffer.hpp"
+#include "openvino/util/file_util.hpp"
 
 namespace {
 static constexpr const char* wait_executor_name = "LlamaCppWaitExecutor";
@@ -33,7 +35,7 @@ std::shared_ptr<ov::ICompiledModel> LlamaCppPlugin::compile_model(const std::sha
     OPENVINO_THROW_NOT_IMPLEMENTED("Currently only direct GGUF file loading is "
                                    "supported for the LLAMA_CPP* plugins");
 }
-std::shared_ptr<ov::ICompiledModel> LlamaCppPlugin::compile_model(const std::string& fname,
+std::shared_ptr<ov::ICompiledModel> LlamaCppPlugin::compile_model(const std::filesystem::path& fname,
                                                                   const ov::AnyMap& properties) const {
     size_t num_threads = 0;
     auto it = properties.find(ov::inference_num_threads.name());
@@ -43,7 +45,7 @@ std::shared_ptr<ov::ICompiledModel> LlamaCppPlugin::compile_model(const std::str
     } else {
         num_threads = m_num_threads;
     }
-    return std::make_shared<LlamaCppModel>(fname, shared_from_this(), num_threads);
+    return std::make_shared<LlamaCppModel>(ov::util::path_to_string(fname), shared_from_this(), num_threads);
 }
 
 void LlamaCppPlugin::set_property(const ov::AnyMap& properties) {
@@ -101,6 +103,21 @@ std::shared_ptr<ov::ICompiledModel> LlamaCppPlugin::import_model(std::istream& m
                                                                  const ov::SoPtr<ov::IRemoteContext>& context,
                                                                  const ov::AnyMap& properties) const {
     OPENVINO_THROW_NOT_IMPLEMENTED("llama_cpp_plugin: model importing not implemented");
+}
+
+std::shared_ptr<ov::ICompiledModel> LlamaCppPlugin::import_model(const ov::Tensor& model,
+                                                                 const ov::AnyMap& properties) const {
+    ov::SharedStreamBuffer buffer{model.data(), model.get_byte_size()};
+    std::istream stream{&buffer};
+    return import_model(stream, properties);
+}
+
+std::shared_ptr<ov::ICompiledModel> LlamaCppPlugin::import_model(const ov::Tensor& model,
+                                                                 const ov::SoPtr<ov::IRemoteContext>& context,
+                                                                 const ov::AnyMap& properties) const {
+    ov::SharedStreamBuffer buffer{model.data(), model.get_byte_size()};
+    std::istream stream{&buffer};
+    return import_model(stream, context, properties);
 }
 
 ov::SupportedOpsMap LlamaCppPlugin::query_model(const std::shared_ptr<const ov::Model>& model,

--- a/modules/llama_cpp_plugin/tests/common/include/model_fixture.hpp
+++ b/modules/llama_cpp_plugin/tests/common/include/model_fixture.hpp
@@ -11,7 +11,7 @@
 #include "openvino/runtime/infer_request.hpp"
 
 const std::string TEST_FILES_DIR = "test_data";
-const auto SEP = ov::util::FileTraits<char>::file_separator;
+const auto SEP = ov::test::utils::FileTraits<char>::file_separator;
 
 class CompiledModelTest : public ::testing::Test {
 public:

--- a/modules/nvidia_plugin/Dockerfile
+++ b/modules/nvidia_plugin/Dockerfile
@@ -1,6 +1,6 @@
-FROM nvidia/cuda:11.8.0-runtime-ubuntu20.04
+FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
 ARG enable_tensorrt
-ADD https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
+ADD https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-ubuntu2204.pin /etc/apt/preferences.d/cuda-repository-pin-600
 
 # nv-tensorrt-repo-*.deb packages
 COPY *.deb  /
@@ -15,8 +15,8 @@ RUN set -exuo pipefail ; \
 		software-properties-common \
 	; \
 	if [[ ${enable_tensorrt-} == "1" ]] ; then dpkg -i /nv-tensorrt-repo-*.deb ; fi; \
-	apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub ; \
-	add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /" ; \
+	apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/3bf863cc.pub ; \
+	add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/ /" ; \
 	apt update ; \
 	DEBIAN_FRONTEND=noninteractive apt install -y \
 		./libcudnn*.deb \

--- a/modules/nvidia_plugin/README.md
+++ b/modules/nvidia_plugin/README.md
@@ -9,7 +9,7 @@ OpenVINO™ NVIDIA GPU plugin is supported and validated on the following platfo
 
 OS                     | GPU                   | Driver               |
 ---------------------- | --------------------- |--------------------- |
-Ubuntu* 20.04 (64-bit) | NVIDIA Quadro RTX 4000| 520.61.05            |
+Ubuntu* 22.04 (64-bit) | NVIDIA Quadro RTX 4000| 520.61.05            |
 
 ## Distribution
 OpenVINO™ NVIDIA GPU plugin is not included into Intel® Distribution of OpenVINO™. To use the plugin, it should be built from source code.

--- a/modules/ollama_openvino/Dockerfile
+++ b/modules/ollama_openvino/Dockerfile
@@ -111,7 +111,7 @@ FROM ${FLAVOR} AS archive
 COPY --from=cpu dist/lib/ollama /lib/ollama
 COPY --from=build /bin/ollama /bin/ollama
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 RUN apt-get update \
     && apt-get install -y ca-certificates \
     && apt-get clean \


### PR DESCRIPTION
Why:
- Ubuntu 20 GitHub-hosted runner image was retired, so jobs pinned to `ubuntu-20.04` can hang waiting for an unavailable runner or fail during GitHub brownouts. GitHub announced that Ubuntu 20 would be fully retired by April 15, 2025 and recommended moving workflows to `ubuntu-22.04` or `ubuntu-24.04`: https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/
- The official `actions/runner-images` README currently lists available Ubuntu labels as `ubuntu-24.04` / `ubuntu-latest` and `ubuntu-22.04`, and documents that only the latest two GA OS images are supported: https://github.com/actions/runner-images#available-images

Changed:
- Replaced Ubuntu 20.04 GitHub Actions runners and job names with Ubuntu 22.04.
- Replaced Ubuntu 20.04 Docker base images and CUDA Ubuntu 20.04 repository URLs with Ubuntu 22.04 variants.
- Updated Ubuntu 20.04 references in NVIDIA plugin documentation to Ubuntu 22.04.
- Updated Ollama OpenVINO CI to use the available Ubuntu 22 OpenVINO GenAI 2025.3 package.
- Replaced deprecated `huggingface-cli` usage with `hf download` and added retries for transient Hugging Face 429 download failures.
- Updated llama.cpp plugin CI to use the same `llama.cpp` tag as the plugin build (`b2417`) and pin a compatible `transformers` version for GPT-2 GGUF conversion.
- Updated the llama.cpp plugin for the current OpenVINO plugin API and fixed `INFERENCE_NUM_THREADS` property handling.