### PR TITLE
[genai_optimizations] Replace fuzzywuzzy with thefuzz

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -28,7 +28,8 @@
   - any-glob-to-any-file: 'modules/openvino_bevfusion/**/*'
 
 'category: FlashOCC':
-- 'modules/openvino_flashocc/**/*'
+- changed-files:
+  - any-glob-to-any-file: 'modules/openvino_flashocc/**/*'
 
 'category: custom operations':
 - changed-files:

--- a/modules/genai_optimizations/benchmarks/longbench.py
+++ b/modules/genai_optimizations/benchmarks/longbench.py
@@ -13,7 +13,7 @@ from contextlib import ExitStack
 import datasets
 import torch
 import transformers
-from fuzzywuzzy import fuzz
+from thefuzz import fuzz
 from rouge import Rouge
 from tqdm import tqdm
 from transformers import AutoModelForCausalLM

--- a/modules/genai_optimizations/setup.py
+++ b/modules/genai_optimizations/setup.py
@@ -9,7 +9,7 @@ EXTRAS_REQUIRE = {
         "datasets==2.14.7",
         "rouge==1.0.1",
         "scikit-learn>=1.7",
-        "fuzzywuzzy",
+        "thefuzz",
         "bitsandbytes==0.47.0",
         "protobuf",
         "sentencepiece==0.2.1",
@@ -24,7 +24,8 @@ INSTALL_REQUIRES = [
     "transformers>=4.48.0",
     "accelerate==1.9.0",
     "wheel==0.45.1",
-    "git+https://github.com/mit-han-lab/Block-Sparse-Attention.git", # Install with limited build threads to avoid OOM (MAX_JOBS=4)
+    # Install with limited build threads to avoid OOM (MAX_JOBS=4)
+    "block_sparse_attn @ git+https://github.com/mit-han-lab/Block-Sparse-Attention.git",
 ]
 
 # Safely read README.md for PyPI long description


### PR DESCRIPTION
- Replace the GPL-2.0-licensed `fuzzywuzzy` dependency with the MIT-licensed `thefuzz`.
- Update the LongBench import.
- Fix the `block_sparse_attn` dependency declaration to use PEP 508 syntax.
- Fix the FlashOCC labeler configuration.
