### PR TITLE
Add Dependabot configuration for all module ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,36 +1,23 @@
 # Copyright (C) 2018-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-# Dependabot configuration for openvino_contrib.
+# Dependabot config for openvino_contrib.
 #
-# Goals:
-#   * Cover every supported manifest under modules/ (pip, npm, gomod, gradle,
-#     docker) plus the GitHub Actions workflows.
-#   * Keep the PR count low by grouping all updates of an ecosystem into a
-#     single PR per manifest directory, for BOTH security and version updates
-#     (see the `groups` blocks with `applies-to`). Without the
-#     `applies-to: security-updates` group, Dependabot opens one PR per alert.
-#   * Stay future-proof: the `directories: ["/modules/**"]` glob automatically
-#     picks up new modules without editing this file.
-#
-# Notes:
-#   * Security updates ignore `open-pull-requests-limit`; the limit only caps
-#     version-update PRs.
-#   * Major version bumps that close security alerts (e.g. electron, lxml,
-#     scikit-learn, langsmith) are intentionally kept in the grouped PRs via
-#     `patterns: ["*"]` so a module's fixes land together; review them as a set.
+# - `/modules/**/*` globstar matches manifests at any depth under modules/.
+# - `applies-to: security-updates` requires "Dependabot security updates"
+#   (+ Dependency graph + alerts) enabled in repo settings; the file alone
+#   does not enable security updates.
+# - Only the `dependencies` label is auto-created; ecosystem labels must exist
+#   in the repo or Dependabot ignores them.
+# - Security updates ignore `open-pull-requests-limit`.
 
 version: 2
 
 updates:
-  # ---------------------------------------------------------------------------
-  # Python — requirements*.txt and setup.py across all modules
-  # (3d/CDPN, 3d/pointPillars, custom_operations/tests, genai_optimizations,
-  #  nvidia_plugin/*, openvino_bevfusion, openvino_training_kit, token_merging)
-  # ---------------------------------------------------------------------------
+  # pip — requirements*.txt and setup.py
   - package-ecosystem: "pip"
     directories:
-      - "/modules/**"
+      - "/modules/**/*"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -50,13 +37,10 @@ updates:
         patterns:
           - "*"
 
-  # ---------------------------------------------------------------------------
-  # JavaScript / TypeScript — npm lockfiles
-  # (ollama_openvino/macapp, openvino-langchain, openvino-langchain/sample)
-  # ---------------------------------------------------------------------------
+  # npm — package.json lockfiles
   - package-ecosystem: "npm"
     directories:
-      - "/modules/**"
+      - "/modules/**/*"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -76,9 +60,7 @@ updates:
         patterns:
           - "*"
 
-  # ---------------------------------------------------------------------------
-  # Go modules — ollama_openvino
-  # ---------------------------------------------------------------------------
+  # gomod — ollama_openvino
   - package-ecosystem: "gomod"
     directory: "/modules/ollama_openvino"
     schedule:
@@ -100,13 +82,10 @@ updates:
         patterns:
           - "*"
 
-  # ---------------------------------------------------------------------------
-  # Java / Kotlin — Gradle builds and version catalogs
-  # (java_api + samples, android_demos/coco_detection_android_demo)
-  # ---------------------------------------------------------------------------
+  # gradle — build.gradle and version catalogs (Java/Kotlin)
   - package-ecosystem: "gradle"
     directories:
-      - "/modules/**"
+      - "/modules/**/*"
     schedule:
       interval: "weekly"
       day: "tuesday"
@@ -126,13 +105,10 @@ updates:
         patterns:
           - "*"
 
-  # ---------------------------------------------------------------------------
-  # Dockerfiles — base image updates
-  # (3d/pointPillars/devops, nvidia_plugin, ollama_openvino)
-  # ---------------------------------------------------------------------------
+  # docker — Dockerfile base images
   - package-ecosystem: "docker"
     directories:
-      - "/modules/**"
+      - "/modules/**/*"
     schedule:
       interval: "weekly"
       day: "tuesday"
@@ -152,9 +128,7 @@ updates:
         patterns:
           - "*"
 
