### PR TITLE
[ci] Modernize and lint GitHub Actions

### DIFF
--- a/.github/ISSUE_TEMPLATE/good_first_issue.yml
+++ b/.github/ISSUE_TEMPLATE/good_first_issue.yml
@@ -35,7 +35,7 @@ body:
           Provide example Pull requests, if there are any.
     validations:
       required: false
-  
+
   - type: textarea
     id: resources
     attributes:

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,16 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Self-hosted runner labels used by the contrib workflows, so actionlint does
+# not flag them as unknown.
+self-hosted-runner:
+  labels:
+    - aks-linux-4-cores-16gb
+    - aks-linux-8-cores-32gb
+    - aks-linux-16-cores-32gb
+    - Nvidia-GPU
+    - RTX-4090
+    - lohika-ci
+    # Labels used by the legacy monolith workflows (linux/mac/windows).
+    - ubuntu-22.04-16-cores
+    - windows-2022-16-core

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -2,61 +2,73 @@
 # SPDX-License-Identifier: Apache-2.0
 
 'category: CI':
-- '.github/**/*'
-- '.ci/**/*'
-- 'Jenkinsfile'
+- changed-files:
+  - any-glob-to-any-file: ['.github/**/*', '.ci/**/*', 'Jenkinsfile']
 # Repository-level meta files that belong to no module: keep every PR labelled.
-- '*.md'
-- 'LICENSE'
-- 'third-party-programs.txt'
-- '.gitignore'
-- '.gitattributes'
-- '.licenserc.yaml'
-- '.readthedocs.yaml'
+- changed-files:
+  - any-glob-to-any-file:
+    - '*.md'
+    - 'LICENSE'
+    - 'third-party-programs.txt'
+    - '.gitignore'
+    - '.gitattributes'
+    - '.licenserc.yaml'
+    - '.readthedocs.yaml'
 
 'category: 3D':
-- 'modules/3d/**/*'
+- changed-files:
+  - any-glob-to-any-file: 'modules/3d/**/*'
 
 'category: android demos':
-- 'modules/android_demos/**/*'
+- changed-files:
+  - any-glob-to-any-file: 'modules/android_demos/**/*'
 
 'category: BEVFusion':
-- 'modules/openvino_bevfusion/**/*'
+- changed-files:
+  - any-glob-to-any-file: 'modules/openvino_bevfusion/**/*'
 
 'category: custom operations':
-- 'modules/custom_operations/**/*'
+- changed-files:
+  - any-glob-to-any-file: 'modules/custom_operations/**/*'
 
 'category: GenAI optimizations':
-- 'modules/genai_optimizations/**/*'
+- changed-files:
+  - any-glob-to-any-file: 'modules/genai_optimizations/**/*'
 
 'category: java API':
-- 'modules/java_api/**/*'
+- changed-files:
+  - any-glob-to-any-file: 'modules/java_api/**/*'
 
 'category: LangChain':
-- 'modules/openvino-langchain/**/*'
+- changed-files:
+  - any-glob-to-any-file: 'modules/openvino-langchain/**/*'
 
 'category: llama.cpp plugin':
-- 'modules/llama_cpp_plugin/**/*'
+- changed-files:
+  - any-glob-to-any-file: 'modules/llama_cpp_plugin/**/*'
 
 'category: NVIDIA plugin':
-- 'modules/nvidia_plugin/**/*'
+- changed-files:
+  - any-glob-to-any-file: 'modules/nvidia_plugin/**/*'
 
 'category: Ollama':
-- 'modules/ollama_openvino/**/*'
+- changed-files:
+  - any-glob-to-any-file: 'modules/ollama_openvino/**/*'
 
 'category: Token Merging':
-- 'modules/token_merging/**/*'
+- changed-files:
+  - any-glob-to-any-file: 'modules/token_merging/**/*'
 
 'category: training kit':
-- 'modules/openvino_training_kit/**/*'
+- changed-files:
+  - any-glob-to-any-file: 'modules/openvino_training_kit/**/*'
 
 'category: build':
-- '**/CMakeLists.txt'
-- '**/*.cmake'
+- changed-files:
+  - any-glob-to-any-file: ['**/CMakeLists.txt', '**/*.cmake']
 
 'dependencies':
