### PR TITLE
[NVIDIA] LLM ChatGPT2 support

### DIFF
--- a/modules/nvidia_plugin/src/ops/split.cpp
+++ b/modules/nvidia_plugin/src/ops/split.cpp
@@ -46,7 +46,9 @@ SplitOp::SplitOp(const CreationContext& context,
     const auto element_type = input_element_type;
 
     auto& data_shape = splitOp->get_input_shape(0);
-    const int64_t axis = *axisNode->get_data_ptr<int64_t>();
+    // cast_vector handles any integer axis element type (e.g. GPT-2 emits an i32
+    // axis); get_data_ptr<int64_t> would over-read a narrower constant.
+    const int64_t axis = axisNode->cast_vector<int64_t>().at(0);
     OPENVINO_ASSERT(axis >= 0 && axis < data_shape.size(), "Node name: ", GetName());
     OPENVINO_ASSERT(data_shape[axis] % num_splits_ == 0, "Node name: ", GetName());
     const size_t split_step_size =

--- a/modules/nvidia_plugin/src/ops/variadic_split.cpp
+++ b/modules/nvidia_plugin/src/ops/variadic_split.cpp
@@ -101,7 +101,7 @@ VariadicSplitOp::VariadicSplitOp(const CreationContext& context,
     const std::vector<int64_t> split_lengths = getSplitLengths(split_lengths_node);
 
     buildAxisHelpers(split_lengths, orig_axis_size);
-    buildSplitIndexHelper(split_lengths, orig_axis_size);
+    buildSplitIndexHelper(orig_axis_size);
 
     const size_t axis_split_step_size =
         std::accumulate(data_shape.begin() + axis + 1, data_shape.end(), 1, std::multiplies<size_t>());
@@ -143,13 +143,16 @@ void VariadicSplitOp::buildAxisHelpers(const std::vector<int64_t>& split_lengths
     }
 }
 
-void VariadicSplitOp::buildSplitIndexHelper(const std::vector<int64_t>& split_lengths, const size_t orig_axis_size) {
+void VariadicSplitOp::buildSplitIndexHelper(const size_t orig_axis_size) {
+    // Use the resolved per-output sizes (axis_sizes_), not the raw split_lengths:
+    // a "-1" (remaining) entry in split_lengths would decrease the running offset
+    // and then index split_lengths out of bounds (e.g. GPT-2's [768, 768, -1]).
     int64_t split_idx = 0;
-    int64_t prev_total_split_size = split_lengths[0];
+    int64_t prev_total_split_size = static_cast<int64_t>(axis_sizes_[0]);
     split_idx_.reserve(orig_axis_size);
-    for (int i = 0; i < orig_axis_size; ++i) {
-        if (i >= prev_total_split_size) {
-            prev_total_split_size += split_lengths[++split_idx];
+    for (size_t i = 0; i < orig_axis_size; ++i) {
+        if (static_cast<int64_t>(i) >= prev_total_split_size) {
+            prev_total_split_size += static_cast<int64_t>(axis_sizes_[++split_idx]);
         }
         split_idx_.push_back(split_idx);
     }

--- a/modules/nvidia_plugin/src/ops/variadic_split.hpp
+++ b/modules/nvidia_plugin/src/ops/variadic_split.hpp
@@ -35,7 +35,7 @@ private:
     enum { kSplitIdxIWBIdx = 0, kAxisSizesIWBIdx, kAxisOffsetSizesIWBIdx, kNumberOfIWIdx };
 
     void buildAxisHelpers(const std::vector<int64_t>& split_lengths, size_t orig_axis_size);
-    void buildSplitIndexHelper(const std::vector<int64_t>& split_lengths, size_t orig_axis_size);
+    void buildSplitIndexHelper(size_t orig_axis_size);
 
     void InitSharedImmutableWorkbuffers(const IOperationExec::Buffers& buffers) override;
     WorkbufferRequest GetWorkBufferRequest() const override;

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/split.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/split.cpp
@@ -1,0 +1,63 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "shared_test_classes/base/ov_subgraph.hpp"
+
+#include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/split.hpp"
+
+#include "cuda_test_constants.hpp"
+
+namespace {
+using namespace ov::test;
+using namespace ov::test::utils;
+
+/**
+ * Regression: a Split whose axis constant is a narrow integer type. GPT-2 emits
+ * an i32 Split axis, and the plugin lowers index/axis constants to i32 anyway,
+ * so SplitOp must read the axis with cast_vector. The pre-fix code used
+ * get_data_ptr<int64_t>(), which over-reads the 4-byte constant and aborts
+ * compile_model with "Buffer over-read".
+ */
+class SplitNVIDIATest : public ov::test::SubgraphBaseTest,
+                        public testing::WithParamInterface<ov::element::Type> {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<ov::element::Type>& obj) {
+        return "modelType=" + obj.param.to_string();
+    }
+
+protected:
+    void SetUp() override {
+        targetDevice = DEVICE_NVIDIA;
+        const ov::element::Type model_type = GetParam();
+        const ov::Shape data_shape{2, 6, 4};
+        const int32_t axis_value = 1;  // split the dim of size 6
+        const size_t num_splits = 3;
+
+        init_input_shapes(ov::test::static_shapes_to_test_representation({data_shape}));
+        auto param = std::make_shared<ov::op::v0::Parameter>(model_type, inputDynamicShapes[0]);
+        // Narrow (i32) axis constant — the scenario the pre-fix code over-read.
+        auto axis = std::make_shared<ov::op::v0::Constant>(ov::element::i32, ov::Shape{}, std::vector<int32_t>{axis_value});
+        auto split = std::make_shared<ov::op::v1::Split>(param, axis, num_splits);
+
+        ov::ResultVector results;
+        for (size_t i = 0; i < split->get_output_size(); ++i) {
+            results.push_back(std::make_shared<ov::op::v0::Result>(split->output(i)));
+        }
+        function = std::make_shared<ov::Model>(results, ov::ParameterVector{param}, "Split");
+    }
+};
+
+TEST_P(SplitNVIDIATest, Inference) {
+    run();
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke_Split_NarrowAxis,
+                         SplitNVIDIATest,
+                         ::testing::Values(ov::element::f32, ov::element::f16),
+                         SplitNVIDIATest::getTestCaseName);
+
+}  // namespace

--- a/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/variadic_split.cpp
+++ b/modules/nvidia_plugin/tests/functional/shared_tests_instances/single_layer_tests/variadic_split.cpp
@@ -6,7 +6,13 @@
 
 #include "common_test_utils/test_constants.hpp"
 #include "cuda_test_constants.hpp"
+#include "shared_test_classes/base/ov_subgraph.hpp"
 #include "single_op_tests/variadic_split.hpp"
+
+#include "openvino/op/constant.hpp"
+#include "openvino/op/parameter.hpp"
+#include "openvino/op/result.hpp"
+#include "openvino/op/variadic_split.hpp"
 
 namespace {
 
@@ -146,4 +152,62 @@ INSTANTIATE_TEST_CASE_P(yolov5_NumSplitsCheck_shape2_axis4,
                                            ::testing::Values(static_shapes_to_test_representation({{1, 3, 80, 80, 85}})),
                                            ::testing::Values(DEVICE_NVIDIA)),
                         VariadicSplitLayerTest::getTestCaseName);
+
+// The shared VariadicSplitLayerTest takes split lengths as unsigned values, so
+// it can never exercise a "-1" (remaining) length. GPT-2's QKV split uses
+// {768, 768, -1}; the custom test below covers that.
+using VariadicSplitRemainingParams = std::tuple<size_t,                // size of the split axis
+                                                std::vector<int64_t>>;  // split lengths, one of them -1
+
+/**
+ * Regression: VariadicSplit with a "-1" (remaining) split length.
+ * buildSplitIndexHelper must build its index table from the resolved per-output
+ * sizes; using the raw split_lengths lets the -1 decrease the running offset and
+ * then index split_lengths out of bounds, so the table holds split indices >=
+ * the number of outputs and the kernel reads its metadata/output-pointer arrays
+ * out of bounds (illegal memory access at inference).
+ */
+class VariadicSplitRemainingNVIDIATest : public ov::test::SubgraphBaseTest,
+                                         public testing::WithParamInterface<VariadicSplitRemainingParams> {
+public:
+    static std::string getTestCaseName(const testing::TestParamInfo<VariadicSplitRemainingParams>& obj) {
+        const auto& [axis_size, lengths] = obj.param;
+        std::ostringstream result;
+        result << "axisSize=" << axis_size << "_lengths=";
+        for (auto l : lengths) {
+            result << l << ".";
+        }
+        return result.str();
+    }
+
+protected:
+    void SetUp() override {
+        targetDevice = DEVICE_NVIDIA;
+        const auto& [axis_size, lengths] = GetParam();
+        const int64_t axis_value = 1;
+        const ov::Shape data_shape{2, axis_size, 3};
+
+        init_input_shapes(ov::test::static_shapes_to_test_representation({data_shape}));
+        auto param = std::make_shared<ov::op::v0::Parameter>(ov::element::f32, inputDynamicShapes[0]);
+        auto axis = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{}, std::vector<int64_t>{axis_value});
+        auto lengths_const = std::make_shared<ov::op::v0::Constant>(ov::element::i64, ov::Shape{lengths.size()}, lengths);
+        auto variadic_split = std::make_shared<ov::op::v1::VariadicSplit>(param, axis, lengths_const);
+
+        ov::ResultVector results;
+        for (size_t i = 0; i < variadic_split->get_output_size(); ++i) {
+            results.push_back(std::make_shared<ov::op::v0::Result>(variadic_split->output(i)));
+        }
+        function = std::make_shared<ov::Model>(results, ov::ParameterVector{param}, "VariadicSplitRemaining");
+    }
+};
+
+TEST_P(VariadicSplitRemainingNVIDIATest, Inference) {
+    run();
+}
+
+INSTANTIATE_TEST_SUITE_P(smoke_VariadicSplit_RemainingPart,
+                         VariadicSplitRemainingNVIDIATest,
+                         ::testing::Values(VariadicSplitRemainingParams{4, {1, 1, -1}},   // GPT-2-like: -1 last
+                                           VariadicSplitRemainingParams{6, {2, -1, 2}}),  // -1 in the middle
+                         VariadicSplitRemainingNVIDIATest::getTestCaseName);
 }  // namespace


### PR DESCRIPTION
## What

Enables **GPT-2 / ChatGPT-2** (`gpt2`, 124M) text generation on the NVIDIA GPU plugin.

GPT-2's QKV projection uses `Split` / `VariadicSplit` with **integer constant** inputs. After the plugin's `i64 → i32` precision downcast those constants are `i32`, but the plugin read them with a fixed 64‑bit type, reading past the end of the buffer. This PR fixes the constant reads and adds regression tests.

## Changes

- **`Split` axis over-read** (`src/ops/split.cpp`): the axis constant was read with `get_data_ptr<int64_t>()`, which over-reads a narrower (`i32`) constant. Read it with `cast_vector<int64_t>()`, which converts from the constant's actual element type.
- **`VariadicSplit` out-of-bounds for the `-1` ("remaining") length** (`src/ops/variadic_split.{cpp,hpp}`): `buildSplitIndexHelper` indexed the raw `split_lengths` (which may contain `-1`), so the running offset decreased and the index ran one element past `split_lengths` → the kernel read out of bounds. Use the resolved per-output sizes (`axis_sizes_`) instead.
- **Regression tests** (`tests/.../single_layer_tests/split.cpp`, `variadic_split.cpp`): an `i32`-axis `Split` and a `VariadicSplit` with `-1` remaining lengths. Both fail without the fixes and pass with them.

## Verification

- The regression tests above (fail before / pass after).
- End-to-end: GPT-2 (fp16, stateful) generates coherent text on the NVIDIA device via OpenVINO GenAI.

## Note on PagedAttention (out of scope for this PR)

OpenVINO GenAI's `LLMPipeline` defaults to the **ContinuousBatching** backend, which converts `ScaledDotProductAttention` into **`PagedAttentionExtension`** (paged KV‑cache). The NVIDIA plugin does not implement `PagedAttentionExtension`, so that path fails with `... PagedAttentionExtension ... Is not found in OperationRegistry`.

GPT‑2 runs on the plugin via the **stateful / SDPA** path — e.g. `LLMPipeline(model, "NVIDIA", ATTENTION_BACKEND="SDPA")`:

| Path | Effort | Result |
| --- | --- | --- |
| **A** — `ATTENTION_BACKEND="SDPA"` (stateful) | none (works today) | GPT‑2 generates; no continuous batching |
| **B** — implement `PagedAttentionExtension` | large, separate feature | GenAI default / continuous batching / higher serving throughput |

`PagedAttentionExtension` support (path B) is tracked separately.