-  # ---------------------------------------------------------------------------
-  # GitHub Actions — workflows under .github/workflows (SHA-pinned)
-  # ---------------------------------------------------------------------------
+  # github-actions — workflows under .github/workflows
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,177 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Dependabot configuration for openvino_contrib.
+#
+# Goals:
+#   * Cover every supported manifest under modules/ (pip, npm, gomod, gradle,
+#     docker) plus the GitHub Actions workflows.
+#   * Keep the PR count low by grouping all updates of an ecosystem into a
+#     single PR per manifest directory, for BOTH security and version updates
+#     (see the `groups` blocks with `applies-to`). Without the
+#     `applies-to: security-updates` group, Dependabot opens one PR per alert.
+#   * Stay future-proof: the `directories: ["/modules/**"]` glob automatically
+#     picks up new modules without editing this file.
+#
+# Notes:
+#   * Security updates ignore `open-pull-requests-limit`; the limit only caps
+#     version-update PRs.
+#   * Major version bumps that close security alerts (e.g. electron, lxml,
+#     scikit-learn, langsmith) are intentionally kept in the grouped PRs via
+#     `patterns: ["*"]` so a module's fixes land together; review them as a set.
+
+version: 2
+
+updates:
+  # ---------------------------------------------------------------------------
+  # Python — requirements*.txt and setup.py across all modules
+  # (3d/CDPN, 3d/pointPillars, custom_operations/tests, genai_optimizations,
+  #  nvidia_plugin/*, openvino_bevfusion, openvino_training_kit, token_merging)
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "pip"
+    directories:
+      - "/modules/**"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "deps(pip)"
+    groups:
+      pip-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      pip-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  # ---------------------------------------------------------------------------
+  # JavaScript / TypeScript — npm lockfiles
+  # (ollama_openvino/macapp, openvino-langchain, openvino-langchain/sample)
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "npm"
+    directories:
+      - "/modules/**"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "deps(npm)"
+    groups:
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      npm-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  # ---------------------------------------------------------------------------
+  # Go modules — ollama_openvino
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "gomod"
+    directory: "/modules/ollama_openvino"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "go"
+    commit-message:
+      prefix: "deps(gomod)"
+    groups:
+      gomod-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      gomod-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  # ---------------------------------------------------------------------------
+  # Java / Kotlin — Gradle builds and version catalogs
+  # (java_api + samples, android_demos/coco_detection_android_demo)
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "gradle"
+    directories:
+      - "/modules/**"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "java"
+    commit-message:
+      prefix: "deps(gradle)"
+    groups:
+      gradle-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      gradle-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  # ---------------------------------------------------------------------------
+  # Dockerfiles — base image updates
+  # (3d/pointPillars/devops, nvidia_plugin, ollama_openvino)
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "docker"
+    directories:
+      - "/modules/**"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "docker"
+    commit-message:
+      prefix: "deps(docker)"
+    groups:
+      docker-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      docker-version:
+        applies-to: version-updates
+        patterns:
+          - "*"
+
+  # ---------------------------------------------------------------------------
+  # GitHub Actions — workflows under .github/workflows (SHA-pinned)
+  # ---------------------------------------------------------------------------
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "deps(actions)"
+    groups:
+      actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+      actions-version:
+        applies-to: version-updates
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,25 +11,29 @@
 #   schedule.interval: "weekly"
 #   groups: one `<eco>-security` (applies-to: security-updates) + one
 #           `<eco>-version` (applies-to: version-updates), both patterns ["*"]
-#   labels: "dependencies" + the ecosystem label
+#   labels: "dependencies" + the ecosystem label IF it exists in the repo
 #   commit-message.prefix: "deps(<eco>)"
 #
 # PER-BLOCK DIFFERENCES — the only values that legitimately vary:
-#   ecosystem | location           | day     | PR limit | label
-#   pip       | /modules/**/*      | monday  | 10       | python
-#   npm       | /modules/**/*      | monday  | 10       | javascript
-#   gomod     | /modules/ollama_openvino | monday | 10  | go
-#   gradle    | /modules/**/*      | tuesday | 10       | java
-#   docker    | /modules/**/*      | tuesday | 5        | docker
-#   actions   | /                  | tuesday | 5        | github-actions
+#   ecosystem | day     | PR limit | extra label
+#   pip       | monday  | 10       | python
+#   npm       | monday  | 10       | javascript
+#   gomod     | monday  | 10       | (none)
+#   gradle    | tuesday | 10       | (none)
+#   docker    | tuesday | 5        | (none)
+#   actions   | tuesday | 5        | (none)
 #
 # Notes:
-# - `/modules/**/*` globstar matches manifests at any depth under modules/.
+# - `directories` lists concrete manifest paths (Dependabot does not glob these
+#   into real jobs reliably); add the directory here when a new module ships a
+#   manifest for that ecosystem.
 # - `applies-to: security-updates` requires "Dependabot security updates"
 #   (+ Dependency graph + alerts) enabled in repo settings; the file alone
 #   does not enable security updates.
-# - Only the `dependencies` label is auto-created; ecosystem labels must exist
-#   in the repo or Dependabot ignores them.
+# - Only labels that already exist in the repo are applied; Dependabot silently
+#   ignores unknown labels. Currently only `dependencies`, `python` and
+#   `javascript` exist, so the gomod/gradle/docker/actions blocks carry just
+#   `dependencies`. Add the ecosystem label to a block once it is created.
 # - Security updates ignore `open-pull-requests-limit`.
 
 version: 2
@@ -38,7 +42,16 @@ updates:
   # pip — requirements*.txt and setup.py
   - package-ecosystem: "pip"
     directories:
-      - "/modules/**/*"
+      - "/modules/3d/CDPN"
+      - "/modules/3d/pointPillars"
+      - "/modules/custom_operations/tests"
+      - "/modules/genai_optimizations"
+      - "/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/generator"
+      - "/modules/nvidia_plugin/utils/shape-extractor"
+      - "/modules/nvidia_plugin/wheel"
+      - "/modules/openvino_bevfusion"
+      - "/modules/openvino_training_kit"
+      - "/modules/token_merging"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -61,7 +74,9 @@ updates:
   # npm — package.json lockfiles
   - package-ecosystem: "npm"
     directories:
-      - "/modules/**/*"
+      - "/modules/ollama_openvino/macapp"
+      - "/modules/openvino-langchain"
+      - "/modules/openvino-langchain/sample"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -90,7 +105,6 @@ updates:
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
-      - "go"
     commit-message:
       prefix: "deps(gomod)"
     groups:
@@ -106,14 +120,18 @@ updates:
   # gradle — build.gradle and version catalogs (Java/Kotlin)
   - package-ecosystem: "gradle"
     directories:
-      - "/modules/**/*"
+      - "/modules/android_demos/coco_detection_android_demo"
+      - "/modules/android_demos/coco_detection_android_demo/app"
+      - "/modules/java_api"
+      - "/modules/java_api/samples/face_detection_java_sample"
+      - "/modules/java_api/samples/face_detection_kotlin_sample"
+      - "/modules/java_api/samples/hello_query_device"
     schedule:
       interval: "weekly"
       day: "tuesday"
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
-      - "java"
     commit-message:
       prefix: "deps(gradle)"
     groups:
@@ -129,14 +147,15 @@ updates:
   # docker — Dockerfile base images
   - package-ecosystem: "docker"
     directories:
-      - "/modules/**/*"
+      - "/modules/3d/pointPillars/devops"
+      - "/modules/nvidia_plugin"
+      - "/modules/ollama_openvino"
     schedule:
       interval: "weekly"
       day: "tuesday"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "docker"
     commit-message:
       prefix: "deps(docker)"
     groups:
@@ -158,7 +177,6 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
-      - "github-actions"
     commit-message:
       prefix: "deps(actions)"
     groups:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,45 +1,9 @@
 # Copyright (C) 2018-2026 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-# Dependabot config for openvino_contrib.