-- '**/requirement*.txt'
-- '.gitmodules'
-- '**/setup.py'
-- any: ['**/thirdparty/**/*',
-        '!**/CMakeLists.txt']
+- changed-files:
+  - any-glob-to-any-file: ['**/requirement*.txt', '.gitmodules', '**/setup.py']
+- changed-files:
+  - all-globs-to-any-file: ['**/thirdparty/**/*', '!**/CMakeLists.txt']

--- a/.github/scripts/check_codeowners.py
+++ b/.github/scripts/check_codeowners.py
@@ -19,10 +19,7 @@ CODEOWNERS_FILE = os.path.join(".github", "CODEOWNERS")
 
 
 def main():
-    modules = {
-        d for d in os.listdir(MODULES_DIR)
-        if os.path.isdir(os.path.join(MODULES_DIR, d))
-    }
+    modules = {d for d in os.listdir(MODULES_DIR) if os.path.isdir(os.path.join(MODULES_DIR, d))}
 
     errors = []
     with open(CODEOWNERS_FILE, encoding="utf-8") as f:
@@ -50,7 +47,7 @@ def main():
         )
         return 1
 
-    print(f"OK: all CODEOWNERS module rules point at existing modules")
+    print("OK: all CODEOWNERS module rules point at existing modules")
     return 0
 
 

--- a/.github/scripts/check_module_labels.py
+++ b/.github/scripts/check_module_labels.py
@@ -39,10 +39,7 @@ def flatten_patterns(node):
 def main():
     errors = []
 
-    modules = sorted(
-        d for d in os.listdir(MODULES_DIR)
-        if os.path.isdir(os.path.join(MODULES_DIR, d))
-    )
+    modules = sorted(d for d in os.listdir(MODULES_DIR) if os.path.isdir(os.path.join(MODULES_DIR, d)))
 
     with open(LABELER_FILE, encoding="utf-8") as f:
         labeler = yaml.safe_load(f) or {}

--- a/.github/scripts/ruff.toml
+++ b/.github/scripts/ruff.toml
@@ -1,0 +1,9 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Ruff config for the CI helper scripts under .github/scripts.
+line-length = 110
+target-version = "py310"
+
+[lint]
+select = ["E", "F", "I", "W", "UP", "B"]

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -17,7 +17,7 @@ jobs:
   Java:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # v5.0.0
         with:

--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -20,11 +20,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.23.6'
+          cache: false
+
+      - name: Install License Eye
+        run: go install github.com/apache/skywalking-eyes/cmd/license-eye@v0.8.0
 
       - name: Check license headers
-        uses: apache/skywalking-eyes/header@61275cc80d0798a405cb070f7d3a8aaf7cf2c2c1 # v0.8.0
-        with:
-          config: .licenserc.yaml
-          mode: check
-          token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: license-eye -v info -c .licenserc.yaml header check

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -36,7 +36,7 @@ jobs:
       # just added by hand to a PR the globs do not cover.
       - name: Assign category labels from changed paths
         if: github.event.action != 'labeled' && github.event.action != 'unlabeled'
-        uses: actions/labeler@ac9175f8a1f3625fd0d4fb234536d26811351594 # v4.3.0
+        uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: '.github/labeler.yml'

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -37,7 +37,7 @@ jobs:
       issues: write
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: crazy-max/ghaction-github-labeler@548a7c3603594ec17c819e1239f281a3b801ab4d # v6.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -53,8 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-      - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.11'
       - name: Install dependencies

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -57,7 +57,7 @@ jobs:
           apt-get install --assume-yes --no-install-recommends git git-lfs ca-certificates
 
       - name: Clone OpenVINO
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: 'openvinotoolkit/openvino'
           path: ${{ env.OPENVINO_REPO }}
@@ -65,13 +65,13 @@ jobs:
           ref: ${{ env.OV_BRANCH}}
 
       - name: Clone OpenVINO Contrib
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: ${{ env.OPENVINO_CONTRIB_REPO }}
           submodules: 'true'
 
       - name: Clone Testdata
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: 'openvinotoolkit/testdata'
           path: ${{ env.TEST_DATA }}
