### PR TITLE
[JAVA_API] Fix inverted double-free guard in Wrapper.close()

### DIFF
--- a/modules/java_api/src/main/java/org/intel/openvino/Wrapper.java
+++ b/modules/java_api/src/main/java/org/intel/openvino/Wrapper.java
@@ -27,7 +27,7 @@ public class Wrapper implements AutoCloseable {
 
     @Override
     public void close() {
-        if (!closed.compareAndSet(false, true)) {
+        if (closed.compareAndSet(false, true)) {
             delete(nativeObj);
         }
     }


### PR DESCRIPTION
### Fix an inverted double-free guard in `Wrapper.close()`

`Wrapper.close()` released the native object only on the **second** call:

```java
if (!closed.compareAndSet(false, true)) {   // false on the 1st close, true after
    delete(nativeObj);
}
```

`compareAndSet(false, true)` returns `true` on the first close (CAS succeeds),
so `!true` skips `delete()` — the object is leaked. A later close then takes the
branch and frees it, so a third call would double-free. Inverting the condition
makes `delete()` run once, on the first successful CAS.