-#
-# Dependabot has no shared-defaults/inheritance and rejects YAML anchors
-# (`YAML aliases are not supported`, dependabot/dependabot-core#1582), so every
-# `updates` block below repeats the same shape. To keep that controllable:
-#
-# SHARED SETTINGS — keep identical across ALL blocks; change here, then mirror:
-#   schedule.interval: "weekly"
-#   groups: one `<eco>-security` (applies-to: security-updates) + one
-#           `<eco>-version` (applies-to: version-updates), both patterns ["*"]
-#   labels: "dependencies" + the ecosystem label IF it exists in the repo
-#   commit-message.prefix: "deps(<eco>)"
-#
-# PER-BLOCK DIFFERENCES — the only values that legitimately vary:
-#   ecosystem | day     | PR limit | extra label
-#   pip       | monday  | 10       | python
-#   npm       | monday  | 10       | javascript
-#   gomod     | monday  | 10       | (none)
-#   gradle    | tuesday | 10       | (none)
-#   docker    | tuesday | 5        | (none)
-#   actions   | tuesday | 5        | (none)
-#
-# Notes:
-# - `directories` lists concrete manifest paths (Dependabot does not glob these
-#   into real jobs reliably); add the directory here when a new module ships a
-#   manifest for that ecosystem.
-# - `applies-to: security-updates` requires "Dependabot security updates"
-#   (+ Dependency graph + alerts) enabled in repo settings; the file alone
-#   does not enable security updates.
-# - Only labels that already exist in the repo are applied; Dependabot silently
-#   ignores unknown labels. Currently only `dependencies`, `python` and
-#   `javascript` exist, so the gomod/gradle/docker/actions blocks carry just
-#   `dependencies`. Add the ecosystem label to a block once it is created.
-# - Security updates ignore `open-pull-requests-limit`.
-
 version: 2
 
 updates:
-  # pip — requirements*.txt and setup.py
   - package-ecosystem: "pip"
     directories:
       - "/modules/3d/CDPN"
@@ -71,7 +35,6 @@ updates:
         patterns:
           - "*"
 
-  # npm — package.json lockfiles
   - package-ecosystem: "npm"
     directories:
       - "/modules/ollama_openvino/macapp"
@@ -96,7 +59,6 @@ updates:
         patterns:
           - "*"
 
-  # gomod — ollama_openvino
   - package-ecosystem: "gomod"
     directory: "/modules/ollama_openvino"
     schedule:
@@ -117,7 +79,6 @@ updates:
         patterns:
           - "*"
 
-  # gradle — build.gradle and version catalogs (Java/Kotlin)
   - package-ecosystem: "gradle"
     directories:
       - "/modules/android_demos/coco_detection_android_demo"
@@ -144,7 +105,6 @@ updates:
         patterns:
           - "*"
 
-  # docker — Dockerfile base images
   - package-ecosystem: "docker"
     directories:
       - "/modules/3d/pointPillars/devops"
@@ -168,7 +128,6 @@ updates:
         patterns:
           - "*"
 
-  # github-actions — workflows under .github/workflows
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,27 @@
 
 # Dependabot config for openvino_contrib.
 #
+# Dependabot has no shared-defaults/inheritance and rejects YAML anchors
+# (`YAML aliases are not supported`, dependabot/dependabot-core#1582), so every
+# `updates` block below repeats the same shape. To keep that controllable:
+#
+# SHARED SETTINGS — keep identical across ALL blocks; change here, then mirror:
+#   schedule.interval: "weekly"
+#   groups: one `<eco>-security` (applies-to: security-updates) + one
+#           `<eco>-version` (applies-to: version-updates), both patterns ["*"]
+#   labels: "dependencies" + the ecosystem label
+#   commit-message.prefix: "deps(<eco>)"
+#
+# PER-BLOCK DIFFERENCES — the only values that legitimately vary:
+#   ecosystem | location           | day     | PR limit | label
+#   pip       | /modules/**/*      | monday  | 10       | python
+#   npm       | /modules/**/*      | monday  | 10       | javascript
+#   gomod     | /modules/ollama_openvino | monday | 10  | go
+#   gradle    | /modules/**/*      | tuesday | 10       | java
+#   docker    | /modules/**/*      | tuesday | 5        | docker
+#   actions   | /                  | tuesday | 5        | github-actions
+#
+# Notes:
 # - `/modules/**/*` globstar matches manifests at any depth under modules/.
 # - `applies-to: security-updates` requires "Dependabot security updates"
 #   (+ Dependency graph + alerts) enabled in repo settings; the file alone


### PR DESCRIPTION
**Problem:** The repository has no `.github/dependabot.yml`, so the 156 open Dependabot alerts across pip, npm, gomod, gradle, docker, and GitHub Actions manifests are not remediated automatically and would otherwise generate one pull request per alert.

**Solution:** Add a Dependabot config covering every module ecosystem with grouped security and version updates per manifest directory, which keeps all 156 alerts under automated remediation while collapsing them into one grouped pull request per ecosystem instead of one per alert.