@@ -89,24 +89,22 @@ jobs:
           apt install --assume-yes --no-install-recommends default-jdk libopencv-dev unzip
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43 # v3.3.2
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           gradle-version: ${{ env.GRADLE_VER }}
 
       - name: Setup Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Install python dependencies
         run: python3 -m pip install -r ${OPENVINO_REPO}/src/bindings/python/wheel/requirements-dev.txt
 
-      - name: Setup ccache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - name: Restore ccache
+        id: ccache-restore
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          # Should save cache only if run in the master branch of the base repo
-          # github.ref_name is 'ref/PR_#' in case of the PR, and 'branch_name' when executed on push
-          save-always: ${{ github.ref_name == 'master' && 'true' || 'false'  }}
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ github.sha }}
           restore-keys: |
@@ -150,6 +148,13 @@ jobs:
       - name: Show ccache stats
         run: ccache --show-stats
 
+      - name: Save ccache
+        if: github.ref_name == 'master'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
+
       - name: Cmake install
         run: |
           cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR} -P ${BUILD_DIR}/cmake_install.cmake
@@ -188,7 +193,7 @@ jobs:
           popd
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: test-results-java
@@ -197,7 +202,7 @@ jobs:
 
       - name: Upload openvino package
         if: ${{ always() }}
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: openvino_package
           path: ${{ env.BUILD_DIR }}/openvino_package.tar.gz
@@ -205,7 +210,7 @@ jobs:
 
       - name: Upload openvino developer package
         if: ${{ always() }}
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: openvino_developer_package
           path: ${{ env.BUILD_DIR }}/openvino_developer_package.tar.gz

--- a/.github/workflows/llama_cpp_plugin_build_and_test.yml
+++ b/.github/workflows/llama_cpp_plugin_build_and_test.yml
@@ -16,32 +16,32 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Setup cmake
-        uses: jwlawson/actions-setup-cmake@d06b37b47cfd043ec794ffa3e40e0b6b5858a7ec # v1.14.2
+        uses: jwlawson/actions-setup-cmake@0d6a7d60b009d01c9e7523be22153ff8f19460d3 # v2.2.0
         with:
-          cmake-version: '3.24.x'
+          cmake-version: '3.26.x'
 
       - name: Checkout openvino_contrib
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           path: openvino_contrib
 
       - name: Checkout openvino
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           repository: openvinotoolkit/openvino
           path: openvino
 
       - name: CMake - configure
-        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DOPENVINO_EXTRA_MODULES=${{ github.workspace }}/openvino_contrib/modules/llama_cpp_plugin -DENABLE_TESTS=ON -DENABLE_FUNCTIONAL_TESTS=ON -DENABLE_PLUGINS_XML=ON -DENABLE_LLAMA_CPP_PLUGIN_REGISTRATION=ON openvino
+        run: cmake -B build -DCMAKE_BUILD_TYPE=Release -DOPENVINO_EXTRA_MODULES=${{ github.workspace }}/openvino_contrib/modules/llama_cpp_plugin -DENABLE_TESTS=ON -DENABLE_FUNCTIONAL_TESTS=ON -DENABLE_PLUGINS_XML=ON -DENABLE_LLAMA_CPP_PLUGIN_REGISTRATION=ON -DLLAMA_NATIVE=OFF openvino
 
       - name: CMake - build
-        run: cmake --build build -j`nproc` -- llama_cpp_plugin llama_cpp_e2e_tests llama_cpp_func_tests
+        run: cmake --build build -j"$(nproc)" -- llama_cpp_plugin llama_cpp_e2e_tests llama_cpp_func_tests
 
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build_artifacts
           path: ${{ github.workspace }}/openvino/bin/intel64/Release/
@@ -51,19 +51,19 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: build_artifacts
           path: ${{ github.workspace }}/binaries
 
       - name: Prepare test data - checkout llama.cpp repo
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ggerganov/llama.cpp
           ref: b2417
           path: llama.cpp
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.10'
 

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -47,7 +47,7 @@ jobs:
       GRADLE_VER: '7.1.1'
     steps:
       - name: Clone OpenVINO
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: 'openvinotoolkit/openvino'
           path: 'openvino'
@@ -55,12 +55,12 @@ jobs:
           ref: ${{ env.OV_BRANCH}}
 
       - name: Clone OpenVINO Contrib
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: 'openvino_contrib'
 
       - name: Clone Testdata
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: 'openvinotoolkit/testdata'
           path: 'testdata'
