### PR TITLE
[CI] Fix FlashOCC labeler configuration

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -28,7 +28,8 @@
   - any-glob-to-any-file: 'modules/openvino_bevfusion/**/*'
 
 'category: FlashOCC':
-- 'modules/openvino_flashocc/**/*'
+- changed-files:
+  - any-glob-to-any-file: 'modules/openvino_flashocc/**/*'
 
 'category: custom operations':
 - changed-files:


### PR DESCRIPTION
Fix the invalid `actions/labeler@v7` rule for `category: FlashOCC` by using the same `changed-files` schema as the other module labels.

The scalar rule currently makes every `pull_request_target` labeler run fail before the category-label check.

Validation:
- parsed `.github/labeler.yml` and asserted the resulting FlashOCC rule structure
- `actionlint -shellcheck=`
- `git diff --check`