@@ -75,7 +75,7 @@ jobs:
         run: brew install coreutils ninja scons automake gradle ccache
 
       - name: Setup Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -86,12 +86,10 @@ jobs:
       # Build
       #
 
-      - name: Setup ccache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - name: Restore ccache
+        id: ccache-restore
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          # Should save cache only if run in the master branch of the base repo
-          # github.ref_name is 'ref/PR_#' in case of the PR, and 'branch_name' when executed on push
-          save-always: ${{ github.ref_name == 'master' && 'true' || 'false'  }}
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ github.sha }}
           restore-keys: |
@@ -125,6 +123,13 @@ jobs:
       - name: Show ccache stats
         run: ccache --show-stats
 
+      - name: Save ccache
+        if: github.ref_name == 'master'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
+
       - name: Cmake install
         run: |
           cmake -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -P ${{ env.BUILD_DIR }}/cmake_install.cmake
@@ -150,7 +155,7 @@ jobs:
           popd
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: test-results-java

--- a/.github/workflows/ollama_openvino_build_and_test.yml
+++ b/.github/workflows/ollama_openvino_build_and_test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Download repo
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: openvinotoolkit/openvino_contrib
           path: openvino_contrib
@@ -25,7 +25,7 @@ jobs:
           sparse-checkout-cone-mode: true
 
       - name: Setup python env
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.10'
 

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -1,0 +1,49 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Run the repository pre-commit hooks (actionlint, ruff, yaml/whitespace) in CI
+# so the checks that guard the CI infrastructure are enforced on every PR, not
+# only locally. Scope follows .pre-commit-config.yaml (files under .github/).
+
+name: Pre-commit
+
+on:
+  pull_request:
+    paths:
+      - '.github/**'
+      - '.pre-commit-config.yaml'
+  push:
+    branches:
+      - master
+      - 'releases/**'
+    paths:
+      - '.github/**'
+      - '.pre-commit-config.yaml'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  pre-commit:
+    name: pre-commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.11'
+
+      - name: Cache pre-commit environments
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
+      - name: Install pre-commit
+        run: python -m pip install pre-commit
+
+      - name: Run pre-commit
+        run: pre-commit run --show-diff-on-failure --color=always --all-files

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
     timeout-minutes: 10
     steps:
-      - uses: actions/stale@1e223db275d687790206a7acac4d1a11bd6fe629 # v10.4.0
+      - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           # Process more pull requests per run so a large backlog is not spread

--- a/.github/workflows/token_merging.yml
+++ b/.github/workflows/token_merging.yml
@@ -10,7 +10,7 @@ on:
     paths:
       - 'modules/token_merging/**'
   pull_request:
-    branches: 
+    branches:
       - master
     paths:
       - 'modules/token_merging/**'
@@ -30,9 +30,9 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
     - name: Setup Python ${{ matrix.python-version }}
-      uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Create and start a virtual environment

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -49,7 +49,7 @@ jobs:
         run: git config --system core.longpaths true
 
       - name: Clone OpenVINO
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: 'openvinotoolkit/openvino'
           path: ${{ env.OPENVINO_REPO }}
@@ -57,13 +57,13 @@ jobs:
           ref: ${{ env.OV_BRANCH}}
 
       - name: Clone OpenVINO Contrib
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: ${{ env.OPENVINO_CONTRIB_REPO }}
           submodules: 'true'
 
       - name: Clone Testdata
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: 'openvinotoolkit/testdata'
           path: ${{ env.TEST_DATA }}
@@ -75,12 +75,12 @@ jobs:
       #
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@db19848a5fa7950289d3668fb053140cf3028d43 # v3.3.2
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           gradle-version: ${{ env.GRADLE_VER }}
 
       - name: Setup Python ${{ env.PYTHON_VERSION }}
-        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -103,7 +103,23 @@ jobs:
       #
 
       - name: Configure Developer Command Prompt for Microsoft Visual C++
-        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
+        shell: pwsh
+        run: |
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+          $installationPath = & $vswhere -latest -products * `
+            -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+          if (-not $installationPath) {
+            throw 'Visual Studio with the C++ toolchain was not found'
+          }
+
+          $vsDevCmd = Join-Path $installationPath 'Common7\Tools\VsDevCmd.bat'
+          $environment = & $env:COMSPEC /d /s /c "call `"$vsDevCmd`" -no_logo -arch=x64 -host_arch=x64 && set"
+          foreach ($line in $environment) {
+            $name, $value = $line -split '=', 2
+            if ($name -and $null -ne $value) {
+              "$name=$value" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            }
+          }
 
       - name: Download and install ccache
         run: |
@@ -112,12 +128,10 @@ jobs:
           Move-Item -Path 'C:\temp\ccache\*' -Destination 'C:\ccache'
           Add-Content -Path $env:GITHUB_PATH -Value "C:\ccache"
 
-      - name: Setup ccache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      - name: Restore ccache
+        id: ccache-restore
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          # Should save cache only if run in the master branch of the base repo
-          # github.ref_name is 'ref/PR_#' in case of the PR, and 'branch_name' when executed on push
-          save-always: ${{ github.ref_name == 'master' && 'true' || 'false'  }}
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ runner.arch }}-ccache-${{ github.sha }}
           restore-keys: |
@@ -156,6 +170,13 @@ jobs:
       - name: Show ccache stats
         run: ccache --show-stats
 
+      - name: Save ccache
+        if: github.ref_name == 'master'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ steps.ccache-restore.outputs.cache-primary-key }}
+
       - name: Cmake install - OpenVINO
         run: cmake -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -P ${{ env.BUILD_DIR }}/cmake_install.cmake
 
@@ -191,7 +212,7 @@ jobs:
           CUSTOM_OP_LIB: ${{ env.OPENVINO_REPO }}/bin/intel64/${{ env.CMAKE_BUILD_TYPE }}/user_ov_extensions.dll
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ !cancelled() }}
         with:
           name: test-results-java

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,39 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Pre-commit hooks for the CI infrastructure under .github/. Scope is limited to
+# .github/ so the many independently-managed modules under modules/ are not
+# affected. Run locally with:  pre-commit run --all-files
+
+minimum_pre_commit_version: "3.5.0"
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-yaml
+        files: ^\.github/.*\.ya?ml$
+      - id: end-of-file-fixer
+        files: ^\.github/.*\.(ya?ml|py)$
+      - id: trailing-whitespace
+        files: ^\.github/.*\.(ya?ml|py)$
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.6
+    hooks:
+      - id: ruff
+        args: [--fix, --config, .github/scripts/ruff.toml]
+        files: ^\.github/.*\.py$
+      - id: ruff-format
+        args: [--config, .github/scripts/ruff.toml]
+        files: ^\.github/.*\.py$
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint
+        files: ^\.github/workflows/.*\.ya?ml$
+        # Lint workflow structure/expressions/runner labels across all workflows.
+        # The external shellcheck integration is disabled: our scripts are Python
+        # (no inline bash), and we do not rewrite the legacy monolith bash here.
+        args: ['-shellcheck=']


### PR DESCRIPTION
## What changed

- migrated the existing GitHub workflows from deprecated Node.js 20 action runtimes to pinned Node.js 24-compatible releases;
- updated the labeler configuration for `actions/labeler` v6;
- replaced Node.js 20-only license-header and Visual Studio setup actions with direct tool setup;
- added repository-scoped pre-commit checks for workflow YAML and CI Python helpers;
- fixed the llama.cpp workflow for the current OpenVINO CMake requirement and portable execution across heterogeneous hosted runners.

## Why

These repository-wide maintenance changes are independent from the reusable per-module CI architecture introduced in #1126. Keeping them here makes #1126 about the reusable infrastructure and its first NVIDIA consumer only.

The llama.cpp failure was caused by `llama.cpp b2417` enabling `-march=native` on the build runner and then executing the artifact on a different CPU. `LLAMA_NATIVE=OFF` keeps its intended portable x86 feature set.

## Validation

- `actionlint -shellcheck=` across all existing workflows, including the legacy CUDA workflows;
- Ruff lint and format checks for `.github` Python files;
- Python bytecode compilation for the CI helpers;
- CODEOWNERS and module-label consistency scripts;
- `git diff --check`.

Merge this PR before #1126. Afterward #1126 contains only the reusable module CI architecture and the NVIDIA implementation.
