### PR TITLE
[license_compliance] Add end-to-end license compliance tooling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,7 +3,7 @@
 
 'category: CI':
 - changed-files:
-  - any-glob-to-any-file: ['.github/**/*', '.ci/**/*', 'Jenkinsfile']
+  - any-glob-to-any-file: ['.github/**/*', '.ci/**/*', 'tools/license_compliance/**/*', 'Jenkinsfile']
 # Repository-level meta files that belong to no module: keep every PR labelled.
 - changed-files:
   - any-glob-to-any-file:

--- a/.github/workflows/license_compliance.yml
+++ b/.github/workflows/license_compliance.yml
@@ -27,13 +27,13 @@ jobs:
           fetch-depth: 0
 
       - name: Create isolated Python environment
-        run: python3 -m venv .license-venv
+        run: python3 -m venv .venv
 
       - name: Install compliance tool
-        run: .license-venv/bin/python -m pip install ./tools/license_compliance
+        run: .venv/bin/python -m pip install ./tools/license_compliance
 
       - name: Run offline unit tests
-        run: .license-venv/bin/python -m unittest discover -s tools/license_compliance/tests -v
+        run: .venv/bin/python -m unittest discover -s tools/license_compliance/tests -v
 
       - name: Evaluate license policy
         shell: bash
@@ -42,7 +42,7 @@ jobs:
           if [[ -n "${BASE_SHA}" && -n "${HEAD_SHA}" ]]; then
             discovery_args+=(--base-ref "${BASE_SHA}" --head-ref "${HEAD_SHA}")
           fi
-          .license-venv/bin/ov-contrib-license check . \
+          .venv/bin/ov-contrib-license check . \
             --offline \
             --fail-on FAIL \
             --inventory-output license-inventory.json \
@@ -52,7 +52,7 @@ jobs:
 
       - name: Reconcile third-party notices
         run: |
-          .license-venv/bin/ov-contrib-license tpp check . \
+          .venv/bin/ov-contrib-license tpp check . \
             --source-inventory license-inventory.json \
             --offline \
             --fail-on FAIL \
@@ -66,7 +66,7 @@ jobs:
           if [[ -n "${BASE_SHA}" && -n "${HEAD_SHA}" ]]; then
             discovery_args+=(--base-ref "${BASE_SHA}" --head-ref "${HEAD_SHA}")
           fi
-          .license-venv/bin/ov-contrib-license toolchain check . \
+          .venv/bin/ov-contrib-license toolchain check . \
             --fail-on FAIL \
             --report toolchain-report.md \
             --github-summary "${GITHUB_STEP_SUMMARY}" \
@@ -74,7 +74,7 @@ jobs:
 
       - name: Generate SPDX SBOM
         run: >-
-          .license-venv/bin/ov-contrib-license sbom .
+          .venv/bin/ov-contrib-license sbom .
           --source-inventory license-inventory.json
           --output openvino-contrib.spdx.json
 

--- a/.github/workflows/license_compliance.yml
+++ b/.github/workflows/license_compliance.yml
@@ -1,0 +1,92 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+name: License Compliance
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  compliance:
+    name: Repository policy and notices
+    runs-on: ubuntu-22.04
+    env:
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Create isolated Python environment
+        run: python3 -m venv .license-venv
+
+      - name: Install compliance tool
+        run: .license-venv/bin/python -m pip install ./tools/license_compliance
+
+      - name: Run offline unit tests
+        run: .license-venv/bin/python -m unittest discover -s tools/license_compliance/tests -v
+
+      - name: Evaluate license policy
+        shell: bash
+        run: |
+          discovery_args=()
+          if [[ -n "${BASE_SHA}" && -n "${HEAD_SHA}" ]]; then
+            discovery_args+=(--base-ref "${BASE_SHA}" --head-ref "${HEAD_SHA}")
+          fi
+          .license-venv/bin/ov-contrib-license check . \
+            --offline \
+            --fail-on FAIL \
+            --inventory-output license-inventory.json \
+            --report license-report.md \
+            --github-summary "${GITHUB_STEP_SUMMARY}" \
+            "${discovery_args[@]}"
+
+      - name: Reconcile third-party notices
+        run: |
+          .license-venv/bin/ov-contrib-license tpp check . \
+            --source-inventory license-inventory.json \
+            --offline \
+            --fail-on FAIL \
+            --report tpp-report.md \
+            --github-summary "${GITHUB_STEP_SUMMARY}"
+
+      - name: Audit the compliance toolchain
+        shell: bash
+        run: |
+          discovery_args=()
+          if [[ -n "${BASE_SHA}" && -n "${HEAD_SHA}" ]]; then
+            discovery_args+=(--base-ref "${BASE_SHA}" --head-ref "${HEAD_SHA}")
+          fi
+          .license-venv/bin/ov-contrib-license toolchain check . \
+            --fail-on FAIL \
+            --report toolchain-report.md \
+            --github-summary "${GITHUB_STEP_SUMMARY}" \
+            "${discovery_args[@]}"
+
+      - name: Generate SPDX SBOM
+        run: >-
+          .license-venv/bin/ov-contrib-license sbom .
+          --source-inventory license-inventory.json
+          --output openvino-contrib.spdx.json
+
+      - name: Upload compliance evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: license-compliance-evidence
+          if-no-files-found: warn
+          path: |
+            license-inventory.json
+            license-report.md
+            tpp-report.md
+            toolchain-report.md
+            openvino-contrib.spdx.json

--- a/.github/workflows/license_compliance.yml
+++ b/.github/workflows/license_compliance.yml
@@ -22,7 +22,7 @@ jobs:
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -80,7 +80,7 @@ jobs:
 
       - name: Upload compliance evidence
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: license-compliance-evidence
           if-no-files-found: warn

--- a/tools/license_compliance/.gitignore
+++ b/tools/license_compliance/.gitignore
@@ -1,0 +1,9 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+__pycache__/
+*.egg-info/
+*.py[cod]
+.pytest_cache/
+build/
+dist/

--- a/tools/license_compliance/README.md
+++ b/tools/license_compliance/README.md
@@ -5,66 +5,180 @@ SPDX-License-Identifier: Apache-2.0
 
 # OpenVINO Contrib License Compliance
 
-`ov-contrib-license` builds a deterministic inventory of third-party software
-entry points in an `openvino_contrib` checkout. It is repository tooling and is
-deliberately independent of the OpenVINO build and runtime.
+`ov-contrib-license` builds a deterministic third-party component inventory,
+imports evidence from FOSS scanners, applies repository-owned policy, reconciles
+third-party notices, emits SPDX, and compares built artifacts with source
+expectations. It is independent of the OpenVINO build and runtime.
 
-This initial implementation is the discovery-only first stage of the compliance
-design. It records evidence and uncertainty; it does not make license
-compatibility decisions. Policy evaluation, provider adapters, TPP
-reconciliation, and artifact verification belong to later reviewable changes.
+The checker is a policy automation tool, not a legal opinion. Unknown evidence
+is preserved as `REVIEW` or `FAIL`; it is never silently treated as compatible.
 
-## Install and run
+## End-to-end quick start
+
+Always install and run the tool in a virtual environment:
 
 ```bash
 python3 -m venv .venv
 .venv/bin/python -m pip install ./tools/license_compliance
-.venv/bin/ov-contrib-license inventory . --output inventory.json
+.venv/bin/python -m unittest discover -s tools/license_compliance/tests -v
 ```
 
-The command has no runtime dependencies outside the Python standard library and
-does not access the network. JSON is the canonical output. A human-readable YAML
-representation is also available:
+Run the same source-policy check used by CI:
 
 ```bash
+.venv/bin/ov-contrib-license check . \
+  --offline \
+  --fail-on FAIL \
+  --inventory-output inventory.json \
+  --report license-report.md
+```
+
+For a PR-sized check, discovery expands changed files to their owning module or
+repository scope:
+
+```bash
+.venv/bin/ov-contrib-license check . \
+  --base-ref origin/master \
+  --head-ref HEAD \
+  --offline \
+  --fail-on FAIL \
+  --inventory-output inventory.json \
+  --report license-report.md
+```
+
+Policy lives under `policy/`. The initial rollout blocks unsuppressed `FAIL`
+findings while leaving insufficient evidence visible as `REVIEW`. Passing
+`--fail-on REVIEW` enables the stricter gate.
+
+## Evidence providers
+
+Repository discovery is built in and offline. Previously generated ORT and
+License Eye JSON can enrich the same canonical inventory:
+
+```bash
+.venv/bin/ov-contrib-license check . \
+  --ort-result ort-result.json \
+  --license-eye-result license-eye-result.json \
+  --inventory-output inventory.json
+```
+
+Provider errors use a distinct infrastructure exit code and cannot become a
+policy pass. ORT and License Eye are optional executables: the core never
+downloads tools or contacts a SaaS backend. Syft can either run locally against
+an explicit artifact or consume a saved result:
+
+```bash
+.venv/bin/ov-contrib-license artifact check build/install \
+  --source-inventory inventory.json \
+  --report artifact-report.md
+
+.venv/bin/ov-contrib-license artifact check build/install \
+  --source-inventory inventory.json \
+  --syft-result syft-result.json
+```
+
+Artifact reconciliation reports undeclared packages, missing expected runtime
+packages, and source/artifact license mismatches. Build-, test-, and dev-only
+dependencies are not expected in runtime artifacts.
+
+## Repository discovery
+
+The inventory command is also available without policy evaluation:
+
+```bash
+.venv/bin/ov-contrib-license inventory . --output inventory.json
 .venv/bin/ov-contrib-license inventory . --format yaml
 ```
 
-For a pull-request-sized inventory, provide both Git revisions. Discovery is
-expanded from changed files to their owning module or repository scope:
-
-```bash
-.venv/bin/ov-contrib-license inventory . \
-  --base-ref origin/master \
-  --head-ref HEAD \
-  --output inventory.json
-```
-
-Additional `--include` and `--exclude` globs may be repeated. Paths are always
-reported relative to the repository root. Canonical JSON contains no timestamps
-and has stable ordering.
-
-## What is discovered
+Discovery covers:
 
 - Python, Node.js, Go, Gradle, Cargo, Conan, Docker, and Git manifests;
 - balanced, multiline CMake dependency commands without evaluating conditions;
 - executable `git clone`, `curl`, `wget`, and remote package-install commands;
 - Git submodules, including their index commit when available;
-- conventional vendored-source directory names, nested license files, and
-  foreign-copyright clusters;
+- vendored-source directories, nested license files, and foreign-copyright clusters;
 - local, container, and repository-backed GitHub Actions.
 
-Unresolved CMake revisions and mutable GitHub Action refs are retained as
-explicit `REVIEW` discovery findings. They are data-quality findings, not legal
-policy verdicts.
+Additional `--include` and `--exclude` globs may be repeated. Canonical output
+uses repository-relative paths, stable ordering, and no timestamps.
 
-## Development
+## Policy, exceptions, and baseline
 
-The offline test suite uses only `unittest`:
+The policy directory contains:
 
-```bash
-.venv/bin/python -m unittest discover -s tools/license_compliance/tests -v
+```text
+licenses.yml     maintainer-approved license classifications
+rules.yml        relationship- and distribution-aware decisions
+obligations.yml  attribution/source obligations
+exceptions.yml   exact, approved, expiring exceptions
+baseline.yml     exact historical finding fingerprints
+toolchain.yml    FOSS provider/action policy and curated license registry
 ```
 
-The project is licensed under Apache-2.0, like the containing repository. See
-the repository root `LICENSE` file.
+Policy evaluates the complete SPDX expression. `OR` alternatives are not
+flattened into simultaneous obligations, while `AND` branches are all applied.
+Exceptions must pin component version/revision, module, relationship,
+distribution, approver, rationale, and expiration. A baseline suppresses only
+the exact fingerprint; changing version, relationship, distribution, module, or
+rule creates a new finding.
+
+Use `explain` with an inventory component or finding ID:
+
+```bash
+.venv/bin/ov-contrib-license explain pkg:pypi/example@1.2.3 \
+  --inventory inventory.json
+```
+
+## TPP and SPDX
+
+`third-party-programs.txt` remains human-reviewed and authoritative. The tool
+checks evidence-driven coverage and can generate a preview without overwriting
+the repository file:
+
+```bash
+.venv/bin/ov-contrib-license tpp check . \
+  --source-inventory inventory.json \
+  --report tpp-report.md
+.venv/bin/ov-contrib-license tpp generate . \
+  --source-inventory inventory.json \
+  --output /tmp/third-party-programs.preview.txt
+```
+
+Generate a deterministic SPDX 2.3 JSON document from the same inventory:
+
+```bash
+.venv/bin/ov-contrib-license sbom . \
+  --source-inventory inventory.json \
+  --format spdx-json \
+  --output openvino-contrib.spdx.json
+```
+
+## Toolchain audit and CI
+
+The self-audit checks immutable GitHub Action pins, curated FOSS licenses,
+direct Python dependencies, and forbidden proprietary decision backends:
+
+```bash
+.venv/bin/ov-contrib-license toolchain check . --fail-on FAIL
+```
+
+`.github/workflows/license_compliance.yml` runs the offline suite and PR
+fast-path, writes the Markdown reports to the GitHub step summary, and uploads
+the canonical inventory, reports, and SPDX output. Artifact checking remains a
+separate command because the compliance module does not build OpenVINO; build
+jobs should pass an existing install tree or package to it.
+
+## Exit codes
+
+```text
+0  no configured blocking findings
+2  unsuppressed policy FAIL
+3  REVIEW is configured as blocking
+4  invalid arguments, policy, or schema
+5  discovery/provider infrastructure failure
+6  unexpected internal error
+```
+
+The direct Python dependencies are PyYAML 6.0.3 (MIT), used to load explicit
+version-controlled policy, and Tomli 2.2.1 (MIT) on Python 3.10. Optional ORT,
+License Eye, and Syft executables are not installed or downloaded by the package.

--- a/tools/license_compliance/README.md
+++ b/tools/license_compliance/README.md
@@ -1,0 +1,70 @@
+<!--
+Copyright (C) 2018-2026 Intel Corporation
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# OpenVINO Contrib License Compliance
+
+`ov-contrib-license` builds a deterministic inventory of third-party software
+entry points in an `openvino_contrib` checkout. It is repository tooling and is
+deliberately independent of the OpenVINO build and runtime.
+
+This initial implementation is the discovery-only first stage of the compliance
+design. It records evidence and uncertainty; it does not make license
+compatibility decisions. Policy evaluation, provider adapters, TPP
+reconciliation, and artifact verification belong to later reviewable changes.
+
+## Install and run
+
+```bash
+python3 -m venv .venv
+.venv/bin/python -m pip install ./tools/license_compliance
+.venv/bin/ov-contrib-license inventory . --output inventory.json
+```
+
+The command has no runtime dependencies outside the Python standard library and
+does not access the network. JSON is the canonical output. A human-readable YAML
+representation is also available:
+
+```bash
+.venv/bin/ov-contrib-license inventory . --format yaml
+```
+
+For a pull-request-sized inventory, provide both Git revisions. Discovery is
+expanded from changed files to their owning module or repository scope:
+
+```bash
+.venv/bin/ov-contrib-license inventory . \
+  --base-ref origin/master \
+  --head-ref HEAD \
+  --output inventory.json
+```
+
+Additional `--include` and `--exclude` globs may be repeated. Paths are always
+reported relative to the repository root. Canonical JSON contains no timestamps
+and has stable ordering.
+
+## What is discovered
+
+- Python, Node.js, Go, Gradle, Cargo, Conan, Docker, and Git manifests;
+- balanced, multiline CMake dependency commands without evaluating conditions;
+- executable `git clone`, `curl`, `wget`, and remote package-install commands;
+- Git submodules, including their index commit when available;
+- conventional vendored-source directory names, nested license files, and
+  foreign-copyright clusters;
+- local, container, and repository-backed GitHub Actions.
+
+Unresolved CMake revisions and mutable GitHub Action refs are retained as
+explicit `REVIEW` discovery findings. They are data-quality findings, not legal
+policy verdicts.
+
+## Development
+
+The offline test suite uses only `unittest`:
+
+```bash
+.venv/bin/python -m unittest discover -s tools/license_compliance/tests -v
+```
+
+The project is licensed under Apache-2.0, like the containing repository. See
+the repository root `LICENSE` file.

--- a/tools/license_compliance/policy/baseline.yml
+++ b/tools/license_compliance/policy/baseline.yml
@@ -1,0 +1,17 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# Only exact finding fingerprints may be listed here. Entries do not approve a license.
+baseline:
+  - finding_fingerprint: sha256:352ce150e14da218d7bb30efb9cf5c9547c4e2c370795586381f3310a0efa159
+    reason: existing vendored-source classification pending evidence review
+  - finding_fingerprint: sha256:58db16e2e17f79ebc7ae4b8134447dc39f06e76511174fb061a1b8f15dc40ab5
+    reason: existing vendored-source classification pending evidence review
+  - finding_fingerprint: sha256:6b94676d218214f25ae542c9c9d59559018278bbb15b1035a80ecadd24424180
+    reason: existing vendored-source classification pending evidence review
+  - finding_fingerprint: sha256:8bff9512641cf84ca8fe910dfd23841fd680954c152751ad82fb400614ccc496
+    reason: existing vendored-source classification pending evidence review
+  - finding_fingerprint: sha256:ad9a48cc63ceb66241df7c98c4c4a1dc56eab4d01b35a90eed37a2290cc39ff8
+    reason: existing vendored-source classification pending evidence review
+  - finding_fingerprint: sha256:e9f064e1ebb9c4fe5a2bb9835d736e361467eb90745705b790047648b3dea621
+    reason: existing vendored-source classification pending evidence review

--- a/tools/license_compliance/policy/exceptions.yml
+++ b/tools/license_compliance/policy/exceptions.yml
@@ -1,0 +1,4 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+exceptions: []

--- a/tools/license_compliance/policy/licenses.yml
+++ b/tools/license_compliance/policy/licenses.yml
@@ -1,0 +1,29 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+classes:
+  permissive:
+    - Apache-2.0
+    - MIT
+    - BSD-2-Clause
+    - BSD-3-Clause
+    - ISC
+    - Zlib
+    - BSL-1.0
+    - Python-2.0
+    - PSF-2.0
+    - Unicode-3.0
+  weak_copyleft:
+    - LGPL-2.1-only
+    - LGPL-2.1-or-later
+    - LGPL-3.0-only
+    - MPL-2.0
+  strong_copyleft:
+    - GPL-2.0-only
+    - GPL-2.0-or-later
+    - GPL-3.0-only
+    - GPL-3.0-or-later
+    - AGPL-3.0-only
+    - AGPL-3.0-or-later
+  unknown:
+    - NOASSERTION

--- a/tools/license_compliance/policy/obligations.yml
+++ b/tools/license_compliance/policy/obligations.yml
@@ -1,0 +1,25 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+classes:
+  permissive:
+    - RETAIN_COPYRIGHT
+    - RETAIN_LICENSE_TEXT
+  weak_copyleft:
+    - RETAIN_COPYRIGHT
+    - RETAIN_LICENSE_TEXT
+    - SEPARATE_LICENSE_TERMS
+    - MANUAL_REVIEW
+  strong_copyleft:
+    - RETAIN_COPYRIGHT
+    - RETAIN_LICENSE_TEXT
+    - PROVIDE_SOURCE
+    - MANUAL_REVIEW
+  unknown:
+    - MANUAL_REVIEW
+licenses:
+  Apache-2.0:
+    - RETAIN_COPYRIGHT
+    - RETAIN_LICENSE_TEXT
+    - RETAIN_NOTICE
+    - MARK_MODIFICATIONS

--- a/tools/license_compliance/policy/rules.yml
+++ b/tools/license_compliance/policy/rules.yml
@@ -1,0 +1,58 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# These are OpenVINO Contrib project-policy inputs, not universal legal conclusions.
+rules:
+  - id: LIC-UNKNOWN-DISTRIBUTED-001
+    when:
+      license_class: unknown
+      distribution: DISTRIBUTED
+    decision: FAIL
+  - id: LIC-UNKNOWN-001
+    when:
+      license_class: unknown
+    decision: REVIEW
+  - id: LIC-STRONG-COPYLEFT-DISTRIBUTED-001
+    when:
+      license_class: strong_copyleft
+      relationship:
+        - STATIC_LINK
+        - VENDORED_SOURCE
+        - BUNDLED_BINARY
+      distribution: DISTRIBUTED
+    decision: FAIL
+  - id: LIC-STRONG-COPYLEFT-BUILD-001
+    when:
+      license_class: strong_copyleft
+      relationship:
+        - BUILD_TOOL
+        - CODE_GENERATOR
+        - TEST_ONLY
+        - DEV_ONLY
+      distribution: NOT_DISTRIBUTED
+    decision: PASS
+  - id: LIC-STRONG-COPYLEFT-001
+    when:
+      license_class: strong_copyleft
+    decision: REVIEW
+  - id: LIC-WEAK-COPYLEFT-BUILD-001
+    when:
+      license_class: weak_copyleft
+      relationship:
+        - BUILD_TOOL
+        - CODE_GENERATOR
+        - TEST_ONLY
+        - DEV_ONLY
+      distribution: NOT_DISTRIBUTED
+    decision: PASS
+  - id: LIC-WEAK-COPYLEFT-001
+    when:
+      license_class: weak_copyleft
+    decision: REVIEW
+  - id: LIC-PERMISSIVE-001
+    when:
+      license_class: permissive
+    decision: PASS
+  - id: LIC-UNCLASSIFIED-001
+    when: {}
+    decision: REVIEW

--- a/tools/license_compliance/policy/toolchain.yml
+++ b/tools/license_compliance/policy/toolchain.yml
@@ -1,0 +1,61 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+allowed_license_classes:
+  - permissive
+allowed_explicit_licenses:
+  - Apache-2.0
+  - MIT
+  - BSD-2-Clause
+  - BSD-3-Clause
+  - ISC
+require_full_sha_for_github_actions: true
+
+# Curated bootstrap registry. Keys identify public source repositories or direct packages.
+actions:
+  actions/checkout: MIT
+  actions/setup-python: MIT
+  actions/setup-go: MIT
+  actions/setup-java: MIT
+  actions/stale: MIT
+  actions/labeler: MIT
+  actions/upload-artifact: MIT
+  actions/download-artifact: MIT
+  actions/cache: MIT
+  github/codeql-action: MIT
+  docker/setup-buildx-action: Apache-2.0
+  docker/login-action: Apache-2.0
+  docker/build-push-action: Apache-2.0
+  dorny/paths-filter: MIT
+  softprops/action-gh-release: MIT
+  axel-op/googlejavaformat-action: MIT
+  bdougie/take-action: MIT
+  crazy-max/ghaction-github-labeler: MIT
+  openvinotoolkit/openvino: Apache-2.0
+
+dependencies:
+  pyyaml: MIT
+  setuptools: MIT
+  tomli: MIT
+
+providers:
+  ort:
+    enabled: false
+    command: ort
+  license_eye:
+    enabled: false
+    command: license-eye
+  syft:
+    enabled: false
+    command: syft
+  scancode:
+    enabled: false
+    command: scancode
+
+forbidden_services:
+  - id: fossa.com
+    reason: proprietary SaaS cannot provide the authoritative verdict
+  - id: snyk.io
+    reason: proprietary SaaS cannot provide the authoritative verdict
+  - id: blackduck
+    reason: proprietary SaaS cannot provide the authoritative verdict

--- a/tools/license_compliance/pyproject.toml
+++ b/tools/license_compliance/pyproject.toml
@@ -1,0 +1,24 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ov-contrib-license"
+version = "0.1.0"
+description = "Deterministic third-party software discovery for OpenVINO contrib"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+authors = [
+  {name = "Intel Corporation"},
+]
+dependencies = []
+
+[project.scripts]
+ov-contrib-license = "ov_contrib_license.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/tools/license_compliance/pyproject.toml
+++ b/tools/license_compliance/pyproject.toml
@@ -7,15 +7,18 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ov-contrib-license"
-version = "0.1.0"
-description = "Deterministic third-party software discovery for OpenVINO contrib"
+version = "0.2.0"
+description = "Reproducible license compliance checks for OpenVINO contrib"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "Apache-2.0"
 authors = [
   {name = "Intel Corporation"},
 ]
-dependencies = []
+dependencies = [
+  "PyYAML==6.0.3",
+  "tomli==2.2.1; python_version < '3.11'",
+]
 
 [project.scripts]
 ov-contrib-license = "ov_contrib_license.cli:main"

--- a/tools/license_compliance/schemas/inventory.schema.json
+++ b/tools/license_compliance/schemas/inventory.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openvinotoolkit.org/schemas/openvino-contrib-license-inventory-v1.json",
+  "title": "OpenVINO Contrib license discovery inventory",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "repository",
+    "components",
+    "discoveries",
+    "findings",
+    "providers"
+  ],
+  "properties": {
+    "schema_version": {"const": 1},
+    "repository": {
+      "type": "object",
+      "required": ["path", "revision", "base_ref", "head_ref", "impacted_scopes"],
+      "properties": {
+        "path": {"type": "string"},
+        "revision": {"type": ["string", "null"]},
+        "base_ref": {"type": ["string", "null"]},
+        "head_ref": {"type": ["string", "null"]},
+        "impacted_scopes": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+    "components": {"type": "array", "items": {"$ref": "#/$defs/component"}},
+    "discoveries": {"type": "array", "items": {"$ref": "#/$defs/discovery"}},
+    "findings": {"type": "array", "items": {"$ref": "#/$defs/finding"}},
+    "providers": {"type": "array", "items": {"$ref": "#/$defs/provider"}}
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "evidence": {
+      "type": "object",
+      "required": ["kind", "source", "path", "value", "confidence", "details"],
+      "properties": {
+        "kind": {"type": "string"},
+        "source": {"type": "string"},
+        "path": {"type": ["string", "null"]},
+        "value": {"type": ["string", "null"]},
+        "confidence": {"enum": ["HIGH", "MEDIUM", "LOW"]},
+        "details": {"type": "object", "additionalProperties": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+    "component": {
+      "type": "object",
+      "required": [
+        "id", "name", "version", "module", "paths", "declared_license",
+        "detected_licenses", "relationships", "evidence", "distribution", "details"
+      ],
+      "properties": {
+        "id": {"type": "string"},
+        "name": {"type": "string"},
+        "version": {"type": ["string", "null"]},
+        "module": {"type": ["string", "null"]},
+        "paths": {"type": "array", "items": {"type": "string"}},
+        "declared_license": {"type": ["string", "null"]},
+        "detected_licenses": {"type": "array", "items": {"type": "string"}},
+        "relationships": {"type": "array", "items": {"type": "string"}},
+        "evidence": {"type": "array", "items": {"$ref": "#/$defs/evidence"}},
+        "distribution": {"enum": ["DISTRIBUTED", "NOT_DISTRIBUTED", "UNKNOWN"]},
+        "details": {"type": "object", "additionalProperties": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+    "discovery": {
+      "type": "object",
+      "required": ["kind", "path", "module", "ecosystem", "details"],
+      "properties": {
+        "kind": {"type": "string"},
+        "path": {"type": "string"},
+        "module": {"type": ["string", "null"]},
+        "ecosystem": {"type": ["string", "null"]},
+        "details": {"type": "object", "additionalProperties": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+    "finding": {
+      "type": "object",
+      "required": [
+        "id", "code", "severity", "decision", "component_id", "message",
+        "evidence", "remediation"
+      ],
+      "properties": {
+        "id": {"type": "string"},
+        "code": {"type": "string"},
+        "severity": {"enum": ["INFO", "WARNING", "ERROR"]},
+        "decision": {"enum": ["PASS", "REVIEW", "FAIL"]},
+        "component_id": {"type": ["string", "null"]},
+        "message": {"type": "string"},
+        "evidence": {"type": "array", "items": {"$ref": "#/$defs/evidence"}},
+        "remediation": {"type": "array", "items": {"type": "string"}}
+      },
+      "additionalProperties": false
+    },
+    "provider": {
+      "type": "object",
+      "required": ["name", "version", "status"],
+      "properties": {
+        "name": {"type": "string"},
+        "version": {"type": "string"},
+        "status": {"enum": ["SUCCESS", "FAILED", "SKIPPED"]}
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/tools/license_compliance/schemas/inventory.schema.json
+++ b/tools/license_compliance/schemas/inventory.schema.json
@@ -49,7 +49,7 @@
       "type": "object",
       "required": [
         "id", "name", "version", "module", "paths", "declared_license",
-        "detected_licenses", "relationships", "evidence", "distribution", "details"
+        "detected_licenses", "relationships", "evidence", "distribution", "obligations", "details"
       ],
       "properties": {
         "id": {"type": "string"},
@@ -62,6 +62,16 @@
         "relationships": {"type": "array", "items": {"type": "string"}},
         "evidence": {"type": "array", "items": {"$ref": "#/$defs/evidence"}},
         "distribution": {"enum": ["DISTRIBUTED", "NOT_DISTRIBUTED", "UNKNOWN"]},
+        "obligations": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "RETAIN_COPYRIGHT", "RETAIN_LICENSE_TEXT", "RETAIN_NOTICE",
+              "MARK_MODIFICATIONS", "PROVIDE_SOURCE", "PROVIDE_SOURCE_OFFER",
+              "SEPARATE_LICENSE_TERMS", "NO_TRADEDOWN", "MANUAL_REVIEW"
+            ]
+          }
+        },
         "details": {"type": "object", "additionalProperties": {"type": "string"}}
       },
       "additionalProperties": false
@@ -82,7 +92,7 @@
       "type": "object",
       "required": [
         "id", "code", "severity", "decision", "component_id", "message",
-        "evidence", "remediation"
+        "evidence", "remediation", "suppressed", "suppression_reason"
       ],
       "properties": {
         "id": {"type": "string"},
@@ -92,7 +102,9 @@
         "component_id": {"type": ["string", "null"]},
         "message": {"type": "string"},
         "evidence": {"type": "array", "items": {"$ref": "#/$defs/evidence"}},
-        "remediation": {"type": "array", "items": {"type": "string"}}
+        "remediation": {"type": "array", "items": {"type": "string"}},
+        "suppressed": {"type": "boolean"},
+        "suppression_reason": {"type": ["string", "null"]}
       },
       "additionalProperties": false
     },

--- a/tools/license_compliance/src/ov_contrib_license/__init__.py
+++ b/tools/license_compliance/src/ov_contrib_license/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenVINO contrib license discovery package."""
+
+__version__ = "0.1.0"

--- a/tools/license_compliance/src/ov_contrib_license/__init__.py
+++ b/tools/license_compliance/src/ov_contrib_license/__init__.py
@@ -3,4 +3,4 @@
 
 """OpenVINO contrib license discovery package."""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"

--- a/tools/license_compliance/src/ov_contrib_license/__main__.py
+++ b/tools/license_compliance/src/ov_contrib_license/__main__.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from .cli import main
+
+raise SystemExit(main())

--- a/tools/license_compliance/src/ov_contrib_license/adapters/__init__.py
+++ b/tools/license_compliance/src/ov_contrib_license/adapters/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from .license_eye import import_license_eye
+from .ort import import_ort
+from .syft import import_syft, run_syft
+
+__all__ = ["import_license_eye", "import_ort", "import_syft", "run_syft"]

--- a/tools/license_compliance/src/ov_contrib_license/adapters/common.py
+++ b/tools/license_compliance/src/ov_contrib_license/adapters/common.py
@@ -1,0 +1,26 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+class ProviderError(RuntimeError):
+    pass
+
+
+def read_json(path: Path, provider: str) -> dict[str, Any]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise ProviderError(
+            f"Unable to read {provider} result {path}: {error}"
+        ) from error
+    except json.JSONDecodeError as error:
+        raise ProviderError(f"Invalid {provider} JSON in {path}: {error}") from error
+    if not isinstance(data, dict):
+        raise ProviderError(f"{provider} result must contain a JSON object")
+    return data

--- a/tools/license_compliance/src/ov_contrib_license/adapters/license_eye.py
+++ b/tools/license_compliance/src/ov_contrib_license/adapters/license_eye.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ov_contrib_license.model import (
+    Decision,
+    Evidence,
+    EvidenceKind,
+    Finding,
+    Inventory,
+    InventoryBuilder,
+    Provider,
+    Severity,
+)
+
+from .common import ProviderError, read_json
+
+
+def _paths(value: Any) -> tuple[str, ...]:
+    if isinstance(value, int):
+        return tuple(f"<count:{value}>" for _ in range(1 if value else 0))
+    if not isinstance(value, list):
+        return ()
+    result: list[str] = []
+    for item in value:
+        if isinstance(item, str):
+            result.append(item)
+        elif isinstance(item, dict) and item.get("path"):
+            result.append(str(item["path"]))
+    return tuple(sorted(set(result)))
+
+
+def import_license_eye(inventory: Inventory, path: Path) -> Inventory:
+    data = read_json(path, "License Eye")
+    summary = data.get("header", data)
+    if not isinstance(summary, dict):
+        raise ProviderError("License Eye result does not contain a header summary")
+    builder = InventoryBuilder.from_inventory(inventory)
+    invalid = _paths(summary.get("invalid"))
+    ignored = _paths(summary.get("ignored"))
+    if invalid:
+        evidence = tuple(
+            Evidence(EvidenceKind.SPDX_HEADER, "license-eye", item, "invalid")
+            for item in invalid
+        )
+        builder.add_finding(
+            Finding.create(
+                code="HEADER_INVALID",
+                severity=Severity.ERROR,
+                decision=Decision.FAIL,
+                component_id=None,
+                message=f"License Eye reported {len(invalid)} invalid header path(s).",
+                evidence=evidence,
+                remediation=(
+                    "Add an approved first-party header or a reviewed exclusion.",
+                ),
+            )
+        )
+    if ignored:
+        evidence = tuple(
+            Evidence(EvidenceKind.SPDX_HEADER, "license-eye", item, "ignored")
+            for item in ignored
+        )
+        builder.add_finding(
+            Finding.create(
+                code="HEADER_IGNORED_PATHS",
+                severity=Severity.WARNING,
+                decision=Decision.REVIEW,
+                component_id=None,
+                message=f"License Eye ignored {len(ignored)} path(s); ignored content is not auto-approved.",
+                evidence=evidence,
+                remediation=(
+                    "Audit broad ignores and classify embedded third-party content separately.",
+                ),
+            )
+        )
+    builder.add_provider(
+        Provider("license-eye", str(data.get("version", "unknown")), "SUCCESS")
+    )
+    return builder.build()

--- a/tools/license_compliance/src/ov_contrib_license/adapters/ort.py
+++ b/tools/license_compliance/src/ov_contrib_license/adapters/ort.py
@@ -1,0 +1,120 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+from ov_contrib_license.model import (
+    Component,
+    Confidence,
+    DistributionStatus,
+    Evidence,
+    EvidenceKind,
+    Inventory,
+    InventoryBuilder,
+    Provider,
+    Relationship,
+)
+from ov_contrib_license.model.types import normalize_details
+
+from .common import ProviderError, read_json
+
+
+def _identifier(value: Any) -> tuple[str, str, str, str]:
+    if isinstance(value, dict):
+        return (
+            str(value.get("type", "Generic")),
+            str(value.get("namespace", "")),
+            str(value.get("name", "unknown")),
+            str(value.get("version", "")),
+        )
+    if isinstance(value, str):
+        parts = value.split(":")
+        if len(parts) >= 4:
+            return parts[0], parts[1], parts[2], ":".join(parts[3:])
+    raise ProviderError(f"ORT package has an invalid identifier: {value!r}")
+
+
+def _purl(item: dict[str, Any], identifier: tuple[str, str, str, str]) -> str:
+    value = item.get("purl")
+    if isinstance(value, str) and value.startswith("pkg:"):
+        return value
+    package_type, namespace, name, version = identifier
+    ecosystem = {
+        "PyPI": "pypi",
+        "NPM": "npm",
+        "Maven": "maven",
+        "Gradle": "maven",
+        "GoMod": "golang",
+        "Cargo": "cargo",
+        "Conan": "conan",
+    }.get(package_type, "generic")
+    identity = "/".join(filter(None, (namespace, name)))
+    result = f"pkg:{ecosystem}/{quote(identity, safe='/.-_')}"
+    return result + (f"@{quote(version, safe='.-_+')}" if version else "")
+
+
+def _license(item: dict[str, Any]) -> str | None:
+    processed = item.get("declared_licenses_processed")
+    if isinstance(processed, dict):
+        expression = processed.get("spdx_expression")
+        if isinstance(expression, str) and expression:
+            return expression
+    values = item.get("declared_licenses")
+    if isinstance(values, list):
+        licenses = sorted({str(value) for value in values if value})
+        if licenses:
+            return " AND ".join(licenses)
+    return None
+
+
+def _packages(data: dict[str, Any]) -> list[dict[str, Any]]:
+    analyzer = data.get("analyzer", data)
+    if isinstance(analyzer, dict):
+        analyzer = analyzer.get("result", analyzer)
+    packages = analyzer.get("packages", ()) if isinstance(analyzer, dict) else ()
+    if not isinstance(packages, list):
+        raise ProviderError("ORT result does not contain analyzer.result.packages")
+    return [item for item in packages if isinstance(item, dict)]
+
+
+def import_ort(inventory: Inventory, path: Path) -> Inventory:
+    data = read_json(path, "ORT")
+    builder = InventoryBuilder.from_inventory(inventory)
+    for item in _packages(data):
+        identifier = _identifier(item.get("id"))
+        component_id = _purl(item, identifier)
+        package_type, namespace, name, version = identifier
+        evidence = Evidence(
+            kind=EvidenceKind.ORT,
+            source="ort-analyzer",
+            value=component_id,
+            confidence=Confidence.HIGH,
+            details=normalize_details(
+                {
+                    "package_type": package_type,
+                    "namespace": namespace,
+                    "source": item.get("source_artifact", {}).get("url")
+                    if isinstance(item.get("source_artifact"), dict)
+                    else None,
+                }
+            ),
+        )
+        builder.add_component(
+            Component(
+                id=component_id,
+                name=name,
+                version=version or None,
+                declared_license=_license(item),
+                relationships=(Relationship.RUNTIME_DEPENDENCY,),
+                evidence=(evidence,),
+                distribution=DistributionStatus.UNKNOWN,
+                details=normalize_details({"namespace": namespace, "provider": "ort"}),
+            )
+        )
+    version = str(data.get("ort_version") or data.get("version") or "unknown")
+    builder.add_provider(Provider("ort", version, "SUCCESS"))
+    return builder.build()

--- a/tools/license_compliance/src/ov_contrib_license/adapters/syft.py
+++ b/tools/license_compliance/src/ov_contrib_license/adapters/syft.py
@@ -1,0 +1,202 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+from ov_contrib_license.model import (
+    Component,
+    Confidence,
+    DistributionStatus,
+    Evidence,
+    EvidenceKind,
+    Inventory,
+    InventoryBuilder,
+    Provider,
+    Relationship,
+)
+from ov_contrib_license.model.types import normalize_details
+
+from .common import ProviderError, read_json
+
+
+def _license(values: Any) -> str | None:
+    if isinstance(values, str):
+        return values if values and values != "NOASSERTION" else None
+    if not isinstance(values, list):
+        return None
+    result: set[str] = set()
+    for item in values:
+        if isinstance(item, str):
+            result.add(item)
+        elif isinstance(item, dict):
+            value = item.get("spdxExpression") or item.get("value")
+            if value:
+                result.add(str(value))
+    return " AND ".join(sorted(result)) if result else None
+
+
+def _native_components(data: dict[str, Any]) -> tuple[Component, ...]:
+    artifacts = data.get("artifacts", ())
+    if not isinstance(artifacts, list):
+        raise ProviderError("Syft result does not contain an artifacts list")
+    result: list[Component] = []
+    for item in artifacts:
+        if not isinstance(item, dict) or not item.get("name"):
+            continue
+        name = str(item["name"])
+        version = str(item.get("version") or "")
+        purl = item.get("purl")
+        component_id = (
+            str(purl)
+            if isinstance(purl, str) and purl.startswith("pkg:")
+            else f"pkg:generic/{quote(name.lower(), safe='.-_')}"
+            + (f"@{quote(version, safe='.-_+')}" if version else "")
+        )
+        paths = tuple(
+            sorted(
+                {
+                    str(location.get("path", "")).lstrip("/")
+                    for location in item.get("locations", ())
+                    if isinstance(location, dict) and location.get("path")
+                }
+            )
+        )
+        evidence = Evidence(
+            EvidenceKind.ARTIFACT_SBOM,
+            "syft",
+            paths[0] if paths else None,
+            component_id,
+            Confidence.HIGH,
+            normalize_details({"syft_id": item.get("id"), "type": item.get("type")}),
+        )
+        result.append(
+            Component(
+                id=component_id,
+                name=name,
+                version=version or None,
+                paths=paths,
+                declared_license=_license(item.get("licenses")),
+                relationships=(Relationship.BUNDLED_BINARY,),
+                evidence=(evidence,),
+                distribution=DistributionStatus.DISTRIBUTED,
+                details=normalize_details(
+                    {"artifact_scope": "runtime-package", "provider": "syft"}
+                ),
+            )
+        )
+    return tuple(result)
+
+
+def _spdx_components(data: dict[str, Any]) -> tuple[Component, ...]:
+    packages = data.get("packages", ())
+    if not isinstance(packages, list):
+        raise ProviderError("SPDX result does not contain a packages list")
+    result: list[Component] = []
+    for item in packages:
+        if not isinstance(item, dict) or not item.get("name"):
+            continue
+        name = str(item["name"])
+        version = str(item.get("versionInfo") or "")
+        refs = item.get("externalRefs", ())
+        purl = next(
+            (
+                str(ref.get("referenceLocator"))
+                for ref in refs
+                if isinstance(ref, dict)
+                and str(ref.get("referenceType", "")).lower() == "purl"
+            ),
+            None,
+        )
+        component_id = purl or f"pkg:generic/{quote(name.lower(), safe='.-_')}" + (
+            f"@{quote(version, safe='.-_+')}" if version else ""
+        )
+        evidence = Evidence(
+            EvidenceKind.ARTIFACT_SBOM,
+            "syft-spdx",
+            value=component_id,
+            confidence=Confidence.HIGH,
+        )
+        result.append(
+            Component(
+                id=component_id,
+                name=name,
+                version=version or None,
+                declared_license=_license(item.get("licenseDeclared")),
+                detected_licenses=tuple(
+                    value
+                    for value in (_license(item.get("licenseConcluded")),)
+                    if value
+                ),
+                relationships=(Relationship.BUNDLED_BINARY,),
+                evidence=(evidence,),
+                distribution=DistributionStatus.DISTRIBUTED,
+                details=normalize_details(
+                    {"artifact_scope": "runtime-package", "provider": "syft"}
+                ),
+            )
+        )
+    return tuple(result)
+
+
+def import_syft(path: Path) -> Inventory:
+    data = read_json(path, "Syft")
+    from ov_contrib_license.model import RepositoryInfo
+
+    builder = InventoryBuilder(RepositoryInfo("artifact", None))
+    components = (
+        _native_components(data) if "artifacts" in data else _spdx_components(data)
+    )
+    for component in components:
+        builder.add_component(component)
+    descriptor = data.get("descriptor", {})
+    version = (
+        str(descriptor.get("version", "unknown"))
+        if isinstance(descriptor, dict)
+        else "unknown"
+    )
+    builder.add_provider(Provider("syft", version, "SUCCESS"))
+    return builder.build()
+
+
+def run_syft(artifact: Path, command: str = "syft") -> Inventory:
+    try:
+        result = subprocess.run(
+            [command, str(artifact), "-o", "syft-json"],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+    except OSError as error:
+        raise ProviderError(
+            f"Unable to execute Syft command {command!r}: {error}"
+        ) from error
+    if result.returncode:
+        reason = result.stderr.strip() or f"exit status {result.returncode}"
+        raise ProviderError(f"Syft failed: {reason}")
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as error:
+        raise ProviderError(f"Syft returned invalid JSON: {error}") from error
+    if not isinstance(data, dict):
+        raise ProviderError("Syft returned a non-object JSON document")
+    components = _native_components(data)
+    from ov_contrib_license.model import RepositoryInfo
+
+    builder = InventoryBuilder(RepositoryInfo(str(artifact), None))
+    for component in components:
+        builder.add_component(component)
+    descriptor = data.get("descriptor", {})
+    version = (
+        str(descriptor.get("version", "unknown"))
+        if isinstance(descriptor, dict)
+        else "unknown"
+    )
+    builder.add_provider(Provider("syft", version, "SUCCESS"))
+    return builder.build()

--- a/tools/license_compliance/src/ov_contrib_license/cli.py
+++ b/tools/license_compliance/src/ov_contrib_license/cli.py
@@ -6,13 +6,47 @@ from __future__ import annotations
 import argparse
 import sys
 from collections.abc import Sequence
+from dataclasses import replace
 from pathlib import Path
 
+from ov_contrib_license.adapters import (
+    import_license_eye,
+    import_ort,
+    import_syft,
+    run_syft,
+)
+from ov_contrib_license.adapters.common import ProviderError
 from ov_contrib_license.discovery import DiscoveryOptions, RepositoryDiscovery
 from ov_contrib_license.discovery.repository import DiscoveryError
-from ov_contrib_license.reporters import write_inventory
+from ov_contrib_license.model import (
+    Decision,
+    Inventory,
+    InventoryBuilder,
+    Provider,
+    read_inventory,
+)
+from ov_contrib_license.policy import (
+    apply_baseline,
+    evaluate_inventory,
+    load_baseline,
+    load_policy,
+)
+from ov_contrib_license.reconciliation import (
+    generate_tpp_preview,
+    reconcile_artifact,
+    reconcile_tpp,
+)
+from ov_contrib_license.reporters import (
+    render_inventory,
+    render_markdown,
+    render_spdx,
+    write_inventory,
+)
+from ov_contrib_license.toolchain import audit_toolchain
 
 EXIT_SUCCESS = 0
+EXIT_POLICY_FAIL = 2
+EXIT_REVIEW_BLOCKING = 3
 EXIT_CONFIGURATION_ERROR = 4
 EXIT_DISCOVERY_ERROR = 5
 EXIT_INTERNAL_ERROR = 6
@@ -27,36 +61,405 @@ class ArgumentParser(argparse.ArgumentParser):
         raise ConfigurationError(message)
 
 
+def _add_discovery_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--base-ref", help="base Git revision for incremental discovery"
+    )
+    parser.add_argument(
+        "--head-ref", help="head Git revision for incremental discovery"
+    )
+    parser.add_argument(
+        "--offline", action="store_true", help="forbid network providers"
+    )
+    parser.add_argument("--include", action="append", default=[], metavar="GLOB")
+    parser.add_argument("--exclude", action="append", default=[], metavar="GLOB")
+
+
+def _add_policy_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--policy-dir", type=Path, help="policy directory")
+    parser.add_argument("--baseline", type=Path, help="override baseline YAML")
+
+
+def _add_provider_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--ort-result", type=Path, help="import a previously generated ORT JSON result"
+    )
+    parser.add_argument(
+        "--license-eye-result",
+        type=Path,
+        help="import a previously generated License Eye JSON result",
+    )
+
+
+def _add_report_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--report", type=Path, help="write the compliance report")
+    parser.add_argument(
+        "--report-format", choices=("markdown", "json"), default="markdown"
+    )
+    parser.add_argument(
+        "--inventory-output", type=Path, help="write the canonical evaluated inventory"
+    )
+    parser.add_argument(
+        "--github-summary",
+        type=Path,
+        help="append the Markdown report to a GitHub step-summary file",
+    )
+    parser.add_argument("--fail-on", choices=("REVIEW", "FAIL"), default="FAIL")
+
+
 def build_parser() -> argparse.ArgumentParser:
-    parser = ArgumentParser(prog="ov-contrib-license", description="OpenVINO contrib license discovery")
-    subparsers = parser.add_subparsers(dest="command", required=True, parser_class=ArgumentParser)
-    inventory = subparsers.add_parser("inventory", help="build a deterministic repository inventory")
-    inventory.add_argument(
-        "path", nargs="?", default=".", help="repository path (default: current directory)"
+    parser = ArgumentParser(
+        prog="ov-contrib-license",
+        description="OpenVINO contrib license compliance",
     )
-    inventory.add_argument("--output", type=Path, help="write the inventory to this file")
-    inventory.add_argument("--format", dest="output_format", choices=("json", "yaml"), default="json")
-    inventory.add_argument("--base-ref", help="base Git revision for incremental discovery")
-    inventory.add_argument("--head-ref", help="head Git revision for incremental discovery")
-    inventory.add_argument(
-        "--offline", action="store_true", help="forbid network providers (discovery is offline)"
+    subparsers = parser.add_subparsers(
+        dest="command", required=True, parser_class=ArgumentParser
     )
-    inventory.add_argument("--include", action="append", default=[], metavar="GLOB")
-    inventory.add_argument("--exclude", action="append", default=[], metavar="GLOB")
+
+    inventory = subparsers.add_parser(
+        "inventory", help="build a deterministic repository inventory"
+    )
+    inventory.add_argument("path", nargs="?", default=".", help="repository path")
+    inventory.add_argument(
+        "--output", type=Path, help="write the inventory to this file"
+    )
+    inventory.add_argument(
+        "--format", dest="output_format", choices=("json", "yaml"), default="json"
+    )
+    _add_discovery_options(inventory)
+
+    check = subparsers.add_parser(
+        "check", help="evaluate repository components against policy"
+    )
+    check.add_argument("path", nargs="?", default=".", help="repository path")
+    _add_discovery_options(check)
+    _add_policy_options(check)
+    _add_provider_options(check)
+    _add_report_options(check)
+
+    explain = subparsers.add_parser("explain", help="explain a component or finding")
+    explain.add_argument("identifier")
+    explain.add_argument("--path", default=".", help="repository path")
+    explain.add_argument(
+        "--inventory", type=Path, help="read an existing evaluated inventory"
+    )
+    _add_policy_options(explain)
+    _add_provider_options(explain)
+
+    tpp = subparsers.add_parser("tpp", help="reconcile third-party-programs.txt")
+    tpp_commands = tpp.add_subparsers(
+        dest="tpp_command", required=True, parser_class=ArgumentParser
+    )
+    tpp_check = tpp_commands.add_parser("check", help="check TPP coverage")
+    tpp_check.add_argument("path", nargs="?", default=".", help="repository path")
+    tpp_check.add_argument("--source-inventory", type=Path)
+    tpp_check.add_argument("--tpp-file", type=Path, help="third-party programs file")
+    _add_discovery_options(tpp_check)
+    _add_policy_options(tpp_check)
+    _add_provider_options(tpp_check)
+    _add_report_options(tpp_check)
+    tpp_generate = tpp_commands.add_parser(
+        "generate", help="generate a non-authoritative TPP preview"
+    )
+    tpp_generate.add_argument("path", nargs="?", default=".", help="repository path")
+    tpp_generate.add_argument("--source-inventory", type=Path)
+    tpp_generate.add_argument("--tpp-file", type=Path)
+    tpp_generate.add_argument("--output", type=Path, required=True)
+    _add_policy_options(tpp_generate)
+
+    sbom = subparsers.add_parser("sbom", help="generate a deterministic SPDX SBOM")
+    sbom.add_argument("path", nargs="?", default=".", help="repository path")
+    sbom.add_argument("--source-inventory", type=Path)
+    sbom.add_argument("--format", choices=("spdx-json",), default="spdx-json")
+    sbom.add_argument("--output", type=Path, required=True)
+    _add_policy_options(sbom)
+    _add_discovery_options(sbom)
+    _add_provider_options(sbom)
+
+    artifact = subparsers.add_parser(
+        "artifact", help="verify a built artifact using Syft"
+    )
+    artifact_commands = artifact.add_subparsers(
+        dest="artifact_command", required=True, parser_class=ArgumentParser
+    )
+    artifact_check = artifact_commands.add_parser(
+        "check", help="reconcile artifact and source inventories"
+    )
+    artifact_check.add_argument("path", type=Path, help="install tree or package path")
+    artifact_check.add_argument("--source-inventory", type=Path, required=True)
+    artifact_check.add_argument(
+        "--syft-result", type=Path, help="read Syft JSON instead of executing Syft"
+    )
+    _add_policy_options(artifact_check)
+    _add_report_options(artifact_check)
+
+    toolchain = subparsers.add_parser(
+        "toolchain", help="audit compliance tooling and GitHub Actions"
+    )
+    toolchain_commands = toolchain.add_subparsers(
+        dest="toolchain_command", required=True, parser_class=ArgumentParser
+    )
+    toolchain_check = toolchain_commands.add_parser(
+        "check", help="run the toolchain audit"
+    )
+    toolchain_check.add_argument("path", nargs="?", default=".", help="repository path")
+    _add_discovery_options(toolchain_check)
+    _add_policy_options(toolchain_check)
+    _add_report_options(toolchain_check)
     return parser
 
 
-def _run_inventory(arguments: argparse.Namespace) -> int:
-    options = DiscoveryOptions(
-        base_ref=arguments.base_ref,
-        head_ref=arguments.head_ref,
-        includes=tuple(arguments.include),
-        excludes=tuple(arguments.exclude),
-        offline=arguments.offline,
+def _options(arguments: argparse.Namespace) -> DiscoveryOptions:
+    return DiscoveryOptions(
+        base_ref=getattr(arguments, "base_ref", None),
+        head_ref=getattr(arguments, "head_ref", None),
+        includes=tuple(getattr(arguments, "include", ())),
+        excludes=tuple(getattr(arguments, "exclude", ())),
+        offline=bool(getattr(arguments, "offline", False)),
     )
-    inventory = RepositoryDiscovery(Path(arguments.path), options).run()
+
+
+def _discover(path: str | Path, arguments: argparse.Namespace) -> Inventory:
+    return RepositoryDiscovery(Path(path), _options(arguments)).run()
+
+
+def _default_policy_dir(root: Path) -> Path:
+    repository_policy = root / "tools" / "license_compliance" / "policy"
+    if repository_policy.is_dir():
+        return repository_policy
+    return Path(__file__).resolve().parents[2] / "policy"
+
+
+def _config(arguments: argparse.Namespace, root: Path):
+    config = load_policy(arguments.policy_dir or _default_policy_dir(root))
+    baseline_path = getattr(arguments, "baseline", None)
+    if baseline_path:
+        config = replace(config, baseline=load_baseline(baseline_path))
+    return config
+
+
+def _providers(
+    inventory: Inventory, arguments: argparse.Namespace, config
+) -> Inventory:
+    ort_result = getattr(arguments, "ort_result", None)
+    license_eye_result = getattr(arguments, "license_eye_result", None)
+    if ort_result:
+        inventory = import_ort(inventory, ort_result)
+    if license_eye_result:
+        inventory = import_license_eye(inventory, license_eye_result)
+    builder = InventoryBuilder.from_inventory(inventory)
+    present = {item.name for item in inventory.providers}
+    for policy_name, provider_name in (("ort", "ort"), ("license_eye", "license-eye")):
+        if provider_name in present:
+            continue
+        provider_config = config.providers.get(policy_name, {})
+        version = (
+            str(provider_config.get("version", "not-run"))
+            if isinstance(provider_config, dict)
+            else "not-run"
+        )
+        builder.add_provider(Provider(provider_name, version, "SKIPPED"))
+    inventory = builder.build()
+    return inventory
+
+
+def _evaluated(root: Path, arguments: argparse.Namespace):
+    config = _config(arguments, root)
+    inventory = _providers(_discover(root, arguments), arguments, config)
+    return evaluate_inventory(inventory, config).inventory, config
+
+
+def _active_decisions(inventory: Inventory) -> tuple[int, int]:
+    active = [item for item in inventory.findings if not item.suppressed]
+    return (
+        sum(item.decision is Decision.FAIL for item in active),
+        sum(item.decision is Decision.REVIEW for item in active),
+    )
+
+
+def _exit_code(inventory: Inventory, fail_on: str) -> int:
+    failures, reviews = _active_decisions(inventory)
+    if failures:
+        return EXIT_POLICY_FAIL
+    if reviews and fail_on == "REVIEW":
+        return EXIT_REVIEW_BLOCKING
+    return EXIT_SUCCESS
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _report(
+    inventory: Inventory,
+    arguments: argparse.Namespace,
+    *,
+    title: str = "License Compliance",
+) -> None:
+    markdown = render_markdown(inventory, title)
+    output_format = getattr(arguments, "report_format", "markdown")
+    rendered = render_inventory(inventory) if output_format == "json" else markdown
+    report_path = getattr(arguments, "report", None)
+    if report_path:
+        _write_text(report_path, rendered)
+    else:
+        print(rendered, end="")
+    inventory_output = getattr(arguments, "inventory_output", None)
+    if inventory_output:
+        write_inventory(inventory, inventory_output)
+    summary_path = getattr(arguments, "github_summary", None)
+    if summary_path:
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        with summary_path.open("a", encoding="utf-8") as summary:
+            summary.write(markdown)
+
+
+def _run_inventory(arguments: argparse.Namespace) -> int:
+    inventory = _discover(arguments.path, arguments)
     write_inventory(inventory, arguments.output, arguments.output_format)
     return EXIT_SUCCESS
+
+
+def _run_check(arguments: argparse.Namespace) -> int:
+    root = Path(arguments.path).resolve()
+    inventory, _ = _evaluated(root, arguments)
+    _report(inventory, arguments)
+    return _exit_code(inventory, arguments.fail_on)
+
+
+def _run_explain(arguments: argparse.Namespace) -> int:
+    root = Path(arguments.path).resolve()
+    inventory = (
+        read_inventory(arguments.inventory)
+        if arguments.inventory
+        else _evaluated(root, arguments)[0]
+    )
+    component = next(
+        (item for item in inventory.components if item.id == arguments.identifier), None
+    )
+    finding = next(
+        (item for item in inventory.findings if item.id == arguments.identifier), None
+    )
+    if finding and component is None and finding.component_id:
+        component = next(
+            (item for item in inventory.components if item.id == finding.component_id),
+            None,
+        )
+    related = [
+        item
+        for item in inventory.findings
+        if item.id == arguments.identifier
+        or (component and item.component_id == component.id)
+    ]
+    if component is None and finding is None:
+        raise ConfigurationError(
+            f"No component or finding matches {arguments.identifier!r}"
+        )
+    lines: list[str] = []
+    if component:
+        lines.extend(
+            (
+                f"Component: {component.id}",
+                f"Name: {component.name}",
+                f"Version: {component.version or 'unknown'}",
+                f"Module: {component.module or 'repository'}",
+                f"License: {component.declared_license or 'NOASSERTION'}",
+                f"Relationship: {', '.join(item.value for item in component.relationships)}",
+                f"Distribution: {component.distribution.value}",
+                f"Obligations: {', '.join(item.value for item in component.obligations) or 'none'}",
+            )
+        )
+    for item in related:
+        lines.extend(
+            (
+                "",
+                f"Finding: {item.id}",
+                f"Code: {item.code}",
+                f"Decision: {item.decision.value}",
+                f"Suppressed: {'yes' if item.suppressed else 'no'}",
+                f"Reason: {item.message}",
+            )
+        )
+    print("\n".join(lines).rstrip())
+    return EXIT_SUCCESS
+
+
+def _run_tpp_check(arguments: argparse.Namespace) -> int:
+    root = Path(arguments.path).resolve()
+    if arguments.source_inventory:
+        config = _config(arguments, root)
+        source = read_inventory(arguments.source_inventory)
+        source = replace(
+            source,
+            findings=tuple(
+                item for item in source.findings if not item.code.startswith("POLICY_")
+            ),
+        )
+        inventory = evaluate_inventory(source, config).inventory
+    else:
+        inventory, config = _evaluated(root, arguments)
+    tpp_path = arguments.tpp_file or root / "third-party-programs.txt"
+    inventory = apply_baseline(reconcile_tpp(inventory, tpp_path), config)
+    _report(inventory, arguments, title="Third-Party Programs Reconciliation")
+    return _exit_code(inventory, arguments.fail_on)
+
+
+def _run_tpp_generate(arguments: argparse.Namespace) -> int:
+    root = Path(arguments.path).resolve()
+    inventory = (
+        read_inventory(arguments.source_inventory)
+        if arguments.source_inventory
+        else _evaluated(root, arguments)[0]
+    )
+    existing = arguments.tpp_file or root / "third-party-programs.txt"
+    _write_text(arguments.output, generate_tpp_preview(inventory, existing))
+    return EXIT_SUCCESS
+
+
+def _run_sbom(arguments: argparse.Namespace) -> int:
+    root = Path(arguments.path).resolve()
+    inventory = (
+        read_inventory(arguments.source_inventory)
+        if arguments.source_inventory
+        else _evaluated(root, arguments)[0]
+    )
+    _write_text(arguments.output, render_spdx(inventory))
+    return EXIT_SUCCESS
+
+
+def _run_artifact_check(arguments: argparse.Namespace) -> int:
+    source = read_inventory(arguments.source_inventory)
+    root = Path.cwd().resolve()
+    config = _config(arguments, root)
+    if arguments.syft_result:
+        artifact = import_syft(arguments.syft_result)
+    else:
+        syft_config = config.providers.get("syft", {})
+        command = (
+            str(syft_config.get("command", "syft"))
+            if isinstance(syft_config, dict)
+            else "syft"
+        )
+        artifact = run_syft(arguments.path, command)
+    reconciled = reconcile_artifact(source, artifact)
+    reconciled = replace(
+        reconciled,
+        findings=tuple(
+            item for item in reconciled.findings if not item.code.startswith("POLICY_")
+        ),
+    )
+    inventory = evaluate_inventory(reconciled, config).inventory
+    _report(inventory, arguments, title="Artifact License Reconciliation")
+    return _exit_code(inventory, arguments.fail_on)
+
+
+def _run_toolchain_check(arguments: argparse.Namespace) -> int:
+    root = Path(arguments.path).resolve()
+    config = _config(arguments, root)
+    result = audit_toolchain(root, _discover(root, arguments), config).inventory
+    _report(result, arguments, title="License Toolchain Audit")
+    return _exit_code(result, arguments.fail_on)
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -65,17 +468,31 @@ def main(argv: Sequence[str] | None = None) -> int:
         arguments = parser.parse_args(argv)
         if arguments.command == "inventory":
             return _run_inventory(arguments)
+        if arguments.command == "check":
+            return _run_check(arguments)
+        if arguments.command == "explain":
+            return _run_explain(arguments)
+        if arguments.command == "tpp" and arguments.tpp_command == "check":
+            return _run_tpp_check(arguments)
+        if arguments.command == "tpp" and arguments.tpp_command == "generate":
+            return _run_tpp_generate(arguments)
+        if arguments.command == "sbom":
+            return _run_sbom(arguments)
+        if arguments.command == "artifact" and arguments.artifact_command == "check":
+            return _run_artifact_check(arguments)
+        if arguments.command == "toolchain" and arguments.toolchain_command == "check":
+            return _run_toolchain_check(arguments)
         raise ConfigurationError(f"Unsupported command: {arguments.command}")
     except (ConfigurationError, ValueError) as error:
         print(f"configuration error: {error}", file=sys.stderr)
         return EXIT_CONFIGURATION_ERROR
-    except DiscoveryError as error:
-        print(f"discovery error: {error}", file=sys.stderr)
+    except (DiscoveryError, ProviderError) as error:
+        print(f"provider/discovery error: {error}", file=sys.stderr)
         return EXIT_DISCOVERY_ERROR
     except OSError as error:
         print(f"discovery I/O error: {error}", file=sys.stderr)
         return EXIT_DISCOVERY_ERROR
-    except Exception as error:  # pragma: no cover - final CLI containment
+    except Exception as error:  # noqa: BLE001  # pragma: no cover - final CLI containment
         print(f"internal error: {error}", file=sys.stderr)
         return EXIT_INTERNAL_ERROR
 

--- a/tools/license_compliance/src/ov_contrib_license/cli.py
+++ b/tools/license_compliance/src/ov_contrib_license/cli.py
@@ -1,0 +1,84 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from ov_contrib_license.discovery import DiscoveryOptions, RepositoryDiscovery
+from ov_contrib_license.discovery.repository import DiscoveryError
+from ov_contrib_license.reporters import write_inventory
+
+EXIT_SUCCESS = 0
+EXIT_CONFIGURATION_ERROR = 4
+EXIT_DISCOVERY_ERROR = 5
+EXIT_INTERNAL_ERROR = 6
+
+
+class ConfigurationError(ValueError):
+    pass
+
+
+class ArgumentParser(argparse.ArgumentParser):
+    def error(self, message: str) -> None:
+        raise ConfigurationError(message)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = ArgumentParser(prog="ov-contrib-license", description="OpenVINO contrib license discovery")
+    subparsers = parser.add_subparsers(dest="command", required=True, parser_class=ArgumentParser)
+    inventory = subparsers.add_parser("inventory", help="build a deterministic repository inventory")
+    inventory.add_argument(
+        "path", nargs="?", default=".", help="repository path (default: current directory)"
+    )
+    inventory.add_argument("--output", type=Path, help="write the inventory to this file")
+    inventory.add_argument("--format", dest="output_format", choices=("json", "yaml"), default="json")
+    inventory.add_argument("--base-ref", help="base Git revision for incremental discovery")
+    inventory.add_argument("--head-ref", help="head Git revision for incremental discovery")
+    inventory.add_argument(
+        "--offline", action="store_true", help="forbid network providers (discovery is offline)"
+    )
+    inventory.add_argument("--include", action="append", default=[], metavar="GLOB")
+    inventory.add_argument("--exclude", action="append", default=[], metavar="GLOB")
+    return parser
+
+
+def _run_inventory(arguments: argparse.Namespace) -> int:
+    options = DiscoveryOptions(
+        base_ref=arguments.base_ref,
+        head_ref=arguments.head_ref,
+        includes=tuple(arguments.include),
+        excludes=tuple(arguments.exclude),
+        offline=arguments.offline,
+    )
+    inventory = RepositoryDiscovery(Path(arguments.path), options).run()
+    write_inventory(inventory, arguments.output, arguments.output_format)
+    return EXIT_SUCCESS
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    try:
+        arguments = parser.parse_args(argv)
+        if arguments.command == "inventory":
+            return _run_inventory(arguments)
+        raise ConfigurationError(f"Unsupported command: {arguments.command}")
+    except (ConfigurationError, ValueError) as error:
+        print(f"configuration error: {error}", file=sys.stderr)
+        return EXIT_CONFIGURATION_ERROR
+    except DiscoveryError as error:
+        print(f"discovery error: {error}", file=sys.stderr)
+        return EXIT_DISCOVERY_ERROR
+    except OSError as error:
+        print(f"discovery I/O error: {error}", file=sys.stderr)
+        return EXIT_DISCOVERY_ERROR
+    except Exception as error:  # pragma: no cover - final CLI containment
+        print(f"internal error: {error}", file=sys.stderr)
+        return EXIT_INTERNAL_ERROR
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/license_compliance/src/ov_contrib_license/discovery/__init__.py
+++ b/tools/license_compliance/src/ov_contrib_license/discovery/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from .repository import DiscoveryOptions, RepositoryDiscovery
+
+__all__ = ["DiscoveryOptions", "RepositoryDiscovery"]

--- a/tools/license_compliance/src/ov_contrib_license/discovery/cmake.py
+++ b/tools/license_compliance/src/ov_contrib_license/discovery/cmake.py
@@ -38,7 +38,12 @@ CM_COMMANDS = frozenset(
     }
 )
 REMOTE_COMMANDS = frozenset(
-    {"fetchcontent_declare", "fetchcontent_populate", "externalproject_add", "cpmaddpackage"}
+    {
+        "fetchcontent_declare",
+        "fetchcontent_populate",
+        "externalproject_add",
+        "cpmaddpackage",
+    }
 )
 KEYWORDS = frozenset(
     {
@@ -198,7 +203,11 @@ def parse_cmake(text: str) -> tuple[CMakeCommand, ...]:
         body, index = parsed
         if name.lower() in CM_COMMANDS:
             commands.append(
-                CMakeCommand(name.lower(), _tokenize(body), text.count("\n", 0, command_start) + 1)
+                CMakeCommand(
+                    name.lower(),
+                    _tokenize(body),
+                    text.count("\n", 0, command_start) + 1,
+                )
             )
     return tuple(commands)
 
@@ -214,11 +223,15 @@ def _keyword_values(arguments: tuple[str, ...]) -> dict[str, str]:
 
 def _github_url(url: str) -> tuple[str, str] | None:
     normalized = url.strip().removesuffix(".git").rstrip("/")
-    match = re.match(r"(?:https?://github\.com/|git@github\.com:)([^/]+)/([^/]+)$", normalized)
+    match = re.match(
+        r"(?:https?://github\.com/|git@github\.com:)([^/]+)/([^/]+)$", normalized
+    )
     return (match.group(1), match.group(2)) if match else None
 
 
-def _component_id(name: str, source_url: str | None, revision: str | None, path: str) -> str:
+def _component_id(
+    name: str, source_url: str | None, revision: str | None, path: str
+) -> str:
     if source_url:
         github = _github_url(source_url)
         if github and revision:
@@ -237,7 +250,9 @@ def _is_unresolved(value: str | None) -> bool:
     return value is None or "${" in value or "$<" in value
 
 
-def _remote_component(command: CMakeCommand, path: str) -> tuple[Component, Finding | None] | None:
+def _remote_component(
+    command: CMakeCommand, path: str
+) -> tuple[Component, Finding | None] | None:
     if not command.arguments:
         return None
     values = _keyword_values(command.arguments)
@@ -245,7 +260,9 @@ def _remote_component(command: CMakeCommand, path: str) -> tuple[Component, Find
     source_url = values.get("GIT_REPOSITORY") or values.get("URL")
     revision = values.get("GIT_TAG") or values.get("VERSION") or values.get("URL_HASH")
 
-    if command.name == "cpmaddpackage" and command.arguments[0].lower().startswith("gh:"):
+    if command.name == "cpmaddpackage" and command.arguments[0].lower().startswith(
+        "gh:"
+    ):
         shorthand = command.arguments[0][3:]
         repository, separator, shorthand_revision = shorthand.partition("@")
         source_url = f"https://github.com/{repository}"
@@ -299,7 +316,9 @@ def _remote_component(command: CMakeCommand, path: str) -> tuple[Component, Find
             component_id=component_id,
             message=f"CMake dependency {name!r} does not have a statically resolved revision.",
             evidence=(evidence,),
-            remediation=("Pin an exact revision or provide resolution evidence in a later provider stage.",),
+            remediation=(
+                "Pin an exact revision or provide resolution evidence in a later provider stage.",
+            ),
             fingerprint_values=(unresolved_expression or "missing",),
         )
     return component, finding
@@ -321,7 +340,11 @@ def _lookup_component(command: CMakeCommand, path: str) -> Component | None:
                 else command.arguments[0]
             )
         else:
-            name = command.arguments[1] if len(command.arguments) > 1 else command.arguments[0]
+            name = (
+                command.arguments[1]
+                if len(command.arguments) > 1
+                else command.arguments[0]
+            )
         evidence_kind = EvidenceKind.CMAKE_FIND_LIBRARY
     else:
         return None
@@ -343,7 +366,9 @@ def _lookup_component(command: CMakeCommand, path: str) -> Component | None:
     )
 
 
-def discover_cmake(builder: InventoryBuilder, root: Path, files: tuple[str, ...]) -> None:
+def discover_cmake(
+    builder: InventoryBuilder, root: Path, files: tuple[str, ...]
+) -> None:
     for path in files:
         pure_path = PurePosixPath(path)
         if pure_path.name != "CMakeLists.txt" and pure_path.suffix.lower() != ".cmake":

--- a/tools/license_compliance/src/ov_contrib_license/discovery/cmake.py
+++ b/tools/license_compliance/src/ov_contrib_license/discovery/cmake.py
@@ -1,0 +1,378 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from urllib.parse import quote
+
+from ov_contrib_license.model import (
+    Component,
+    Confidence,
+    Decision,
+    Discovery,
+    DistributionStatus,
+    Evidence,
+    EvidenceKind,
+    Finding,
+    InventoryBuilder,
+    Relationship,
+    Severity,
+)
+from ov_contrib_license.model.types import normalize_details
+
+from .common import owning_module
+
+CM_COMMANDS = frozenset(
+    {
+        "fetchcontent_declare",
+        "fetchcontent_makeavailable",
+        "fetchcontent_populate",
+        "externalproject_add",
+        "cpmaddpackage",
+        "find_package",
+        "find_library",
+        "add_subdirectory",
+    }
+)
+REMOTE_COMMANDS = frozenset(
+    {"fetchcontent_declare", "fetchcontent_populate", "externalproject_add", "cpmaddpackage"}
+)
+KEYWORDS = frozenset(
+    {
+        "NAME",
+        "GIT_REPOSITORY",
+        "GIT_TAG",
+        "URL",
+        "URL_HASH",
+        "GITHUB_REPOSITORY",
+        "VERSION",
+        "DOWNLOAD_COMMAND",
+    }
+)
+
+
+@dataclass(frozen=True)
+class CMakeCommand:
+    name: str
+    arguments: tuple[str, ...]
+    line: int
+
+
+def _bracket_delimiter(text: str, start: int) -> tuple[str, int] | None:
+    match = re.match(r"\[(=*)\[", text[start:])
+    if match is None:
+        return None
+    equals = match.group(1)
+    return f"]{equals}]", len(match.group(0))
+
+
+def _skip_space_and_comments(text: str, start: int) -> int:
+    index = start
+    while index < len(text):
+        if text[index].isspace():
+            index += 1
+        elif text[index] == "#":
+            bracket = _bracket_delimiter(text, index + 1)
+            if bracket:
+                delimiter, prefix_length = bracket
+                end = text.find(delimiter, index + 1 + prefix_length)
+                index = len(text) if end < 0 else end + len(delimiter)
+            else:
+                end = text.find("\n", index)
+                index = len(text) if end < 0 else end + 1
+        else:
+            break
+    return index
+
+
+def _command_body(text: str, start: int) -> tuple[str, int] | None:
+    depth = 1
+    index = start
+    body: list[str] = []
+    quoted = False
+    escaped = False
+    while index < len(text):
+        char = text[index]
+        if quoted:
+            body.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                quoted = False
+            index += 1
+            continue
+        if char == '"':
+            quoted = True
+            body.append(char)
+            index += 1
+            continue
+        bracket = _bracket_delimiter(text, index) if char == "[" else None
+        if bracket:
+            delimiter, prefix_length = bracket
+            end = text.find(delimiter, index + prefix_length)
+            if end < 0:
+                return None
+            body.append(text[index + prefix_length : end])
+            index = end + len(delimiter)
+            continue
+        if char == "#":
+            bracket_comment = _bracket_delimiter(text, index + 1)
+            if bracket_comment:
+                delimiter, prefix_length = bracket_comment
+                end = text.find(delimiter, index + 1 + prefix_length)
+                if end < 0:
+                    return None
+                body.append(" ")
+                index = end + len(delimiter)
+            else:
+                end = text.find("\n", index)
+                body.append("\n")
+                index = len(text) if end < 0 else end + 1
+            continue
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return "".join(body), index + 1
+        body.append(char)
+        index += 1
+    return None
+
+
+def _tokenize(body: str) -> tuple[str, ...]:
+    tokens: list[str] = []
+    token: list[str] = []
+    quoted = False
+    escaped = False
+    for char in body:
+        if quoted:
+            if escaped:
+                token.append(char)
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                quoted = False
+            else:
+                token.append(char)
+        elif char == '"':
+            quoted = True
+        elif char.isspace() or char == ";":
+            if token:
+                tokens.append("".join(token))
+                token = []
+        else:
+            token.append(char)
+    if escaped:
+        token.append("\\")
+    if token:
+        tokens.append("".join(token))
+    return tuple(tokens)
+
+
+def parse_cmake(text: str) -> tuple[CMakeCommand, ...]:
+    """Parse CMake command calls while preserving unresolved arguments."""
+    commands: list[CMakeCommand] = []
+    index = 0
+    while index < len(text):
+        index = _skip_space_and_comments(text, index)
+        match = re.match(r"[A-Za-z_][A-Za-z0-9_]*", text[index:])
+        if match is None:
+            index += 1
+            continue
+        name = match.group(0)
+        command_start = index
+        index += len(name)
+        index = _skip_space_and_comments(text, index)
+        if index >= len(text) or text[index] != "(":
+            continue
+        parsed = _command_body(text, index + 1)
+        if parsed is None:
+            break
+        body, index = parsed
+        if name.lower() in CM_COMMANDS:
+            commands.append(
+                CMakeCommand(name.lower(), _tokenize(body), text.count("\n", 0, command_start) + 1)
+            )
+    return tuple(commands)
+
+
+def _keyword_values(arguments: tuple[str, ...]) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for index, argument in enumerate(arguments[:-1]):
+        keyword = argument.upper()
+        if keyword in KEYWORDS and arguments[index + 1].upper() not in KEYWORDS:
+            values.setdefault(keyword, arguments[index + 1])
+    return values
+
+
+def _github_url(url: str) -> tuple[str, str] | None:
+    normalized = url.strip().removesuffix(".git").rstrip("/")
+    match = re.match(r"(?:https?://github\.com/|git@github\.com:)([^/]+)/([^/]+)$", normalized)
+    return (match.group(1), match.group(2)) if match else None
+
+
+def _component_id(name: str, source_url: str | None, revision: str | None, path: str) -> str:
+    if source_url:
+        github = _github_url(source_url)
+        if github and revision:
+            owner = quote(github[0], safe="")
+            repository = quote(github[1], safe="")
+            return f"pkg:github/{owner}/{repository}@{quote(revision, safe='.-_')}"
+        normalized = source_url.removesuffix(".git").rstrip("/")
+        return f"vcs:{normalized}" + (f"@{revision}" if revision else "")
+    escaped_name = quote(name.lower(), safe=".-_")
+    if revision:
+        return f"pkg:generic/{escaped_name}@{quote(revision, safe='.-_')}"
+    return f"local:cmake/{path}#{escaped_name}"
+
+
+def _is_unresolved(value: str | None) -> bool:
+    return value is None or "${" in value or "$<" in value
+
+
+def _remote_component(command: CMakeCommand, path: str) -> tuple[Component, Finding | None] | None:
+    if not command.arguments:
+        return None
+    values = _keyword_values(command.arguments)
+    name = values.get("NAME", command.arguments[0])
+    source_url = values.get("GIT_REPOSITORY") or values.get("URL")
+    revision = values.get("GIT_TAG") or values.get("VERSION") or values.get("URL_HASH")
+
+    if command.name == "cpmaddpackage" and command.arguments[0].lower().startswith("gh:"):
+        shorthand = command.arguments[0][3:]
+        repository, separator, shorthand_revision = shorthand.partition("@")
+        source_url = f"https://github.com/{repository}"
+        revision = shorthand_revision if separator else revision
+        name = values.get("NAME", repository.rsplit("/", 1)[-1])
+    elif values.get("GITHUB_REPOSITORY"):
+        source_url = f"https://github.com/{values['GITHUB_REPOSITORY']}"
+
+    if not source_url and command.name != "cpmaddpackage":
+        return None
+
+    unresolved_expression = revision if _is_unresolved(revision) else None
+    resolved_revision = None if unresolved_expression else revision
+    evidence_kind = {
+        "externalproject_add": EvidenceKind.CMAKE_EXTERNAL_PROJECT,
+        "cpmaddpackage": EvidenceKind.CMAKE_CPM,
+    }.get(command.name, EvidenceKind.CMAKE_FETCHCONTENT)
+    details = {
+        "line": command.line,
+        "mechanism": command.name,
+        "revision": resolved_revision,
+        "source_url": source_url,
+        "unresolved_revision_expression": unresolved_expression,
+    }
+    evidence = Evidence(
+        kind=evidence_kind,
+        source="cmake-static-discovery",
+        path=path,
+        value=source_url or name,
+        confidence=Confidence.HIGH if source_url or name else Confidence.LOW,
+        details=normalize_details(details),
+    )
+    component_id = _component_id(name, source_url, resolved_revision, path)
+    component = Component(
+        id=component_id,
+        name=name,
+        version=resolved_revision,
+        module=owning_module(path),
+        paths=(path,),
+        relationships=(Relationship.FETCHED_AT_BUILD,),
+        evidence=(evidence,),
+        distribution=DistributionStatus.UNKNOWN,
+        details=normalize_details({"source_url": source_url}),
+    )
+    finding = None
+    if source_url and _is_unresolved(revision):
+        finding = Finding.create(
+            code="DISCOVERY_CMAKE_UNRESOLVED_REVISION",
+            severity=Severity.WARNING,
+            decision=Decision.REVIEW,
+            component_id=component_id,
+            message=f"CMake dependency {name!r} does not have a statically resolved revision.",
+            evidence=(evidence,),
+            remediation=("Pin an exact revision or provide resolution evidence in a later provider stage.",),
+            fingerprint_values=(unresolved_expression or "missing",),
+        )
+    return component, finding
+
+
+def _lookup_component(command: CMakeCommand, path: str) -> Component | None:
+    if not command.arguments:
+        return None
+    if command.name == "find_package":
+        name = command.arguments[0]
+        evidence_kind = EvidenceKind.CMAKE_FIND_PACKAGE
+    elif command.name == "find_library":
+        upper_arguments = tuple(argument.upper() for argument in command.arguments)
+        if "NAMES" in upper_arguments:
+            names_index = upper_arguments.index("NAMES")
+            name = (
+                command.arguments[names_index + 1]
+                if names_index + 1 < len(command.arguments)
+                else command.arguments[0]
+            )
+        else:
+            name = command.arguments[1] if len(command.arguments) > 1 else command.arguments[0]
+        evidence_kind = EvidenceKind.CMAKE_FIND_LIBRARY
+    else:
+        return None
+    evidence = Evidence(
+        kind=evidence_kind,
+        source="cmake-static-discovery",
+        path=path,
+        value=name,
+        confidence=Confidence.MEDIUM,
+        details=normalize_details({"line": command.line, "mechanism": command.name}),
+    )
+    return Component(
+        id=f"pkg:generic/{quote(name.lower(), safe='.-_')}",
+        name=name,
+        module=owning_module(path),
+        paths=(path,),
+        relationships=(Relationship.UNKNOWN,),
+        evidence=(evidence,),
+    )
+
+
+def discover_cmake(builder: InventoryBuilder, root: Path, files: tuple[str, ...]) -> None:
+    for path in files:
+        pure_path = PurePosixPath(path)
+        if pure_path.name != "CMakeLists.txt" and pure_path.suffix.lower() != ".cmake":
+            continue
+        try:
+            text = (root / path).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for command in parse_cmake(text):
+            details = {"command": command.name, "line": command.line}
+            if command.arguments:
+                details["subject"] = command.arguments[0]
+            builder.add_discovery(
+                Discovery(
+                    kind="cmake",
+                    path=path,
+                    module=owning_module(path),
+                    ecosystem="cmake",
+                    details=normalize_details(details),
+                )
+            )
+            if command.name in REMOTE_COMMANDS:
+                result = _remote_component(command, path)
+                if result:
+                    component, finding = result
+                    builder.add_component(component)
+                    if finding:
+                        builder.add_finding(finding)
+            else:
+                component = _lookup_component(command, path)
+                if component:
+                    builder.add_component(component)

--- a/tools/license_compliance/src/ov_contrib_license/discovery/common.py
+++ b/tools/license_compliance/src/ov_contrib_license/discovery/common.py
@@ -1,0 +1,20 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import PurePosixPath
+
+
+def owning_scope(path: str) -> str:
+    parts = PurePosixPath(path).parts
+    if len(parts) >= 2 and parts[0] == "modules":
+        return f"module:{parts[1]}"
+    if parts and parts[0] == ".github":
+        return "repository-ci"
+    if parts and parts[0] == "tools":
+        return "repository-tooling"
+    return "repository"
+
+
+def owning_module(path: str) -> str | None:
+    scope = owning_scope(path)
+    return scope.removeprefix("module:") if scope.startswith("module:") else scope

--- a/tools/license_compliance/src/ov_contrib_license/discovery/downloads.py
+++ b/tools/license_compliance/src/ov_contrib_license/discovery/downloads.py
@@ -25,18 +25,32 @@ from ov_contrib_license.model.types import normalize_details
 
 from .common import owning_module
 
-DOWNLOAD_FILE_SUFFIXES = frozenset({".sh", ".bash", ".zsh", ".py", ".cmake", ".yml", ".yaml"})
+DOWNLOAD_FILE_SUFFIXES = frozenset(
+    {".sh", ".bash", ".zsh", ".py", ".cmake", ".yml", ".yaml"}
+)
 COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "git-clone",
-        re.compile(r"\bgit\s+clone(?:\s+--?[\w-]+(?:=\S+|\s+\S+)?)*\s+([^\s;&|]+)", re.IGNORECASE),
+        re.compile(
+            r"\bgit\s+clone(?:\s+--?[\w-]+(?:=\S+|\s+\S+)?)*\s+([^\s;&|]+)",
+            re.IGNORECASE,
+        ),
     ),
     (
         "git-submodule",
-        re.compile(r"\bgit\s+submodule\s+(?:add|update)(?:\s+--?[\w-]+)*\s+([^\s;&|]+)", re.IGNORECASE),
+        re.compile(
+            r"\bgit\s+submodule\s+(?:add|update)(?:\s+--?[\w-]+)*\s+([^\s;&|]+)",
+            re.IGNORECASE,
+        ),
     ),
-    ("curl", re.compile(r"\bcurl\b[^\n]*?((?:git\+)?https?://[^\s'\";&|)]+)", re.IGNORECASE)),
-    ("wget", re.compile(r"\bwget\b[^\n]*?((?:git\+)?https?://[^\s'\";&|)]+)", re.IGNORECASE)),
+    (
+        "curl",
+        re.compile(r"\bcurl\b[^\n]*?((?:git\+)?https?://[^\s'\";&|)]+)", re.IGNORECASE),
+    ),
+    (
+        "wget",
+        re.compile(r"\bwget\b[^\n]*?((?:git\+)?https?://[^\s'\";&|)]+)", re.IGNORECASE),
+    ),
     (
         "pip-install",
         re.compile(
@@ -44,7 +58,12 @@ COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
             re.IGNORECASE,
         ),
     ),
-    ("npm-install", re.compile(r"\bnpm\s+(?:install|i)\b[^\n]*?(github:[^\s'\";&|)]+)", re.IGNORECASE)),
+    (
+        "npm-install",
+        re.compile(
+            r"\bnpm\s+(?:install|i)\b[^\n]*?(github:[^\s'\";&|)]+)", re.IGNORECASE
+        ),
+    ),
 )
 PYTHON_COMMAND_CALLS = frozenset(
     {
@@ -81,7 +100,9 @@ def _literal_command(node: ast.AST) -> str | None:
     if isinstance(node, (ast.List, ast.Tuple)):
         values: list[str] = []
         for element in node.elts:
-            if not isinstance(element, ast.Constant) or not isinstance(element.value, str):
+            if not isinstance(element, ast.Constant) or not isinstance(
+                element.value, str
+            ):
                 return None
             values.append(element.value)
         return " ".join(values)
@@ -127,11 +148,16 @@ def _strip_comment(line: str) -> str:
     return line
 
 
-def extract_downloads(text: str, *, python: bool = False) -> tuple[DownloadCandidate, ...]:
+def extract_downloads(
+    text: str, *, python: bool = False
+) -> tuple[DownloadCandidate, ...]:
     command_lines = (
         _python_command_text(text)
         if python
-        else tuple((line, index) for index, line in enumerate(text.replace("\\\n", " ").splitlines(), 1))
+        else tuple(
+            (line, index)
+            for index, line in enumerate(text.replace("\\\n", " ").splitlines(), 1)
+        )
     )
     candidates: set[DownloadCandidate] = set()
     for command_text, line_number in command_lines:
@@ -139,9 +165,13 @@ def extract_downloads(text: str, *, python: bool = False) -> tuple[DownloadCandi
         for mechanism, pattern in COMMAND_PATTERNS:
             for match in pattern.finditer(executable):
                 url = match.group(1).strip("'\"")
-                if url.startswith(("http://", "https://", "git+http", "git@", "ssh://", "github:")):
+                if url.startswith(
+                    ("http://", "https://", "git+http", "git@", "ssh://", "github:")
+                ):
                     candidates.add(DownloadCandidate(mechanism, url, line_number))
-    return tuple(sorted(candidates, key=lambda item: (item.line, item.mechanism, item.url)))
+    return tuple(
+        sorted(candidates, key=lambda item: (item.line, item.mechanism, item.url))
+    )
 
 
 def _normalized_remote(url: str) -> str:
@@ -158,10 +188,14 @@ def _download_identity(url: str) -> tuple[str, str, str | None]:
         if "/" not in candidate:
             normalized, revision = before, candidate
     clean = normalized.removesuffix(".git").rstrip("/")
-    github = re.match(r"(?:https?://github\.com/|git@github\.com:)([^/]+)/([^/]+)$", clean)
+    github = re.match(
+        r"(?:https?://github\.com/|git@github\.com:)([^/]+)/([^/]+)$", clean
+    )
     if github:
         owner, repository = github.groups()
-        component_id = f"pkg:github/{quote(owner, safe='')}/{quote(repository, safe='')}"
+        component_id = (
+            f"pkg:github/{quote(owner, safe='')}/{quote(repository, safe='')}"
+        )
         if revision:
             component_id += f"@{quote(revision, safe='.-_')}"
         return component_id, repository, revision
@@ -175,13 +209,18 @@ def _eligible_file(path: str) -> bool:
     pure = PurePosixPath(path)
     return (
         pure.suffix.lower() in DOWNLOAD_FILE_SUFFIXES - {".yml", ".yaml"}
-        or (pure.parts[:2] == (".github", "workflows") and pure.suffix.lower() in {".yml", ".yaml"})
+        or (
+            pure.parts[:2] == (".github", "workflows")
+            and pure.suffix.lower() in {".yml", ".yaml"}
+        )
         or pure.name.startswith("Dockerfile")
         or pure.name == "CMakeLists.txt"
     )
 
 
-def discover_downloads(builder: InventoryBuilder, root: Path, files: tuple[str, ...]) -> None:
+def discover_downloads(
+    builder: InventoryBuilder, root: Path, files: tuple[str, ...]
+) -> None:
     for path in files:
         if not _eligible_file(path):
             continue
@@ -189,9 +228,13 @@ def discover_downloads(builder: InventoryBuilder, root: Path, files: tuple[str, 
             text = (root / path).read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
-        for candidate in extract_downloads(text, python=PurePosixPath(path).suffix.lower() == ".py"):
+        for candidate in extract_downloads(
+            text, python=PurePosixPath(path).suffix.lower() == ".py"
+        ):
             component_id, name, revision = _download_identity(candidate.url)
-            details = normalize_details({"line": candidate.line, "mechanism": candidate.mechanism})
+            details = normalize_details(
+                {"line": candidate.line, "mechanism": candidate.mechanism}
+            )
             evidence = Evidence(
                 kind=EvidenceKind.DOWNLOAD_URL,
                 source="executable-download-discovery",
@@ -206,7 +249,11 @@ def discover_downloads(builder: InventoryBuilder, root: Path, files: tuple[str, 
                     path=path,
                     module=owning_module(path),
                     details=normalize_details(
-                        {"line": candidate.line, "mechanism": candidate.mechanism, "url": candidate.url}
+                        {
+                            "line": candidate.line,
+                            "mechanism": candidate.mechanism,
+                            "url": candidate.url,
+                        }
                     ),
                 )
             )
@@ -219,6 +266,8 @@ def discover_downloads(builder: InventoryBuilder, root: Path, files: tuple[str, 
                     paths=(path,),
                     relationships=(Relationship.FETCHED_AT_BUILD,),
                     evidence=(evidence,),
-                    details=normalize_details({"source_url": _normalized_remote(candidate.url)}),
+                    details=normalize_details(
+                        {"source_url": _normalized_remote(candidate.url)}
+                    ),
                 )
             )

--- a/tools/license_compliance/src/ov_contrib_license/discovery/downloads.py
+++ b/tools/license_compliance/src/ov_contrib_license/discovery/downloads.py
@@ -1,0 +1,224 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import re
+import textwrap
+import warnings
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from urllib.parse import quote, urlparse
+
+from ov_contrib_license.model import (
+    Component,
+    Confidence,
+    Discovery,
+    Evidence,
+    EvidenceKind,
+    InventoryBuilder,
+    Relationship,
+)
+from ov_contrib_license.model.types import normalize_details
+
+from .common import owning_module
+
+DOWNLOAD_FILE_SUFFIXES = frozenset({".sh", ".bash", ".zsh", ".py", ".cmake", ".yml", ".yaml"})
+COMMAND_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "git-clone",
+        re.compile(r"\bgit\s+clone(?:\s+--?[\w-]+(?:=\S+|\s+\S+)?)*\s+([^\s;&|]+)", re.IGNORECASE),
+    ),
+    (
+        "git-submodule",
+        re.compile(r"\bgit\s+submodule\s+(?:add|update)(?:\s+--?[\w-]+)*\s+([^\s;&|]+)", re.IGNORECASE),
+    ),
+    ("curl", re.compile(r"\bcurl\b[^\n]*?((?:git\+)?https?://[^\s'\";&|)]+)", re.IGNORECASE)),
+    ("wget", re.compile(r"\bwget\b[^\n]*?((?:git\+)?https?://[^\s'\";&|)]+)", re.IGNORECASE)),
+    (
+        "pip-install",
+        re.compile(
+            r"\b(?:python\s+-m\s+)?pip\s+install\b[^\n]*?((?:git\+)?https?://[^\s'\";&|)]+)",
+            re.IGNORECASE,
+        ),
+    ),
+    ("npm-install", re.compile(r"\bnpm\s+(?:install|i)\b[^\n]*?(github:[^\s'\";&|)]+)", re.IGNORECASE)),
+)
+PYTHON_COMMAND_CALLS = frozenset(
+    {
+        "os.popen",
+        "os.system",
+        "subprocess.call",
+        "subprocess.check_call",
+        "subprocess.check_output",
+        "subprocess.Popen",
+        "subprocess.run",
+    }
+)
+
+
+@dataclass(frozen=True)
+class DownloadCandidate:
+    mechanism: str
+    url: str
+    line: int
+
+
+def _call_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _call_name(node.value)
+        return f"{prefix}.{node.attr}" if prefix else node.attr
+    return None
+
+
+def _literal_command(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, (ast.List, ast.Tuple)):
+        values: list[str] = []
+        for element in node.elts:
+            if not isinstance(element, ast.Constant) or not isinstance(element.value, str):
+                return None
+            values.append(element.value)
+        return " ".join(values)
+    return None
+
+
+def _python_command_text(text: str) -> tuple[tuple[str, int], ...]:
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", SyntaxWarning)
+            tree = ast.parse(textwrap.dedent(text))
+    except SyntaxError:
+        return ()
+    commands: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if (
+            not isinstance(node, ast.Call)
+            or _call_name(node.func) not in PYTHON_COMMAND_CALLS
+            or not node.args
+        ):
+            continue
+        command = _literal_command(node.args[0])
+        if command:
+            commands.append((command, node.lineno))
+    return tuple(commands)
+
+
+def _strip_comment(line: str) -> str:
+    single_quoted = False
+    double_quoted = False
+    escaped = False
+    for index, char in enumerate(line):
+        if escaped:
+            escaped = False
+        elif char == "\\" and not single_quoted:
+            escaped = True
+        elif char == "'" and not double_quoted:
+            single_quoted = not single_quoted
+        elif char == '"' and not single_quoted:
+            double_quoted = not double_quoted
+        elif char == "#" and not single_quoted and not double_quoted:
+            return line[:index]
+    return line
+
+
+def extract_downloads(text: str, *, python: bool = False) -> tuple[DownloadCandidate, ...]:
+    command_lines = (
+        _python_command_text(text)
+        if python
+        else tuple((line, index) for index, line in enumerate(text.replace("\\\n", " ").splitlines(), 1))
+    )
+    candidates: set[DownloadCandidate] = set()
+    for command_text, line_number in command_lines:
+        executable = command_text if python else _strip_comment(command_text)
+        for mechanism, pattern in COMMAND_PATTERNS:
+            for match in pattern.finditer(executable):
+                url = match.group(1).strip("'\"")
+                if url.startswith(("http://", "https://", "git+http", "git@", "ssh://", "github:")):
+                    candidates.add(DownloadCandidate(mechanism, url, line_number))
+    return tuple(sorted(candidates, key=lambda item: (item.line, item.mechanism, item.url)))
+
+
+def _normalized_remote(url: str) -> str:
+    if url.startswith("github:"):
+        return f"https://github.com/{url.removeprefix('github:')}"
+    return url.removeprefix("git+").split("#", 1)[0]
+
+
+def _download_identity(url: str) -> tuple[str, str, str | None]:
+    normalized = _normalized_remote(url)
+    revision = None
+    if "@" in normalized and not normalized.startswith("git@"):
+        before, candidate = normalized.rsplit("@", 1)
+        if "/" not in candidate:
+            normalized, revision = before, candidate
+    clean = normalized.removesuffix(".git").rstrip("/")
+    github = re.match(r"(?:https?://github\.com/|git@github\.com:)([^/]+)/([^/]+)$", clean)
+    if github:
+        owner, repository = github.groups()
+        component_id = f"pkg:github/{quote(owner, safe='')}/{quote(repository, safe='')}"
+        if revision:
+            component_id += f"@{quote(revision, safe='.-_')}"
+        return component_id, repository, revision
+    parsed = urlparse(clean)
+    name = PurePosixPath(parsed.path).name or parsed.netloc or "external-download"
+    digest = hashlib.sha256(clean.encode("utf-8")).hexdigest()
+    return f"url:sha256:{digest}", name, revision
+
+
+def _eligible_file(path: str) -> bool:
+    pure = PurePosixPath(path)
+    return (
+        pure.suffix.lower() in DOWNLOAD_FILE_SUFFIXES - {".yml", ".yaml"}
+        or (pure.parts[:2] == (".github", "workflows") and pure.suffix.lower() in {".yml", ".yaml"})
+        or pure.name.startswith("Dockerfile")
+        or pure.name == "CMakeLists.txt"
+    )
+
+
+def discover_downloads(builder: InventoryBuilder, root: Path, files: tuple[str, ...]) -> None:
+    for path in files:
+        if not _eligible_file(path):
+            continue
+        try:
+            text = (root / path).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for candidate in extract_downloads(text, python=PurePosixPath(path).suffix.lower() == ".py"):
+            component_id, name, revision = _download_identity(candidate.url)
+            details = normalize_details({"line": candidate.line, "mechanism": candidate.mechanism})
+            evidence = Evidence(
+                kind=EvidenceKind.DOWNLOAD_URL,
+                source="executable-download-discovery",
+                path=path,
+                value=candidate.url,
+                confidence=Confidence.MEDIUM,
+                details=details,
+            )
+            builder.add_discovery(
+                Discovery(
+                    kind="download",
+                    path=path,
+                    module=owning_module(path),
+                    details=normalize_details(
+                        {"line": candidate.line, "mechanism": candidate.mechanism, "url": candidate.url}
+                    ),
+                )
+            )
+            builder.add_component(
+                Component(
+                    id=component_id,
+                    name=name,
+                    version=revision,
+                    module=owning_module(path),
+                    paths=(path,),
+                    relationships=(Relationship.FETCHED_AT_BUILD,),
+                    evidence=(evidence,),
+                    details=normalize_details({"source_url": _normalized_remote(candidate.url)}),
+                )
+            )

--- a/tools/license_compliance/src/ov_contrib_license/discovery/github_actions.py
+++ b/tools/license_compliance/src/ov_contrib_license/discovery/github_actions.py
@@ -1,0 +1,162 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+from pathlib import Path, PurePosixPath
+from urllib.parse import quote
+
+from ov_contrib_license.model import (
+    Component,
+    Confidence,
+    Decision,
+    Discovery,
+    DistributionStatus,
+    Evidence,
+    EvidenceKind,
+    Finding,
+    InventoryBuilder,
+    Relationship,
+    Severity,
+)
+from ov_contrib_license.model.types import normalize_details
+
+from .common import owning_module
+
+USES_PATTERN = re.compile(r"^\s*(?:-\s*)?uses\s*:\s*([^\s#]+)", re.IGNORECASE)
+FULL_SHA = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+def extract_action_references(text: str) -> tuple[tuple[str, int], ...]:
+    references: list[tuple[str, int]] = []
+    for line_number, line in enumerate(text.splitlines(), 1):
+        match = USES_PATTERN.match(line)
+        if match:
+            references.append((match.group(1).strip("'\""), line_number))
+    return tuple(references)
+
+
+def _is_workflow(path: str) -> bool:
+    pure = PurePosixPath(path)
+    return (
+        len(pure.parts) >= 3
+        and pure.parts[:2] == (".github", "workflows")
+        and pure.suffix.lower() in {".yml", ".yaml"}
+    )
+
+
+def _action_component(reference: str, path: str, line: int) -> tuple[Component, Finding | None] | None:
+    if reference.startswith("./"):
+        return None
+    details = {"line": line, "reference": reference}
+    if reference.startswith("docker://"):
+        image = reference.removeprefix("docker://")
+        name, separator, digest = image.partition("@")
+        component_id = f"pkg:docker/{quote(name, safe='/.-_')}"
+        if separator:
+            component_id += f"@{quote(digest, safe=':.-_')}"
+        evidence = Evidence(
+            kind=EvidenceKind.GITHUB_ACTION,
+            source="github-workflow-discovery",
+            path=path,
+            value=reference,
+            confidence=Confidence.HIGH,
+            details=normalize_details(details),
+        )
+        component = Component(
+            id=component_id,
+            name=name,
+            version=digest or None,
+            module=owning_module(path),
+            paths=(path,),
+            relationships=(Relationship.BUILD_TOOL,),
+            evidence=(evidence,),
+            distribution=DistributionStatus.NOT_DISTRIBUTED,
+            details=normalize_details({"immutable_ref": digest.startswith("sha256:") if digest else False}),
+        )
+        finding = None
+        if not digest.startswith("sha256:"):
+            finding = Finding.create(
+                code="DISCOVERY_ACTION_UNPINNED",
+                severity=Severity.WARNING,
+                decision=Decision.REVIEW,
+                component_id=component_id,
+                message=f"Container action {reference!r} is not pinned by digest.",
+                evidence=(evidence,),
+                remediation=("Pin the container action with an immutable sha256 digest.",),
+                fingerprint_values=(reference,),
+            )
+        return component, finding
+
+    action, separator, ref = reference.rpartition("@")
+    if not separator:
+        action, ref = reference, ""
+    parts = action.split("/")
+    if len(parts) < 2:
+        return None
+    owner, repository = parts[:2]
+    component_id = f"pkg:github/{quote(owner, safe='')}/{quote(repository, safe='')}"
+    if ref:
+        component_id += f"@{quote(ref, safe='.-_')}"
+    pinned = bool(FULL_SHA.fullmatch(ref))
+    evidence = Evidence(
+        kind=EvidenceKind.GITHUB_ACTION,
+        source="github-workflow-discovery",
+        path=path,
+        value=reference,
+        confidence=Confidence.HIGH,
+        details=normalize_details(details),
+    )
+    component = Component(
+        id=component_id,
+        name=action,
+        version=ref or None,
+        module=owning_module(path),
+        paths=(path,),
+        relationships=(Relationship.BUILD_TOOL,),
+        evidence=(evidence,),
+        distribution=DistributionStatus.NOT_DISTRIBUTED,
+        details=normalize_details({"action_path": "/".join(parts[2:]), "immutable_ref": pinned}),
+    )
+    finding = None
+    if not pinned:
+        finding = Finding.create(
+            code="DISCOVERY_ACTION_UNPINNED",
+            severity=Severity.WARNING,
+            decision=Decision.REVIEW,
+            component_id=component_id,
+            message=f"GitHub Action {reference!r} is not pinned to a full commit SHA.",
+            evidence=(evidence,),
+            remediation=("Pin the action to a full 40-character commit SHA.",),
+            fingerprint_values=(reference,),
+        )
+    return component, finding
+
+
+def discover_github_actions(builder: InventoryBuilder, root: Path, files: tuple[str, ...]) -> None:
+    for path in files:
+        if not _is_workflow(path):
+            continue
+        try:
+            text = (root / path).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for reference, line in extract_action_references(text):
+            builder.add_discovery(
+                Discovery(
+                    kind="github-action",
+                    path=path,
+                    module=owning_module(path),
+                    ecosystem="github-actions",
+                    details=normalize_details(
+                        {"line": line, "local": reference.startswith("./"), "reference": reference}
+                    ),
+                )
+            )
+            result = _action_component(reference, path, line)
+            if result:
+                component, finding = result
+                builder.add_component(component)
+                if finding:
+                    builder.add_finding(finding)

--- a/tools/license_compliance/src/ov_contrib_license/discovery/github_actions.py
+++ b/tools/license_compliance/src/ov_contrib_license/discovery/github_actions.py
@@ -46,7 +46,9 @@ def _is_workflow(path: str) -> bool:
     )
 
 
-def _action_component(reference: str, path: str, line: int) -> tuple[Component, Finding | None] | None:
+def _action_component(
+    reference: str, path: str, line: int
+) -> tuple[Component, Finding | None] | None:
     if reference.startswith("./"):
         return None
     details = {"line": line, "reference": reference}
@@ -73,7 +75,9 @@ def _action_component(reference: str, path: str, line: int) -> tuple[Component, 
             relationships=(Relationship.BUILD_TOOL,),
             evidence=(evidence,),
             distribution=DistributionStatus.NOT_DISTRIBUTED,
-            details=normalize_details({"immutable_ref": digest.startswith("sha256:") if digest else False}),
+            details=normalize_details(
+                {"immutable_ref": digest.startswith("sha256:") if digest else False}
+            ),
         )
         finding = None
         if not digest.startswith("sha256:"):
@@ -84,7 +88,9 @@ def _action_component(reference: str, path: str, line: int) -> tuple[Component, 
                 component_id=component_id,
                 message=f"Container action {reference!r} is not pinned by digest.",
                 evidence=(evidence,),
-                remediation=("Pin the container action with an immutable sha256 digest.",),
+                remediation=(
+                    "Pin the container action with an immutable sha256 digest.",
+                ),
                 fingerprint_values=(reference,),
             )
         return component, finding
@@ -117,7 +123,9 @@ def _action_component(reference: str, path: str, line: int) -> tuple[Component, 
         relationships=(Relationship.BUILD_TOOL,),
         evidence=(evidence,),
         distribution=DistributionStatus.NOT_DISTRIBUTED,
-        details=normalize_details({"action_path": "/".join(parts[2:]), "immutable_ref": pinned}),
+        details=normalize_details(
+            {"action_path": "/".join(parts[2:]), "immutable_ref": pinned}
+        ),
     )
     finding = None
     if not pinned:
@@ -134,7 +142,9 @@ def _action_component(reference: str, path: str, line: int) -> tuple[Component, 
     return component, finding
 
 
-def discover_github_actions(builder: InventoryBuilder, root: Path, files: tuple[str, ...]) -> None:
+def discover_github_actions(
+    builder: InventoryBuilder, root: Path, files: tuple[str, ...]
+) -> None:
     for path in files:
         if not _is_workflow(path):
             continue
@@ -150,7 +160,11 @@ def discover_github_actions(builder: InventoryBuilder, root: Path, files: tuple[
                     module=owning_module(path),
                     ecosystem="github-actions",
                     details=normalize_details(
-                        {"line": line, "local": reference.startswith("./"), "reference": reference}
+                        {
+                            "line": line,
+                            "local": reference.startswith("./"),
+                            "reference": reference,
+                        }
                     ),
                 )
             )

--- a/tools/license_compliance/src/ov_contrib_license/discovery/manifests.py
+++ b/tools/license_compliance/src/ov_contrib_license/discovery/manifests.py
@@ -47,5 +47,10 @@ def discover_manifests(builder: InventoryBuilder, files: tuple[str, ...]) -> Non
         if ecosystem is None:
             continue
         builder.add_discovery(
-            Discovery(kind="manifest", path=path, module=owning_module(path), ecosystem=ecosystem)
+            Discovery(
+                kind="manifest",
+                path=path,
+                module=owning_module(path),
+                ecosystem=ecosystem,
+            )
         )

--- a/tools/license_compliance/src/ov_contrib_license/discovery/manifests.py
+++ b/tools/license_compliance/src/ov_contrib_license/discovery/manifests.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import fnmatch
+from pathlib import PurePosixPath
+
+from ov_contrib_license.model import Discovery, InventoryBuilder
+
+from .common import owning_module
+
+MANIFEST_PATTERNS: tuple[tuple[str, str], ...] = (
+    ("requirements*.txt", "python"),
+    ("setup.py", "python"),
+    ("setup.cfg", "python"),
+    ("pyproject.toml", "python"),
+    ("Pipfile*", "python"),
+    ("poetry.lock", "python"),
+    ("package.json", "node"),
+    ("package-lock.json", "node"),
+    ("yarn.lock", "node"),
+    ("pnpm-lock.yaml", "node"),
+    ("go.mod", "go"),
+    ("go.sum", "go"),
+    ("build.gradle*", "gradle"),
+    ("settings.gradle*", "gradle"),
+    ("Cargo.toml", "cargo"),
+    ("Cargo.lock", "cargo"),
+    ("conanfile.*", "conan"),
+    ("Dockerfile*", "docker"),
+    (".gitmodules", "git"),
+)
+
+
+def manifest_ecosystem(path: str) -> str | None:
+    name = PurePosixPath(path).name
+    for pattern, ecosystem in MANIFEST_PATTERNS:
+        if fnmatch.fnmatchcase(name, pattern):
+            return ecosystem
+    return None
+
+
+def discover_manifests(builder: InventoryBuilder, files: tuple[str, ...]) -> None:
+    for path in files:
+        ecosystem = manifest_ecosystem(path)
+        if ecosystem is None:
+            continue
+        builder.add_discovery(
+            Discovery(kind="manifest", path=path, module=owning_module(path), ecosystem=ecosystem)
+        )

--- a/tools/license_compliance/src/ov_contrib_license/discovery/repository.py
+++ b/tools/license_compliance/src/ov_contrib_license/discovery/repository.py
@@ -31,6 +31,7 @@ DEFAULT_IGNORED_DIRECTORY_NAMES = frozenset(
         "build",
         "dist",
         "node_modules",
+        "venv",
     }
 )
 DEFAULT_IGNORED_PATH_PREFIXES = ("tools/license_compliance/tests/fixtures/",)

--- a/tools/license_compliance/src/ov_contrib_license/discovery/repository.py
+++ b/tools/license_compliance/src/ov_contrib_license/discovery/repository.py
@@ -1,0 +1,160 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import fnmatch
+import subprocess
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+from ov_contrib_license.model import Inventory, InventoryBuilder, RepositoryInfo
+
+from .cmake import discover_cmake
+from .common import owning_scope
+from .downloads import discover_downloads
+from .github_actions import discover_github_actions
+from .manifests import discover_manifests
+from .submodules import discover_submodules
+from .vendored import discover_vendored_trees
+
+DEFAULT_IGNORED_DIRECTORY_NAMES = frozenset(
+    {
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+        ".venv",
+        "__pycache__",
+        "build",
+        "dist",
+        "node_modules",
+    }
+)
+
+
+class DiscoveryError(RuntimeError):
+    """Raised when deterministic repository discovery cannot be completed."""
+
+
+@dataclass(frozen=True)
+class DiscoveryOptions:
+    base_ref: str | None = None
+    head_ref: str | None = None
+    includes: tuple[str, ...] = ()
+    excludes: tuple[str, ...] = ()
+    offline: bool = False
+
+    def validate(self) -> None:
+        if bool(self.base_ref) != bool(self.head_ref):
+            raise ValueError("--base-ref and --head-ref must be provided together")
+
+
+def _run_git(root: Path, arguments: list[str], *, required: bool) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), *arguments],
+            check=False,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+    except OSError as error:
+        if required:
+            raise DiscoveryError(f"Unable to execute Git: {error}") from error
+        return None
+    if result.returncode:
+        if required:
+            reason = result.stderr.strip() or f"exit status {result.returncode}"
+            raise DiscoveryError(f"Git {' '.join(arguments)} failed: {reason}")
+        return None
+    return result.stdout
+
+
+def git_revision(root: Path) -> str | None:
+    output = _run_git(root, ["rev-parse", "HEAD"], required=False)
+    return output.strip() if output else None
+
+
+def changed_scopes(root: Path, base_ref: str, head_ref: str) -> tuple[str, ...]:
+    output = _run_git(
+        root,
+        ["diff", "--name-only", "--diff-filter=ACMRTUXB", base_ref, head_ref, "--"],
+        required=True,
+    )
+    assert output is not None
+    return tuple(sorted({owning_scope(line.strip()) for line in output.splitlines() if line.strip()}))
+
+
+def _is_ignored_directory(path: str) -> bool:
+    return any(part in DEFAULT_IGNORED_DIRECTORY_NAMES for part in PurePosixPath(path).parts[:-1])
+
+
+def _matches(path: str, patterns: Iterable[str]) -> bool:
+    pure = PurePosixPath(path)
+    return any(fnmatch.fnmatchcase(path, pattern) or pure.match(pattern) for pattern in patterns)
+
+
+def _selected(path: str, options: DiscoveryOptions, scopes: tuple[str, ...] | None) -> bool:
+    if _is_ignored_directory(path):
+        return False
+    if scopes is not None and owning_scope(path) not in scopes:
+        return False
+    if options.includes and not _matches(path, options.includes):
+        return False
+    return not _matches(path, options.excludes)
+
+
+def repository_files(
+    root: Path, options: DiscoveryOptions, scopes: tuple[str, ...] | None
+) -> tuple[str, ...]:
+    output = _run_git(root, ["ls-files", "-z", "--cached", "--others", "--exclude-standard"], required=False)
+    if output is not None:
+        candidates = output.split("\0")
+    else:
+        candidates = [item.relative_to(root).as_posix() for item in root.rglob("*") if item.is_file()]
+    return tuple(sorted(path for path in candidates if path and _selected(path, options, scopes)))
+
+
+def read_text(root: Path, relative_path: str, *, size_limit: int = 4 * 1024 * 1024) -> str | None:
+    path = root / relative_path
+    try:
+        if not path.is_file() or path.stat().st_size > size_limit:
+            return None
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+
+
+class RepositoryDiscovery:
+    def __init__(self, root: Path, options: DiscoveryOptions | None = None) -> None:
+        self.root = root.resolve()
+        self.options = options or DiscoveryOptions()
+
+    def run(self) -> Inventory:
+        self.options.validate()
+        if not self.root.is_dir():
+            raise ValueError(f"Repository path is not a directory: {self.root}")
+
+        scopes: tuple[str, ...] | None = None
+        if self.options.base_ref and self.options.head_ref:
+            scopes = changed_scopes(self.root, self.options.base_ref, self.options.head_ref)
+        files = repository_files(self.root, self.options, scopes)
+        repository = RepositoryInfo(
+            path=".",
+            revision=git_revision(self.root),
+            base_ref=self.options.base_ref,
+            head_ref=self.options.head_ref,
+            impacted_scopes=scopes or (),
+        )
+        builder = InventoryBuilder(repository)
+
+        discover_manifests(builder, files)
+        discover_cmake(builder, self.root, files)
+        discover_downloads(builder, self.root, files)
+        discover_submodules(builder, self.root, files)
+        discover_vendored_trees(builder, self.root, files)
+        discover_github_actions(builder, self.root, files)
+        return builder.build()

--- a/tools/license_compliance/src/ov_contrib_license/discovery/repository.py
+++ b/tools/license_compliance/src/ov_contrib_license/discovery/repository.py
@@ -33,6 +33,7 @@ DEFAULT_IGNORED_DIRECTORY_NAMES = frozenset(
         "node_modules",
     }
 )
+DEFAULT_IGNORED_PATH_PREFIXES = ("tools/license_compliance/tests/fixtures/",)
 
 
 class DiscoveryError(RuntimeError):
@@ -78,27 +79,49 @@ def git_revision(root: Path) -> str | None:
     return output.strip() if output else None
 
 
-def changed_scopes(root: Path, base_ref: str, head_ref: str) -> tuple[str, ...]:
+def changed_paths(root: Path, base_ref: str, head_ref: str) -> tuple[str, ...]:
     output = _run_git(
         root,
         ["diff", "--name-only", "--diff-filter=ACMRTUXB", base_ref, head_ref, "--"],
         required=True,
     )
     assert output is not None
-    return tuple(sorted({owning_scope(line.strip()) for line in output.splitlines() if line.strip()}))
+    return tuple(sorted(line.strip() for line in output.splitlines() if line.strip()))
+
+
+def changed_scopes(root: Path, base_ref: str, head_ref: str) -> tuple[str, ...]:
+    return tuple(
+        sorted({owning_scope(path) for path in changed_paths(root, base_ref, head_ref)})
+    )
+
+
+def _requires_full_discovery(paths: tuple[str, ...]) -> bool:
+    return any(
+        path == "third-party-programs.txt"
+        or path.startswith("tools/license_compliance/policy/")
+        for path in paths
+    )
 
 
 def _is_ignored_directory(path: str) -> bool:
-    return any(part in DEFAULT_IGNORED_DIRECTORY_NAMES for part in PurePosixPath(path).parts[:-1])
+    return any(
+        part in DEFAULT_IGNORED_DIRECTORY_NAMES
+        for part in PurePosixPath(path).parts[:-1]
+    )
 
 
 def _matches(path: str, patterns: Iterable[str]) -> bool:
     pure = PurePosixPath(path)
-    return any(fnmatch.fnmatchcase(path, pattern) or pure.match(pattern) for pattern in patterns)
+    return any(
+        fnmatch.fnmatchcase(path, pattern) or pure.match(pattern)
+        for pattern in patterns
+    )
 
 
-def _selected(path: str, options: DiscoveryOptions, scopes: tuple[str, ...] | None) -> bool:
-    if _is_ignored_directory(path):
+def _selected(
+    path: str, options: DiscoveryOptions, scopes: tuple[str, ...] | None
+) -> bool:
+    if _is_ignored_directory(path) or path.startswith(DEFAULT_IGNORED_PATH_PREFIXES):
         return False
     if scopes is not None and owning_scope(path) not in scopes:
         return False
@@ -110,15 +133,27 @@ def _selected(path: str, options: DiscoveryOptions, scopes: tuple[str, ...] | No
 def repository_files(
     root: Path, options: DiscoveryOptions, scopes: tuple[str, ...] | None
 ) -> tuple[str, ...]:
-    output = _run_git(root, ["ls-files", "-z", "--cached", "--others", "--exclude-standard"], required=False)
+    output = _run_git(
+        root,
+        ["ls-files", "-z", "--cached", "--others", "--exclude-standard"],
+        required=False,
+    )
     if output is not None:
         candidates = output.split("\0")
     else:
-        candidates = [item.relative_to(root).as_posix() for item in root.rglob("*") if item.is_file()]
-    return tuple(sorted(path for path in candidates if path and _selected(path, options, scopes)))
+        candidates = [
+            item.relative_to(root).as_posix()
+            for item in root.rglob("*")
+            if item.is_file()
+        ]
+    return tuple(
+        sorted(path for path in candidates if path and _selected(path, options, scopes))
+    )
 
 
-def read_text(root: Path, relative_path: str, *, size_limit: int = 4 * 1024 * 1024) -> str | None:
+def read_text(
+    root: Path, relative_path: str, *, size_limit: int = 4 * 1024 * 1024
+) -> str | None:
     path = root / relative_path
     try:
         if not path.is_file() or path.stat().st_size > size_limit:
@@ -139,15 +174,20 @@ class RepositoryDiscovery:
             raise ValueError(f"Repository path is not a directory: {self.root}")
 
         scopes: tuple[str, ...] | None = None
+        impacted_scopes: tuple[str, ...] = ()
         if self.options.base_ref and self.options.head_ref:
-            scopes = changed_scopes(self.root, self.options.base_ref, self.options.head_ref)
+            paths = changed_paths(
+                self.root, self.options.base_ref, self.options.head_ref
+            )
+            impacted_scopes = tuple(sorted({owning_scope(path) for path in paths}))
+            scopes = None if _requires_full_discovery(paths) else impacted_scopes
         files = repository_files(self.root, self.options, scopes)
         repository = RepositoryInfo(
             path=".",
             revision=git_revision(self.root),
             base_ref=self.options.base_ref,
             head_ref=self.options.head_ref,
-            impacted_scopes=scopes or (),
+            impacted_scopes=impacted_scopes,
         )
         builder = InventoryBuilder(repository)
 

--- a/tools/license_compliance/src/ov_contrib_license/discovery/submodules.py
+++ b/tools/license_compliance/src/ov_contrib_license/discovery/submodules.py
@@ -12,6 +12,7 @@ from ov_contrib_license.model import (
     Confidence,
     Decision,
     Discovery,
+    DistributionStatus,
     Evidence,
     EvidenceKind,
     Finding,
@@ -42,7 +43,9 @@ def _index_revision(root: Path, path: str) -> str | None:
     return fields[1] if len(fields) >= 2 and fields[0] == "160000" else None
 
 
-def discover_submodules(builder: InventoryBuilder, root: Path, files: tuple[str, ...]) -> None:
+def discover_submodules(
+    builder: InventoryBuilder, root: Path, files: tuple[str, ...]
+) -> None:
     if ".gitmodules" not in files:
         return
     parser = configparser.ConfigParser(interpolation=None)
@@ -74,7 +77,9 @@ def discover_submodules(builder: InventoryBuilder, root: Path, files: tuple[str,
                 path=".gitmodules",
                 module=owning_module(path),
                 ecosystem="git",
-                details=normalize_details({"submodule_path": path, "url": url, "revision": revision}),
+                details=normalize_details(
+                    {"submodule_path": path, "url": url, "revision": revision}
+                ),
             )
         )
         builder.add_component(
@@ -86,6 +91,7 @@ def discover_submodules(builder: InventoryBuilder, root: Path, files: tuple[str,
                 paths=(path,),
                 relationships=(Relationship.VENDORED_SOURCE,),
                 evidence=(evidence,),
+                distribution=DistributionStatus.DISTRIBUTED,
                 details=normalize_details({"source_url": url}),
             )
         )

--- a/tools/license_compliance/src/ov_contrib_license/discovery/submodules.py
+++ b/tools/license_compliance/src/ov_contrib_license/discovery/submodules.py
@@ -1,0 +1,103 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import configparser
+import subprocess
+from pathlib import Path
+
+from ov_contrib_license.model import (
+    Component,
+    Confidence,
+    Decision,
+    Discovery,
+    Evidence,
+    EvidenceKind,
+    Finding,
+    InventoryBuilder,
+    Relationship,
+    Severity,
+)
+from ov_contrib_license.model.types import normalize_details
+
+from .common import owning_module
+
+
+def _index_revision(root: Path, path: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), "ls-files", "--stage", "--", path],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            encoding="utf-8",
+        )
+    except OSError:
+        return None
+    if result.returncode or not result.stdout.strip():
+        return None
+    fields = result.stdout.split()
+    return fields[1] if len(fields) >= 2 and fields[0] == "160000" else None
+
+
+def discover_submodules(builder: InventoryBuilder, root: Path, files: tuple[str, ...]) -> None:
+    if ".gitmodules" not in files:
+        return
+    parser = configparser.ConfigParser(interpolation=None)
+    try:
+        parser.read(root / ".gitmodules", encoding="utf-8")
+    except (configparser.Error, OSError):
+        return
+
+    for section in sorted(parser.sections()):
+        if not section.startswith("submodule "):
+            continue
+        path = parser.get(section, "path", fallback="").strip()
+        url = parser.get(section, "url", fallback="").strip()
+        if not path or not url:
+            continue
+        revision = _index_revision(root, path)
+        component_id = f"vcs:{url}" + (f"@{revision}" if revision else "")
+        evidence = Evidence(
+            kind=EvidenceKind.GIT_SUBMODULE,
+            source="gitmodules-discovery",
+            path=".gitmodules",
+            value=url,
+            confidence=Confidence.HIGH if revision else Confidence.MEDIUM,
+            details=normalize_details({"path": path, "revision": revision}),
+        )
+        builder.add_discovery(
+            Discovery(
+                kind="git-submodule",
+                path=".gitmodules",
+                module=owning_module(path),
+                ecosystem="git",
+                details=normalize_details({"submodule_path": path, "url": url, "revision": revision}),
+            )
+        )
+        builder.add_component(
+            Component(
+                id=component_id,
+                name=section.removeprefix('submodule "').removesuffix('"'),
+                version=revision,
+                module=owning_module(path),
+                paths=(path,),
+                relationships=(Relationship.VENDORED_SOURCE,),
+                evidence=(evidence,),
+                details=normalize_details({"source_url": url}),
+            )
+        )
+        if revision is None:
+            builder.add_finding(
+                Finding.create(
+                    code="DISCOVERY_SUBMODULE_UNPINNED",
+                    severity=Severity.WARNING,
+                    decision=Decision.REVIEW,
+                    component_id=component_id,
+                    message=f"Git submodule {path!r} has no pinned commit in the Git index.",
+                    evidence=(evidence,),
+                    remediation=("Commit the submodule gitlink at an exact revision.",),
+                )
+            )

--- a/tools/license_compliance/src/ov_contrib_license/discovery/vendored.py
+++ b/tools/license_compliance/src/ov_contrib_license/discovery/vendored.py
@@ -1,0 +1,152 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from pathlib import Path, PurePosixPath
+
+from ov_contrib_license.model import (
+    Component,
+    Confidence,
+    Discovery,
+    Evidence,
+    EvidenceKind,
+    InventoryBuilder,
+    Relationship,
+)
+from ov_contrib_license.model.types import normalize_details
+
+from .common import owning_module
+
+VENDORED_DIRECTORY_NAMES = frozenset(
+    {"third_party", "thirdparty", "3rdparty", "vendor", "vendors", "external", "extern", "deps"}
+)
+LICENSE_FILE_NAMES = frozenset({"copying", "copyright", "license", "notice"})
+SOURCE_SUFFIXES = frozenset(
+    {".c", ".cc", ".cl", ".cpp", ".cxx", ".go", ".h", ".hpp", ".java", ".js", ".kt", ".py", ".ts"}
+)
+COPYRIGHT_PATTERN = re.compile(r"copyright[^\n\r]{0,200}", re.IGNORECASE)
+
+
+def _vendored_root(path: str) -> str | None:
+    parts = PurePosixPath(path).parts
+    for index, part in enumerate(parts[:-1]):
+        if part.lower() in VENDORED_DIRECTORY_NAMES:
+            return PurePosixPath(*parts[: index + 1]).as_posix()
+    return None
+
+
+def _content_root(path: str) -> str | None:
+    parts = PurePosixPath(path).parts
+    if len(parts) >= 4 and parts[0] == "modules":
+        return PurePosixPath(*parts[:3]).as_posix()
+    return None
+
+
+def _license_file(path: str) -> bool:
+    name = PurePosixPath(path).name.lower()
+    stem = name.split(".", 1)[0]
+    return stem in LICENSE_FILE_NAMES
+
+
+def _has_foreign_copyright(path: Path) -> bool:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")[:8192]
+    except OSError:
+        return False
+    matches = COPYRIGHT_PATTERN.findall(text)
+    return any("intel corporation" not in match.lower() for match in matches)
+
+
+def _add_vendored_component(
+    builder: InventoryBuilder,
+    root: str,
+    *,
+    heuristic: str,
+    confidence: Confidence,
+    signal_count: int | None = None,
+) -> None:
+    name = PurePosixPath(root).name
+    details = normalize_details({"heuristic": heuristic, "signal_count": signal_count})
+    evidence_kind = (
+        EvidenceKind.LICENSE_FILE if heuristic == "nested-license-file" else EvidenceKind.VENDORED_TREE
+    )
+    evidence = Evidence(
+        kind=evidence_kind,
+        source="vendored-content-heuristic"
+        if heuristic != "directory-name"
+        else "vendored-directory-heuristic",
+        path=root,
+        value=name,
+        confidence=confidence,
+        details=details,
+    )
+    builder.add_discovery(
+        Discovery(
+            kind="vendored-tree",
+            path=root,
+            module=owning_module(root),
+            details=details,
+        )
+    )
+    builder.add_component(
+        Component(
+            id=f"local:{root}",
+            name=name,
+            module=owning_module(root),
+            paths=(root,),
+            relationships=(Relationship.VENDORED_SOURCE,),
+            evidence=(evidence,),
+        )
+    )
+
+
+def discover_vendored_trees(builder: InventoryBuilder, repository_root: Path, files: tuple[str, ...]) -> None:
+    explicit_roots = sorted(filter(None, {_vendored_root(path) for path in files}))
+    for root in explicit_roots:
+        assert root is not None
+        _add_vendored_component(
+            builder,
+            root,
+            heuristic="directory-name",
+            confidence=Confidence.LOW,
+        )
+
+    nested_license_roots = sorted(
+        {
+            content_root
+            for path in files
+            if _license_file(path)
+            for content_root in (_content_root(path),)
+            if content_root and content_root not in explicit_roots
+        }
+    )
+    for root in nested_license_roots:
+        _add_vendored_component(
+            builder,
+            root,
+            heuristic="nested-license-file",
+            confidence=Confidence.MEDIUM,
+        )
+
+    copyright_signals: dict[str, list[str]] = defaultdict(list)
+    for path in files:
+        content_root = _content_root(path)
+        if (
+            content_root
+            and PurePosixPath(path).suffix.lower() in SOURCE_SUFFIXES
+            and _has_foreign_copyright(repository_root / path)
+        ):
+            copyright_signals[content_root].append(path)
+    for root, signals in sorted(copyright_signals.items()):
+        if len(signals) < 3 or root in explicit_roots or root in nested_license_roots:
+            continue
+        _add_vendored_component(
+            builder,
+            root,
+            heuristic="foreign-copyright-cluster",
+            confidence=Confidence.MEDIUM,
+            signal_count=len(signals),
+        )

--- a/tools/license_compliance/src/ov_contrib_license/discovery/vendored.py
+++ b/tools/license_compliance/src/ov_contrib_license/discovery/vendored.py
@@ -11,6 +11,7 @@ from ov_contrib_license.model import (
     Component,
     Confidence,
     Discovery,
+    DistributionStatus,
     Evidence,
     EvidenceKind,
     InventoryBuilder,
@@ -21,11 +22,34 @@ from ov_contrib_license.model.types import normalize_details
 from .common import owning_module
 
 VENDORED_DIRECTORY_NAMES = frozenset(
-    {"third_party", "thirdparty", "3rdparty", "vendor", "vendors", "external", "extern", "deps"}
+    {
+        "third_party",
+        "thirdparty",
+        "3rdparty",
+        "vendor",
+        "vendors",
+        "external",
+        "extern",
+        "deps",
+    }
 )
 LICENSE_FILE_NAMES = frozenset({"copying", "copyright", "license", "notice"})
 SOURCE_SUFFIXES = frozenset(
-    {".c", ".cc", ".cl", ".cpp", ".cxx", ".go", ".h", ".hpp", ".java", ".js", ".kt", ".py", ".ts"}
+    {
+        ".c",
+        ".cc",
+        ".cl",
+        ".cpp",
+        ".cxx",
+        ".go",
+        ".h",
+        ".hpp",
+        ".java",
+        ".js",
+        ".kt",
+        ".py",
+        ".ts",
+    }
 )
 COPYRIGHT_PATTERN = re.compile(r"copyright[^\n\r]{0,200}", re.IGNORECASE)
 
@@ -71,7 +95,9 @@ def _add_vendored_component(
     name = PurePosixPath(root).name
     details = normalize_details({"heuristic": heuristic, "signal_count": signal_count})
     evidence_kind = (
-        EvidenceKind.LICENSE_FILE if heuristic == "nested-license-file" else EvidenceKind.VENDORED_TREE
+        EvidenceKind.LICENSE_FILE
+        if heuristic == "nested-license-file"
+        else EvidenceKind.VENDORED_TREE
     )
     evidence = Evidence(
         kind=evidence_kind,
@@ -99,11 +125,14 @@ def _add_vendored_component(
             paths=(root,),
             relationships=(Relationship.VENDORED_SOURCE,),
             evidence=(evidence,),
+            distribution=DistributionStatus.DISTRIBUTED,
         )
     )
 
 
-def discover_vendored_trees(builder: InventoryBuilder, repository_root: Path, files: tuple[str, ...]) -> None:
+def discover_vendored_trees(
+    builder: InventoryBuilder, repository_root: Path, files: tuple[str, ...]
+) -> None:
     explicit_roots = sorted(filter(None, {_vendored_root(path) for path in files}))
     for root in explicit_roots:
         assert root is not None

--- a/tools/license_compliance/src/ov_contrib_license/model/__init__.py
+++ b/tools/license_compliance/src/ov_contrib_license/model/__init__.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from .inventory import Inventory, InventoryBuilder, Provider, RepositoryInfo
+from .types import (
+    Component,
+    Confidence,
+    Decision,
+    Discovery,
+    DistributionStatus,
+    Evidence,
+    EvidenceKind,
+    Finding,
+    Relationship,
+    Severity,
+)
+
+__all__ = [
+    "Component",
+    "Confidence",
+    "Decision",
+    "Discovery",
+    "DistributionStatus",
+    "Evidence",
+    "EvidenceKind",
+    "Finding",
+    "Inventory",
+    "InventoryBuilder",
+    "Provider",
+    "Relationship",
+    "RepositoryInfo",
+    "Severity",
+]

--- a/tools/license_compliance/src/ov_contrib_license/model/__init__.py
+++ b/tools/license_compliance/src/ov_contrib_license/model/__init__.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .inventory import Inventory, InventoryBuilder, Provider, RepositoryInfo
+from .serde import inventory_from_dict, read_inventory
 from .types import (
     Component,
     Confidence,
@@ -11,6 +12,7 @@ from .types import (
     Evidence,
     EvidenceKind,
     Finding,
+    Obligation,
     Relationship,
     Severity,
 )
@@ -26,8 +28,11 @@ __all__ = [
     "Finding",
     "Inventory",
     "InventoryBuilder",
+    "Obligation",
     "Provider",
     "Relationship",
     "RepositoryInfo",
     "Severity",
+    "inventory_from_dict",
+    "read_inventory",
 ]

--- a/tools/license_compliance/src/ov_contrib_license/model/inventory.py
+++ b/tools/license_compliance/src/ov_contrib_license/model/inventory.py
@@ -1,0 +1,140 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+
+from ov_contrib_license import __version__
+
+from .types import Component, Discovery, Evidence, Finding, normalize_details
+
+
+@dataclass(frozen=True)
+class RepositoryInfo:
+    path: str
+    revision: str | None
+    base_ref: str | None = None
+    head_ref: str | None = None
+    impacted_scopes: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "path": self.path,
+            "revision": self.revision,
+            "base_ref": self.base_ref,
+            "head_ref": self.head_ref,
+            "impacted_scopes": list(sorted(self.impacted_scopes)),
+        }
+
+
+@dataclass(frozen=True)
+class Provider:
+    name: str
+    version: str
+    status: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {"name": self.name, "version": self.version, "status": self.status}
+
+
+@dataclass(frozen=True)
+class Inventory:
+    repository: RepositoryInfo
+    components: tuple[Component, ...] = field(default_factory=tuple)
+    discoveries: tuple[Discovery, ...] = field(default_factory=tuple)
+    findings: tuple[Finding, ...] = field(default_factory=tuple)
+    providers: tuple[Provider, ...] = field(default_factory=tuple)
+    schema_version: int = 1
+
+    def validate(self) -> None:
+        if self.schema_version != 1:
+            raise ValueError(f"Unsupported inventory schema version: {self.schema_version}")
+        ids = [item.id for item in self.components]
+        if len(ids) != len(set(ids)):
+            raise ValueError("Inventory contains duplicate component IDs")
+        finding_ids = [item.id for item in self.findings]
+        if len(finding_ids) != len(set(finding_ids)):
+            raise ValueError("Inventory contains duplicate finding IDs")
+        for component in self.components:
+            if not component.id or not component.name:
+                raise ValueError("Component ID and name must not be empty")
+            for path in component.paths:
+                if path.startswith("/") or path == ".." or path.startswith("../"):
+                    raise ValueError(f"Component path is not repository-relative: {path}")
+
+    def to_dict(self) -> dict[str, object]:
+        self.validate()
+        return {
+            "schema_version": self.schema_version,
+            "repository": self.repository.to_dict(),
+            "components": [item.to_dict() for item in self.components],
+            "discoveries": [item.to_dict() for item in self.discoveries],
+            "findings": [item.to_dict() for item in self.findings],
+            "providers": [item.to_dict() for item in self.providers],
+        }
+
+
+class InventoryBuilder:
+    def __init__(self, repository: RepositoryInfo) -> None:
+        self.repository = repository
+        self._components: dict[str, Component] = {}
+        self._discoveries: set[Discovery] = set()
+        self._findings: dict[str, Finding] = {}
+
+    def add_component(self, component: Component) -> None:
+        previous = self._components.get(component.id)
+        if previous is None:
+            self._components[component.id] = component
+            return
+
+        modules = set(filter(None, (previous.module, component.module)))
+        modules.update(filter(None, dict(previous.details).get("modules", "").split(",")))
+        modules.update(filter(None, dict(component.details).get("modules", "").split(",")))
+        module = next(iter(modules)) if len(modules) == 1 else None
+        details = dict(previous.details)
+        for key, value in component.details:
+            if key in details and details[key] != value:
+                details[key] = ",".join(sorted(set(details[key].split(",")) | set(value.split(","))))
+            else:
+                details[key] = value
+        if len(modules) > 1:
+            details["modules"] = ",".join(sorted(modules))
+
+        evidence = tuple(sorted(set(previous.evidence + component.evidence), key=Evidence.sort_key))
+        self._components[component.id] = replace(
+            previous,
+            name=previous.name or component.name,
+            version=previous.version or component.version,
+            module=module,
+            paths=tuple(sorted(set(previous.paths + component.paths))),
+            declared_license=previous.declared_license or component.declared_license,
+            detected_licenses=tuple(sorted(set(previous.detected_licenses + component.detected_licenses))),
+            relationships=tuple(
+                sorted(set(previous.relationships + component.relationships), key=lambda item: item.value)
+            ),
+            evidence=evidence,
+            distribution=(
+                previous.distribution
+                if previous.distribution == component.distribution
+                else type(previous.distribution).UNKNOWN
+            ),
+            details=normalize_details(details),
+        )
+
+    def add_discovery(self, discovery: Discovery) -> None:
+        self._discoveries.add(discovery)
+
+    def add_finding(self, finding: Finding) -> None:
+        self._findings[finding.id] = finding
+
+    def build(self) -> Inventory:
+        inventory = Inventory(
+            repository=self.repository,
+            components=tuple(sorted(self._components.values(), key=lambda item: item.id)),
+            discoveries=tuple(sorted(self._discoveries, key=Discovery.sort_key)),
+            findings=tuple(sorted(self._findings.values(), key=Finding.sort_key)),
+            providers=(Provider("repository-discovery", __version__, "SUCCESS"),),
+        )
+        inventory.validate()
+        return inventory

--- a/tools/license_compliance/src/ov_contrib_license/model/inventory.py
+++ b/tools/license_compliance/src/ov_contrib_license/model/inventory.py
@@ -24,7 +24,7 @@ class RepositoryInfo:
             "revision": self.revision,
             "base_ref": self.base_ref,
             "head_ref": self.head_ref,
-            "impacted_scopes": list(sorted(self.impacted_scopes)),
+            "impacted_scopes": sorted(self.impacted_scopes),
         }
 
 
@@ -49,7 +49,9 @@ class Inventory:
 
     def validate(self) -> None:
         if self.schema_version != 1:
-            raise ValueError(f"Unsupported inventory schema version: {self.schema_version}")
+            raise ValueError(
+                f"Unsupported inventory schema version: {self.schema_version}"
+            )
         ids = [item.id for item in self.components]
         if len(ids) != len(set(ids)):
             raise ValueError("Inventory contains duplicate component IDs")
@@ -60,8 +62,10 @@ class Inventory:
             if not component.id or not component.name:
                 raise ValueError("Component ID and name must not be empty")
             for path in component.paths:
-                if path.startswith("/") or path == ".." or path.startswith("../"):
-                    raise ValueError(f"Component path is not repository-relative: {path}")
+                if path.startswith(("/", "../")) or path == "..":
+                    raise ValueError(
+                        f"Component path is not repository-relative: {path}"
+                    )
 
     def to_dict(self) -> dict[str, object]:
         self.validate()
@@ -81,6 +85,24 @@ class InventoryBuilder:
         self._components: dict[str, Component] = {}
         self._discoveries: set[Discovery] = set()
         self._findings: dict[str, Finding] = {}
+        self._providers: dict[str, Provider] = {
+            "repository-discovery": Provider(
+                "repository-discovery", __version__, "SUCCESS"
+            )
+        }
+
+    @classmethod
+    def from_inventory(cls, inventory: Inventory) -> InventoryBuilder:
+        builder = cls(inventory.repository)
+        for component in inventory.components:
+            builder.add_component(component)
+        for discovery in inventory.discoveries:
+            builder.add_discovery(discovery)
+        for finding in inventory.findings:
+            builder.add_finding(finding)
+        for provider in inventory.providers:
+            builder.add_provider(provider)
+        return builder
 
     def add_component(self, component: Component) -> None:
         previous = self._components.get(component.id)
@@ -89,19 +111,27 @@ class InventoryBuilder:
             return
 
         modules = set(filter(None, (previous.module, component.module)))
-        modules.update(filter(None, dict(previous.details).get("modules", "").split(",")))
-        modules.update(filter(None, dict(component.details).get("modules", "").split(",")))
+        modules.update(
+            filter(None, dict(previous.details).get("modules", "").split(","))
+        )
+        modules.update(
+            filter(None, dict(component.details).get("modules", "").split(","))
+        )
         module = next(iter(modules)) if len(modules) == 1 else None
         details = dict(previous.details)
         for key, value in component.details:
             if key in details and details[key] != value:
-                details[key] = ",".join(sorted(set(details[key].split(",")) | set(value.split(","))))
+                details[key] = ",".join(
+                    sorted(set(details[key].split(",")) | set(value.split(",")))
+                )
             else:
                 details[key] = value
         if len(modules) > 1:
             details["modules"] = ",".join(sorted(modules))
 
-        evidence = tuple(sorted(set(previous.evidence + component.evidence), key=Evidence.sort_key))
+        evidence = tuple(
+            sorted(set(previous.evidence + component.evidence), key=Evidence.sort_key)
+        )
         self._components[component.id] = replace(
             previous,
             name=previous.name or component.name,
@@ -109,15 +139,26 @@ class InventoryBuilder:
             module=module,
             paths=tuple(sorted(set(previous.paths + component.paths))),
             declared_license=previous.declared_license or component.declared_license,
-            detected_licenses=tuple(sorted(set(previous.detected_licenses + component.detected_licenses))),
+            detected_licenses=tuple(
+                sorted(set(previous.detected_licenses + component.detected_licenses))
+            ),
             relationships=tuple(
-                sorted(set(previous.relationships + component.relationships), key=lambda item: item.value)
+                sorted(
+                    set(previous.relationships + component.relationships),
+                    key=lambda item: item.value,
+                )
             ),
             evidence=evidence,
             distribution=(
                 previous.distribution
                 if previous.distribution == component.distribution
                 else type(previous.distribution).UNKNOWN
+            ),
+            obligations=tuple(
+                sorted(
+                    set(previous.obligations + component.obligations),
+                    key=lambda item: item.value,
+                )
             ),
             details=normalize_details(details),
         )
@@ -128,13 +169,20 @@ class InventoryBuilder:
     def add_finding(self, finding: Finding) -> None:
         self._findings[finding.id] = finding
 
+    def add_provider(self, provider: Provider) -> None:
+        self._providers[provider.name] = provider
+
     def build(self) -> Inventory:
         inventory = Inventory(
             repository=self.repository,
-            components=tuple(sorted(self._components.values(), key=lambda item: item.id)),
+            components=tuple(
+                sorted(self._components.values(), key=lambda item: item.id)
+            ),
             discoveries=tuple(sorted(self._discoveries, key=Discovery.sort_key)),
             findings=tuple(sorted(self._findings.values(), key=Finding.sort_key)),
-            providers=(Provider("repository-discovery", __version__, "SUCCESS"),),
+            providers=tuple(
+                sorted(self._providers.values(), key=lambda item: item.name)
+            ),
         )
         inventory.validate()
         return inventory

--- a/tools/license_compliance/src/ov_contrib_license/model/serde.py
+++ b/tools/license_compliance/src/ov_contrib_license/model/serde.py
@@ -1,0 +1,116 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .inventory import Inventory, Provider, RepositoryInfo
+from .types import (
+    Component,
+    Confidence,
+    Decision,
+    Discovery,
+    DistributionStatus,
+    Evidence,
+    EvidenceKind,
+    Finding,
+    Obligation,
+    Relationship,
+    Severity,
+    normalize_details,
+)
+
+
+def _evidence(data: dict[str, Any]) -> Evidence:
+    return Evidence(
+        kind=EvidenceKind(data["kind"]),
+        source=str(data["source"]),
+        path=data.get("path"),
+        value=data.get("value"),
+        confidence=Confidence(data.get("confidence", Confidence.MEDIUM.value)),
+        details=normalize_details(data.get("details")),
+    )
+
+
+def inventory_from_dict(data: dict[str, Any]) -> Inventory:
+    repository_data = data["repository"]
+    repository = RepositoryInfo(
+        path=str(repository_data.get("path", ".")),
+        revision=repository_data.get("revision"),
+        base_ref=repository_data.get("base_ref"),
+        head_ref=repository_data.get("head_ref"),
+        impacted_scopes=tuple(repository_data.get("impacted_scopes", ())),
+    )
+    components = tuple(
+        Component(
+            id=str(item["id"]),
+            name=str(item["name"]),
+            version=item.get("version"),
+            module=item.get("module"),
+            paths=tuple(item.get("paths", ())),
+            declared_license=item.get("declared_license"),
+            detected_licenses=tuple(item.get("detected_licenses", ())),
+            relationships=tuple(
+                Relationship(value) for value in item.get("relationships", ("UNKNOWN",))
+            ),
+            evidence=tuple(_evidence(value) for value in item.get("evidence", ())),
+            distribution=DistributionStatus(item.get("distribution", "UNKNOWN")),
+            obligations=tuple(
+                Obligation(value) for value in item.get("obligations", ())
+            ),
+            details=normalize_details(item.get("details")),
+        )
+        for item in data.get("components", ())
+    )
+    discoveries = tuple(
+        Discovery(
+            kind=str(item["kind"]),
+            path=str(item["path"]),
+            module=item.get("module"),
+            ecosystem=item.get("ecosystem"),
+            details=normalize_details(item.get("details")),
+        )
+        for item in data.get("discoveries", ())
+    )
+    findings = tuple(
+        Finding(
+            id=str(item["id"]),
+            code=str(item["code"]),
+            severity=Severity(item["severity"]),
+            decision=Decision(item["decision"]),
+            component_id=item.get("component_id"),
+            message=str(item["message"]),
+            evidence=tuple(_evidence(value) for value in item.get("evidence", ())),
+            remediation=tuple(item.get("remediation", ())),
+            suppressed=bool(item.get("suppressed", False)),
+            suppression_reason=item.get("suppression_reason"),
+        )
+        for item in data.get("findings", ())
+    )
+    providers = tuple(
+        Provider(str(item["name"]), str(item["version"]), str(item["status"]))
+        for item in data.get("providers", ())
+    )
+    inventory = Inventory(
+        repository=repository,
+        components=components,
+        discoveries=discoveries,
+        findings=findings,
+        providers=providers,
+        schema_version=int(data.get("schema_version", 1)),
+    )
+    inventory.validate()
+    return inventory
+
+
+def read_inventory(path: Path) -> Inventory:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"Unable to read inventory {path}: {error}") from error
+    if not isinstance(data, dict):
+        raise ValueError(f"Inventory {path} must contain a JSON object")  # noqa: TRY004
+    return inventory_from_dict(data)

--- a/tools/license_compliance/src/ov_contrib_license/model/types.py
+++ b/tools/license_compliance/src/ov_contrib_license/model/types.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import hashlib
 from collections.abc import Iterable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import Enum
 
 
@@ -54,6 +54,18 @@ class Relationship(str, Enum):
     UNKNOWN = "UNKNOWN"
 
 
+class Obligation(str, Enum):
+    RETAIN_COPYRIGHT = "RETAIN_COPYRIGHT"
+    RETAIN_LICENSE_TEXT = "RETAIN_LICENSE_TEXT"
+    RETAIN_NOTICE = "RETAIN_NOTICE"
+    MARK_MODIFICATIONS = "MARK_MODIFICATIONS"
+    PROVIDE_SOURCE = "PROVIDE_SOURCE"
+    PROVIDE_SOURCE_OFFER = "PROVIDE_SOURCE_OFFER"
+    SEPARATE_LICENSE_TERMS = "SEPARATE_LICENSE_TERMS"
+    NO_TRADEDOWN = "NO_TRADEDOWN"
+    MANUAL_REVIEW = "MANUAL_REVIEW"
+
+
 class EvidenceKind(str, Enum):
     SPDX_HEADER = "SPDX_HEADER"
     LICENSE_FILE = "LICENSE_FILE"
@@ -77,12 +89,16 @@ class EvidenceKind(str, Enum):
 Details = tuple[tuple[str, str], ...]
 
 
-def normalize_details(details: Mapping[str, object] | Iterable[tuple[str, object]] | None = None) -> Details:
+def normalize_details(
+    details: Mapping[str, object] | Iterable[tuple[str, object]] | None = None,
+) -> Details:
     """Return immutable, deterministic string metadata."""
     if details is None:
         return ()
     items = details.items() if isinstance(details, Mapping) else details
-    return tuple(sorted((str(key), str(value)) for key, value in items if value is not None))
+    return tuple(
+        sorted((str(key), str(value)) for key, value in items if value is not None)
+    )
 
 
 @dataclass(frozen=True)
@@ -95,7 +111,13 @@ class Evidence:
     details: Details = field(default_factory=tuple)
 
     def sort_key(self) -> tuple[object, ...]:
-        return (self.kind.value, self.path or "", self.value or "", self.source, self.details)
+        return (
+            self.kind.value,
+            self.path or "",
+            self.value or "",
+            self.source,
+            self.details,
+        )
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -120,6 +142,7 @@ class Component:
     relationships: tuple[Relationship, ...] = (Relationship.UNKNOWN,)
     evidence: tuple[Evidence, ...] = field(default_factory=tuple)
     distribution: DistributionStatus = DistributionStatus.UNKNOWN
+    obligations: tuple[Obligation, ...] = field(default_factory=tuple)
     details: Details = field(default_factory=tuple)
 
     def to_dict(self) -> dict[str, object]:
@@ -128,12 +151,15 @@ class Component:
             "name": self.name,
             "version": self.version,
             "module": self.module,
-            "paths": list(sorted(self.paths)),
+            "paths": sorted(self.paths),
             "declared_license": self.declared_license,
-            "detected_licenses": list(sorted(self.detected_licenses)),
+            "detected_licenses": sorted(self.detected_licenses),
             "relationships": sorted(item.value for item in self.relationships),
-            "evidence": [item.to_dict() for item in sorted(self.evidence, key=Evidence.sort_key)],
+            "evidence": [
+                item.to_dict() for item in sorted(self.evidence, key=Evidence.sort_key)
+            ],
             "distribution": self.distribution.value,
+            "obligations": sorted(item.value for item in self.obligations),
             "details": dict(self.details),
         }
 
@@ -147,7 +173,13 @@ class Discovery:
     details: Details = field(default_factory=tuple)
 
     def sort_key(self) -> tuple[object, ...]:
-        return (self.kind, self.path, self.module or "", self.ecosystem or "", self.details)
+        return (
+            self.kind,
+            self.path,
+            self.module or "",
+            self.ecosystem or "",
+            self.details,
+        )
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -169,6 +201,8 @@ class Finding:
     message: str
     evidence: tuple[Evidence, ...] = field(default_factory=tuple)
     remediation: tuple[str, ...] = field(default_factory=tuple)
+    suppressed: bool = False
+    suppression_reason: str | None = None
 
     @classmethod
     def create(
@@ -200,6 +234,9 @@ class Finding:
             remediation=tuple(remediation),
         )
 
+    def suppress(self, reason: str) -> Finding:
+        return replace(self, suppressed=True, suppression_reason=reason)
+
     def sort_key(self) -> tuple[str, str, str]:
         return (self.decision.value, self.code, self.id)
 
@@ -211,6 +248,10 @@ class Finding:
             "decision": self.decision.value,
             "component_id": self.component_id,
             "message": self.message,
-            "evidence": [item.to_dict() for item in sorted(self.evidence, key=Evidence.sort_key)],
+            "evidence": [
+                item.to_dict() for item in sorted(self.evidence, key=Evidence.sort_key)
+            ],
             "remediation": list(self.remediation),
+            "suppressed": self.suppressed,
+            "suppression_reason": self.suppression_reason,
         }

--- a/tools/license_compliance/src/ov_contrib_license/model/types.py
+++ b/tools/license_compliance/src/ov_contrib_license/model/types.py
@@ -1,0 +1,216 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from enum import Enum
+
+
+class Confidence(str, Enum):
+    HIGH = "HIGH"
+    MEDIUM = "MEDIUM"
+    LOW = "LOW"
+
+
+class Decision(str, Enum):
+    PASS = "PASS"
+    REVIEW = "REVIEW"
+    FAIL = "FAIL"
+
+
+class Severity(str, Enum):
+    INFO = "INFO"
+    WARNING = "WARNING"
+    ERROR = "ERROR"
+
+
+class DistributionStatus(str, Enum):
+    DISTRIBUTED = "DISTRIBUTED"
+    NOT_DISTRIBUTED = "NOT_DISTRIBUTED"
+    UNKNOWN = "UNKNOWN"
+
+
+class Relationship(str, Enum):
+    VENDORED_SOURCE = "VENDORED_SOURCE"
+    COPIED_SNIPPET = "COPIED_SNIPPET"
+    HEADER_ONLY = "HEADER_ONLY"
+    STATIC_LINK = "STATIC_LINK"
+    DYNAMIC_LINK = "DYNAMIC_LINK"
+    RUNTIME_DEPENDENCY = "RUNTIME_DEPENDENCY"
+    RUNTIME_EXTERNAL = "RUNTIME_EXTERNAL"
+    BUILD_TOOL = "BUILD_TOOL"
+    CODE_GENERATOR = "CODE_GENERATOR"
+    TEST_ONLY = "TEST_ONLY"
+    DEV_ONLY = "DEV_ONLY"
+    FETCHED_AT_BUILD = "FETCHED_AT_BUILD"
+    FETCHED_AT_RUNTIME = "FETCHED_AT_RUNTIME"
+    BUNDLED_BINARY = "BUNDLED_BINARY"
+    DATASET = "DATASET"
+    MODEL = "MODEL"
+    DOCUMENTATION_ASSET = "DOCUMENTATION_ASSET"
+    UNKNOWN = "UNKNOWN"
+
+
+class EvidenceKind(str, Enum):
+    SPDX_HEADER = "SPDX_HEADER"
+    LICENSE_FILE = "LICENSE_FILE"
+    NOTICE_FILE = "NOTICE_FILE"
+    PACKAGE_METADATA = "PACKAGE_METADATA"
+    ORT = "ORT"
+    CMAKE_FETCHCONTENT = "CMAKE_FETCHCONTENT"
+    CMAKE_EXTERNAL_PROJECT = "CMAKE_EXTERNAL_PROJECT"
+    CMAKE_FIND_PACKAGE = "CMAKE_FIND_PACKAGE"
+    CMAKE_FIND_LIBRARY = "CMAKE_FIND_LIBRARY"
+    CMAKE_ADD_SUBDIRECTORY = "CMAKE_ADD_SUBDIRECTORY"
+    CMAKE_CPM = "CMAKE_CPM"
+    GIT_SUBMODULE = "GIT_SUBMODULE"
+    DOWNLOAD_URL = "DOWNLOAD_URL"
+    VENDORED_TREE = "VENDORED_TREE"
+    GITHUB_ACTION = "GITHUB_ACTION"
+    ARTIFACT_SBOM = "ARTIFACT_SBOM"
+    MANUAL_CURATED = "MANUAL_CURATED"
+
+
+Details = tuple[tuple[str, str], ...]
+
+
+def normalize_details(details: Mapping[str, object] | Iterable[tuple[str, object]] | None = None) -> Details:
+    """Return immutable, deterministic string metadata."""
+    if details is None:
+        return ()
+    items = details.items() if isinstance(details, Mapping) else details
+    return tuple(sorted((str(key), str(value)) for key, value in items if value is not None))
+
+
+@dataclass(frozen=True)
+class Evidence:
+    kind: EvidenceKind
+    source: str
+    path: str | None = None
+    value: str | None = None
+    confidence: Confidence = Confidence.MEDIUM
+    details: Details = field(default_factory=tuple)
+
+    def sort_key(self) -> tuple[object, ...]:
+        return (self.kind.value, self.path or "", self.value or "", self.source, self.details)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.kind.value,
+            "source": self.source,
+            "path": self.path,
+            "value": self.value,
+            "confidence": self.confidence.value,
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class Component:
+    id: str
+    name: str
+    version: str | None = None
+    module: str | None = None
+    paths: tuple[str, ...] = field(default_factory=tuple)
+    declared_license: str | None = None
+    detected_licenses: tuple[str, ...] = field(default_factory=tuple)
+    relationships: tuple[Relationship, ...] = (Relationship.UNKNOWN,)
+    evidence: tuple[Evidence, ...] = field(default_factory=tuple)
+    distribution: DistributionStatus = DistributionStatus.UNKNOWN
+    details: Details = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "version": self.version,
+            "module": self.module,
+            "paths": list(sorted(self.paths)),
+            "declared_license": self.declared_license,
+            "detected_licenses": list(sorted(self.detected_licenses)),
+            "relationships": sorted(item.value for item in self.relationships),
+            "evidence": [item.to_dict() for item in sorted(self.evidence, key=Evidence.sort_key)],
+            "distribution": self.distribution.value,
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class Discovery:
+    kind: str
+    path: str
+    module: str | None = None
+    ecosystem: str | None = None
+    details: Details = field(default_factory=tuple)
+
+    def sort_key(self) -> tuple[object, ...]:
+        return (self.kind, self.path, self.module or "", self.ecosystem or "", self.details)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.kind,
+            "path": self.path,
+            "module": self.module,
+            "ecosystem": self.ecosystem,
+            "details": dict(self.details),
+        }
+
+
+@dataclass(frozen=True)
+class Finding:
+    id: str
+    code: str
+    severity: Severity
+    decision: Decision
+    component_id: str | None
+    message: str
+    evidence: tuple[Evidence, ...] = field(default_factory=tuple)
+    remediation: tuple[str, ...] = field(default_factory=tuple)
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        code: str,
+        severity: Severity,
+        decision: Decision,
+        component_id: str | None,
+        message: str,
+        evidence: Iterable[Evidence] = (),
+        remediation: Iterable[str] = (),
+        fingerprint_values: Iterable[str] = (),
+    ) -> Finding:
+        normalized_evidence = tuple(sorted(set(evidence), key=Evidence.sort_key))
+        stable_values = [code, component_id or ""]
+        stable_values.extend(str(item) for item in fingerprint_values)
+        for item in normalized_evidence:
+            stable_values.extend((item.kind.value, item.path or "", item.value or ""))
+        digest = hashlib.sha256("\x00".join(stable_values).encode("utf-8")).hexdigest()
+        return cls(
+            id=f"sha256:{digest}",
+            code=code,
+            severity=severity,
+            decision=decision,
+            component_id=component_id,
+            message=message,
+            evidence=normalized_evidence,
+            remediation=tuple(remediation),
+        )
+
+    def sort_key(self) -> tuple[str, str, str]:
+        return (self.decision.value, self.code, self.id)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "id": self.id,
+            "code": self.code,
+            "severity": self.severity.value,
+            "decision": self.decision.value,
+            "component_id": self.component_id,
+            "message": self.message,
+            "evidence": [item.to_dict() for item in sorted(self.evidence, key=Evidence.sort_key)],
+            "remediation": list(self.remediation),
+        }

--- a/tools/license_compliance/src/ov_contrib_license/policy/__init__.py
+++ b/tools/license_compliance/src/ov_contrib_license/policy/__init__.py
@@ -1,0 +1,27 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from .config import (
+    BaselineEntry,
+    ExceptionRule,
+    PolicyConfig,
+    PolicyRule,
+    load_baseline,
+    load_policy,
+)
+from .engine import EvaluationSummary, apply_baseline, evaluate_inventory
+from .expressions import ExpressionError, normalize_expression
+
+__all__ = [
+    "BaselineEntry",
+    "EvaluationSummary",
+    "ExceptionRule",
+    "ExpressionError",
+    "PolicyConfig",
+    "PolicyRule",
+    "apply_baseline",
+    "evaluate_inventory",
+    "load_baseline",
+    "load_policy",
+    "normalize_expression",
+]

--- a/tools/license_compliance/src/ov_contrib_license/policy/config.py
+++ b/tools/license_compliance/src/ov_contrib_license/policy/config.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -16,6 +17,8 @@ from ov_contrib_license.model import (
     Obligation,
     Relationship,
 )
+
+_SHA256_FINGERPRINT = re.compile(r"sha256:[0-9a-f]{64}\Z")
 
 
 def _load_mapping(path: Path) -> dict[str, Any]:
@@ -40,6 +43,30 @@ def _strings(value: Any) -> tuple[str, ...]:
     if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
         raise ValueError(f"Expected a string or list of strings, got {value!r}")
     return tuple(value)
+
+
+def _mapping_list(data: dict[str, Any], key: str) -> list[dict[str, Any]]:
+    value = data.get(key, [])
+    if not isinstance(value, list):
+        raise ValueError(f"Policy key {key!r} must contain a list")  # noqa: TRY004
+    if not all(isinstance(item, dict) for item in value):
+        raise ValueError(f"Every {key!r} entry must be a mapping")
+    return value
+
+
+def _string_mapping(data: dict[str, Any], key: str) -> dict[str, str]:
+    value = data.get(key, {})
+    if not isinstance(value, dict):
+        raise ValueError(f"Policy key {key!r} must contain a mapping")  # noqa: TRY004
+    if not all(
+        isinstance(item_key, str)
+        and item_key.strip()
+        and isinstance(item_value, str)
+        and item_value.strip()
+        for item_key, item_value in value.items()
+    ):
+        raise ValueError(f"Every {key!r} key and value must be a non-empty string")
+    return value
 
 
 @dataclass(frozen=True)
@@ -110,16 +137,24 @@ class PolicyConfig:
 
 def _load_rules(data: dict[str, Any]) -> tuple[PolicyRule, ...]:
     rules: list[PolicyRule] = []
-    for item in data.get("rules", ()):
-        if not isinstance(item, dict) or not isinstance(item.get("when", {}), dict):
+    for item in _mapping_list(data, "rules"):
+        if not isinstance(item.get("when", {}), dict):
             raise ValueError(  # noqa: TRY004
                 "Each policy rule must be a mapping with a 'when' mapping"
+            )
+        identifier = item.get("id")
+        decision = item.get("decision")
+        if not isinstance(identifier, str) or not identifier.strip():
+            raise ValueError("Each policy rule must have a non-empty string ID")
+        if not isinstance(decision, str):
+            raise ValueError(  # noqa: TRY004
+                f"Policy rule {identifier} must have a decision"
             )
         when = item.get("when", {})
         rules.append(
             PolicyRule(
-                id=str(item["id"]),
-                decision=Decision(str(item["decision"])),
+                id=identifier,
+                decision=Decision(decision),
                 licenses=_strings(when.get("license")),
                 license_classes=_strings(when.get("license_class")),
                 relationships=tuple(
@@ -141,19 +176,28 @@ def _load_rules(data: dict[str, Any]) -> tuple[PolicyRule, ...]:
 
 def _load_exceptions(data: dict[str, Any]) -> tuple[ExceptionRule, ...]:
     result: list[ExceptionRule] = []
-    for item in data.get("exceptions", ()):
-        if not isinstance(item, dict):
-            raise ValueError("Each exception must be a mapping")  # noqa: TRY004
-        component = str(item.get("component", ""))
-        if not component or "@" not in component:
+    for item in _mapping_list(data, "exceptions"):
+        identifier = item.get("id")
+        if not isinstance(identifier, str) or not identifier.strip():
+            raise ValueError("Each exception must have a non-empty string ID")
+        component = item.get("component")
+        if (
+            not isinstance(component, str)
+            or "@" not in component
+            or not all(part.strip() for part in component.rsplit("@", 1))
+        ):
             raise ValueError(
                 "Exception component must identify an exact version/revision"
             )
+        module = item.get("module")
+        rationale = item.get("rationale")
+        if not isinstance(module, str) or not module.strip():
+            raise ValueError(f"Exception {identifier} must constrain a module")
+        if not isinstance(rationale, str) or not rationale.strip():
+            raise ValueError(f"Exception {identifier} must contain a rationale")
         approved_by = _strings(item.get("approved_by"))
-        if not approved_by:
-            raise ValueError(
-                f"Exception {item.get('id')} must contain approval metadata"
-            )
+        if not approved_by or not all(item.strip() for item in approved_by):
+            raise ValueError(f"Exception {identifier} must contain approval metadata")
         expires_value = item.get("expires")
         try:
             expires = (
@@ -161,9 +205,9 @@ def _load_exceptions(data: dict[str, Any]) -> tuple[ExceptionRule, ...]:
                 if isinstance(expires_value, dt.date)
                 else dt.date.fromisoformat(str(expires_value))
             )
-        except ValueError as error:
+        except (TypeError, ValueError) as error:
             raise ValueError(
-                f"Exception {item.get('id')} has an invalid expiration date"
+                f"Exception {identifier} has an invalid expiration date"
             ) from error
         relationships = tuple(
             Relationship(value) for value in _strings(item.get("allowed_relationships"))
@@ -174,21 +218,24 @@ def _load_exceptions(data: dict[str, Any]) -> tuple[ExceptionRule, ...]:
         )
         if not relationships or not distributions:
             raise ValueError(
-                f"Exception {item.get('id')} must constrain relationship and distribution"
+                f"Exception {identifier} must constrain relationship and distribution"
             )
         result.append(
             ExceptionRule(
-                id=str(item["id"]),
+                id=identifier,
                 component=component,
-                module=str(item.get("module", "")),
+                module=module,
                 relationships=relationships,
                 distributions=distributions,
-                rationale=str(item.get("rationale", "")),
+                rationale=rationale,
                 approved_by=approved_by,
                 expires=expires,
                 decision=Decision(str(item.get("decision", "PASS"))),
             )
         )
+    identifiers = [item.id for item in result]
+    if len(identifiers) != len(set(identifiers)):
+        raise ValueError("Policy exception IDs must be unique")
     return tuple(result)
 
 
@@ -209,27 +256,48 @@ def _load_obligations(
 
 
 def _load_toolchain(data: dict[str, Any]) -> tuple[ToolchainPolicy, dict[str, Any]]:
-    actions = data.get("actions", {})
-    dependencies = data.get("dependencies", {})
-    if not isinstance(actions, dict) or not isinstance(dependencies, dict):
+    actions = _string_mapping(data, "actions")
+    dependencies = _string_mapping(data, "dependencies")
+    require_full_sha = data.get("require_full_sha_for_github_actions", True)
+    if not isinstance(require_full_sha, bool):
         raise ValueError(  # noqa: TRY004
-            "Toolchain action/dependency registries must be mappings"
+            "Toolchain require_full_sha_for_github_actions must be a boolean"
         )
     forbidden: list[tuple[str, str]] = []
-    for item in data.get("forbidden_services", ()):
-        if not isinstance(item, dict):
-            raise ValueError("Each forbidden service must be a mapping")  # noqa: TRY004
-        forbidden.append(
-            (str(item["id"]), str(item.get("reason", "forbidden by policy")))
-        )
+    for item in _mapping_list(data, "forbidden_services"):
+        identifier = item.get("id")
+        reason = item.get("reason", "forbidden by policy")
+        if not isinstance(identifier, str) or not identifier.strip():
+            raise ValueError("Each forbidden service must have a non-empty string ID")
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError(f"Forbidden service {identifier} must have a reason")
+        forbidden.append((identifier, reason))
+    forbidden_ids = [item[0] for item in forbidden]
+    if len(forbidden_ids) != len(set(forbidden_ids)):
+        raise ValueError("Forbidden service IDs must be unique")
     providers = data.get("providers", {})
+    if not isinstance(providers, dict):
+        raise ValueError("Toolchain providers must be a mapping")  # noqa: TRY004
+    for name, provider in providers.items():
+        if (
+            not isinstance(name, str)
+            or not name.strip()
+            or not isinstance(provider, dict)
+        ):
+            raise ValueError("Every toolchain provider must be a named mapping")
+        if "enabled" in provider and not isinstance(provider["enabled"], bool):
+            raise ValueError(
+                f"Toolchain provider {name} enabled flag must be a boolean"
+            )
+        if "command" in provider and (
+            not isinstance(provider["command"], str) or not provider["command"].strip()
+        ):
+            raise ValueError(f"Toolchain provider {name} command must be a string")
     return ToolchainPolicy(
         allowed_license_classes=_strings(data.get("allowed_license_classes"))
         or ("permissive",),
         allowed_explicit_licenses=_strings(data.get("allowed_explicit_licenses")),
-        require_full_sha_for_github_actions=bool(
-            data.get("require_full_sha_for_github_actions", True)
-        ),
+        require_full_sha_for_github_actions=require_full_sha,
         action_licenses=tuple(
             sorted((str(key).lower(), str(value)) for key, value in actions.items())
         ),
@@ -239,7 +307,25 @@ def _load_toolchain(data: dict[str, Any]) -> tuple[ToolchainPolicy, dict[str, An
             )
         ),
         forbidden_services=tuple(sorted(forbidden)),
-    ), providers if isinstance(providers, dict) else {}
+    ), providers
+
+
+def _load_baseline_entries(data: dict[str, Any]) -> tuple[BaselineEntry, ...]:
+    result: list[BaselineEntry] = []
+    for item in _mapping_list(data, "baseline"):
+        fingerprint = item.get("finding_fingerprint")
+        reason = item.get("reason")
+        if not isinstance(fingerprint, str) or not _SHA256_FINGERPRINT.fullmatch(
+            fingerprint
+        ):
+            raise ValueError("Baseline entries require a sha256 finding_fingerprint")
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError(f"Baseline entry {fingerprint} requires a reason")
+        result.append(BaselineEntry(fingerprint, reason))
+    fingerprints = [item.finding_fingerprint for item in result]
+    if len(fingerprints) != len(set(fingerprints)):
+        raise ValueError("Baseline finding fingerprints must be unique")
+    return tuple(result)
 
 
 def load_policy(directory: Path) -> PolicyConfig:
@@ -276,18 +362,31 @@ def load_policy(directory: Path) -> PolicyConfig:
         raise ValueError(f"Licenses must belong to one class: {duplicates}")
 
     obligations = _load_obligations(_load_mapping(directory / "obligations.yml"))
-    baseline_data = _load_mapping(directory / "baseline.yml")
-    baseline = tuple(
-        BaselineEntry(
-            str(item["finding_fingerprint"]), str(item.get("reason", "baseline"))
+    rules = _load_rules(_load_mapping(directory / "rules.yml"))
+    unknown_rule_classes = {
+        class_name
+        for rule in rules
+        for class_name in rule.license_classes
+        if class_name not in classes
+    }
+    unknown_obligation_classes = set(obligations[1]) - set(classes)
+    if unknown_rule_classes or unknown_obligation_classes:
+        unknown = sorted(unknown_rule_classes | unknown_obligation_classes)
+        raise ValueError(
+            f"Policy references unknown license classes: {', '.join(unknown)}"
         )
-        for item in baseline_data.get("baseline", ())
-    )
+    baseline = _load_baseline_entries(_load_mapping(directory / "baseline.yml"))
     toolchain, providers = _load_toolchain(_load_mapping(directory / "toolchain.yml"))
+    unknown_toolchain_classes = set(toolchain.allowed_license_classes) - set(classes)
+    if unknown_toolchain_classes:
+        raise ValueError(
+            "Toolchain policy references unknown license classes: "
+            + ", ".join(sorted(unknown_toolchain_classes))
+        )
     return PolicyConfig(
         directory=directory,
         license_classes=classes,
-        rules=_load_rules(_load_mapping(directory / "rules.yml")),
+        rules=rules,
         obligations_by_license=obligations[0],
         obligations_by_class=obligations[1],
         exceptions=_load_exceptions(_load_mapping(directory / "exceptions.yml")),
@@ -298,10 +397,4 @@ def load_policy(directory: Path) -> PolicyConfig:
 
 
 def load_baseline(path: Path) -> tuple[BaselineEntry, ...]:
-    data = _load_mapping(path)
-    return tuple(
-        BaselineEntry(
-            str(item["finding_fingerprint"]), str(item.get("reason", "baseline"))
-        )
-        for item in data.get("baseline", ())
-    )
+    return _load_baseline_entries(_load_mapping(path))

--- a/tools/license_compliance/src/ov_contrib_license/policy/config.py
+++ b/tools/license_compliance/src/ov_contrib_license/policy/config.py
@@ -1,0 +1,307 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ov_contrib_license.model import (
+    Decision,
+    DistributionStatus,
+    Obligation,
+    Relationship,
+)
+
+
+def _load_mapping(path: Path) -> dict[str, Any]:
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except OSError as error:
+        raise ValueError(f"Unable to read policy file {path}: {error}") from error
+    except yaml.YAMLError as error:
+        raise ValueError(f"Invalid YAML in policy file {path}: {error}") from error
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Policy file {path} must contain a mapping")  # noqa: TRY004
+    return data
+
+
+def _strings(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        return (value,)
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise ValueError(f"Expected a string or list of strings, got {value!r}")
+    return tuple(value)
+
+
+@dataclass(frozen=True)
+class PolicyRule:
+    id: str
+    decision: Decision
+    licenses: tuple[str, ...] = ()
+    license_classes: tuple[str, ...] = ()
+    relationships: tuple[Relationship, ...] = ()
+    distributions: tuple[DistributionStatus, ...] = ()
+    modules: tuple[str, ...] = ()
+    artifact_scopes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ExceptionRule:
+    id: str
+    component: str
+    module: str
+    relationships: tuple[Relationship, ...]
+    distributions: tuple[DistributionStatus, ...]
+    rationale: str
+    approved_by: tuple[str, ...]
+    expires: dt.date
+    decision: Decision = Decision.PASS
+
+
+@dataclass(frozen=True)
+class BaselineEntry:
+    finding_fingerprint: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class ToolchainPolicy:
+    allowed_license_classes: tuple[str, ...] = ("permissive",)
+    allowed_explicit_licenses: tuple[str, ...] = ()
+    require_full_sha_for_github_actions: bool = True
+    action_licenses: tuple[tuple[str, str], ...] = ()
+    dependency_licenses: tuple[tuple[str, str], ...] = ()
+    forbidden_services: tuple[tuple[str, str], ...] = ()
+
+    @property
+    def actions(self) -> dict[str, str]:
+        return dict(self.action_licenses)
+
+    @property
+    def dependencies(self) -> dict[str, str]:
+        return dict(self.dependency_licenses)
+
+
+@dataclass(frozen=True)
+class PolicyConfig:
+    directory: Path
+    license_classes: dict[str, frozenset[str]]
+    rules: tuple[PolicyRule, ...]
+    obligations_by_license: dict[str, tuple[Obligation, ...]]
+    obligations_by_class: dict[str, tuple[Obligation, ...]]
+    exceptions: tuple[ExceptionRule, ...]
+    baseline: tuple[BaselineEntry, ...]
+    toolchain: ToolchainPolicy
+    providers: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    @property
+    def baseline_by_id(self) -> dict[str, BaselineEntry]:
+        return {item.finding_fingerprint: item for item in self.baseline}
+
+
+def _load_rules(data: dict[str, Any]) -> tuple[PolicyRule, ...]:
+    rules: list[PolicyRule] = []
+    for item in data.get("rules", ()):
+        if not isinstance(item, dict) or not isinstance(item.get("when", {}), dict):
+            raise ValueError(  # noqa: TRY004
+                "Each policy rule must be a mapping with a 'when' mapping"
+            )
+        when = item.get("when", {})
+        rules.append(
+            PolicyRule(
+                id=str(item["id"]),
+                decision=Decision(str(item["decision"])),
+                licenses=_strings(when.get("license")),
+                license_classes=_strings(when.get("license_class")),
+                relationships=tuple(
+                    Relationship(value) for value in _strings(when.get("relationship"))
+                ),
+                distributions=tuple(
+                    DistributionStatus(value)
+                    for value in _strings(when.get("distribution"))
+                ),
+                modules=_strings(when.get("module")),
+                artifact_scopes=_strings(when.get("artifact_scope")),
+            )
+        )
+    identifiers = [item.id for item in rules]
+    if len(identifiers) != len(set(identifiers)):
+        raise ValueError("Policy rule IDs must be unique")
+    return tuple(rules)
+
+
+def _load_exceptions(data: dict[str, Any]) -> tuple[ExceptionRule, ...]:
+    result: list[ExceptionRule] = []
+    for item in data.get("exceptions", ()):
+        if not isinstance(item, dict):
+            raise ValueError("Each exception must be a mapping")  # noqa: TRY004
+        component = str(item.get("component", ""))
+        if not component or "@" not in component:
+            raise ValueError(
+                "Exception component must identify an exact version/revision"
+            )
+        approved_by = _strings(item.get("approved_by"))
+        if not approved_by:
+            raise ValueError(
+                f"Exception {item.get('id')} must contain approval metadata"
+            )
+        expires_value = item.get("expires")
+        try:
+            expires = (
+                expires_value
+                if isinstance(expires_value, dt.date)
+                else dt.date.fromisoformat(str(expires_value))
+            )
+        except ValueError as error:
+            raise ValueError(
+                f"Exception {item.get('id')} has an invalid expiration date"
+            ) from error
+        relationships = tuple(
+            Relationship(value) for value in _strings(item.get("allowed_relationships"))
+        )
+        distributions = tuple(
+            DistributionStatus(value)
+            for value in _strings(item.get("allowed_distribution"))
+        )
+        if not relationships or not distributions:
+            raise ValueError(
+                f"Exception {item.get('id')} must constrain relationship and distribution"
+            )
+        result.append(
+            ExceptionRule(
+                id=str(item["id"]),
+                component=component,
+                module=str(item.get("module", "")),
+                relationships=relationships,
+                distributions=distributions,
+                rationale=str(item.get("rationale", "")),
+                approved_by=approved_by,
+                expires=expires,
+                decision=Decision(str(item.get("decision", "PASS"))),
+            )
+        )
+    return tuple(result)
+
+
+def _load_obligations(
+    data: dict[str, Any],
+) -> tuple[dict[str, tuple[Obligation, ...]], dict[str, tuple[Obligation, ...]]]:
+    def convert(values: Any) -> dict[str, tuple[Obligation, ...]]:
+        if values is None:
+            return {}
+        if not isinstance(values, dict):
+            raise ValueError("Obligation mappings must be mappings")  # noqa: TRY004
+        return {
+            str(key): tuple(Obligation(value) for value in _strings(item))
+            for key, item in values.items()
+        }
+
+    return convert(data.get("licenses")), convert(data.get("classes"))
+
+
+def _load_toolchain(data: dict[str, Any]) -> tuple[ToolchainPolicy, dict[str, Any]]:
+    actions = data.get("actions", {})
+    dependencies = data.get("dependencies", {})
+    if not isinstance(actions, dict) or not isinstance(dependencies, dict):
+        raise ValueError(  # noqa: TRY004
+            "Toolchain action/dependency registries must be mappings"
+        )
+    forbidden: list[tuple[str, str]] = []
+    for item in data.get("forbidden_services", ()):
+        if not isinstance(item, dict):
+            raise ValueError("Each forbidden service must be a mapping")  # noqa: TRY004
+        forbidden.append(
+            (str(item["id"]), str(item.get("reason", "forbidden by policy")))
+        )
+    providers = data.get("providers", {})
+    return ToolchainPolicy(
+        allowed_license_classes=_strings(data.get("allowed_license_classes"))
+        or ("permissive",),
+        allowed_explicit_licenses=_strings(data.get("allowed_explicit_licenses")),
+        require_full_sha_for_github_actions=bool(
+            data.get("require_full_sha_for_github_actions", True)
+        ),
+        action_licenses=tuple(
+            sorted((str(key).lower(), str(value)) for key, value in actions.items())
+        ),
+        dependency_licenses=tuple(
+            sorted(
+                (str(key).lower(), str(value)) for key, value in dependencies.items()
+            )
+        ),
+        forbidden_services=tuple(sorted(forbidden)),
+    ), providers if isinstance(providers, dict) else {}
+
+
+def load_policy(directory: Path) -> PolicyConfig:
+    directory = directory.resolve()
+    required = (
+        "licenses.yml",
+        "rules.yml",
+        "obligations.yml",
+        "exceptions.yml",
+        "baseline.yml",
+        "toolchain.yml",
+    )
+    missing = [name for name in required if not (directory / name).is_file()]
+    if missing:
+        raise ValueError(
+            f"Policy directory {directory} is missing: {', '.join(missing)}"
+        )
+
+    licenses_data = _load_mapping(directory / "licenses.yml")
+    classes_data = licenses_data.get("classes", {})
+    if not isinstance(classes_data, dict):
+        raise ValueError("licenses.yml 'classes' must be a mapping")  # noqa: TRY004
+    classes = {
+        str(key): frozenset(_strings(value)) for key, value in classes_data.items()
+    }
+    duplicate_licenses: dict[str, list[str]] = {}
+    for class_name, values in classes.items():
+        for license_id in values:
+            duplicate_licenses.setdefault(license_id, []).append(class_name)
+    duplicates = {
+        key: value for key, value in duplicate_licenses.items() if len(value) > 1
+    }
+    if duplicates:
+        raise ValueError(f"Licenses must belong to one class: {duplicates}")
+
+    obligations = _load_obligations(_load_mapping(directory / "obligations.yml"))
+    baseline_data = _load_mapping(directory / "baseline.yml")
+    baseline = tuple(
+        BaselineEntry(
+            str(item["finding_fingerprint"]), str(item.get("reason", "baseline"))
+        )
+        for item in baseline_data.get("baseline", ())
+    )
+    toolchain, providers = _load_toolchain(_load_mapping(directory / "toolchain.yml"))
+    return PolicyConfig(
+        directory=directory,
+        license_classes=classes,
+        rules=_load_rules(_load_mapping(directory / "rules.yml")),
+        obligations_by_license=obligations[0],
+        obligations_by_class=obligations[1],
+        exceptions=_load_exceptions(_load_mapping(directory / "exceptions.yml")),
+        baseline=baseline,
+        toolchain=toolchain,
+        providers=providers,
+    )
+
+
+def load_baseline(path: Path) -> tuple[BaselineEntry, ...]:
+    data = _load_mapping(path)
+    return tuple(
+        BaselineEntry(
+            str(item["finding_fingerprint"]), str(item.get("reason", "baseline"))
+        )
+        for item in data.get("baseline", ())
+    )

--- a/tools/license_compliance/src/ov_contrib_license/policy/engine.py
+++ b/tools/license_compliance/src/ov_contrib_license/policy/engine.py
@@ -1,0 +1,400 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass, replace
+
+from ov_contrib_license.model import (
+    Component,
+    Decision,
+    Finding,
+    Inventory,
+    Obligation,
+    Relationship,
+    Severity,
+)
+
+from .config import ExceptionRule, PolicyConfig, PolicyRule
+from .expressions import (
+    Expression,
+    ExpressionError,
+    parse_expression,
+)
+
+_DECISION_RANK = {Decision.PASS: 0, Decision.REVIEW: 1, Decision.FAIL: 2}
+
+
+@dataclass(frozen=True)
+class ComponentEvaluation:
+    decision: Decision
+    license_expression: str
+    rule_ids: tuple[str, ...]
+    obligations: tuple[Obligation, ...]
+    exception_id: str | None = None
+
+
+@dataclass(frozen=True)
+class EvaluationSummary:
+    inventory: Inventory
+    pass_count: int
+    review_count: int
+    fail_count: int
+    suppressed_count: int
+
+    @property
+    def decision(self) -> Decision:
+        if self.fail_count:
+            return Decision.FAIL
+        if self.review_count:
+            return Decision.REVIEW
+        return Decision.PASS
+
+
+def _classify(license_id: str, config: PolicyConfig) -> str:
+    base = license_id.split(" WITH ", 1)[0]
+    for class_name, licenses in config.license_classes.items():
+        if base in licenses:
+            return class_name
+    return "unknown"
+
+
+def _rule_matches(
+    rule: PolicyRule,
+    *,
+    license_expression: str,
+    license_id: str,
+    license_class: str,
+    relationship: Relationship,
+    component: Component,
+) -> bool:
+    if (
+        rule.licenses
+        and license_expression not in rule.licenses
+        and license_id not in rule.licenses
+    ):
+        return False
+    if rule.license_classes and license_class not in rule.license_classes:
+        return False
+    if rule.relationships and relationship not in rule.relationships:
+        return False
+    if rule.distributions and component.distribution not in rule.distributions:
+        return False
+    if rule.modules and (component.module or "repository") not in rule.modules:
+        return False
+    artifact_scope = dict(component.details).get("artifact_scope")
+    return not rule.artifact_scopes or artifact_scope in rule.artifact_scopes
+
+
+def _obligations(license_id: str, config: PolicyConfig) -> tuple[Obligation, ...]:
+    result = set(config.obligations_by_class.get(_classify(license_id, config), ()))
+    result.update(config.obligations_by_license.get(license_id, ()))
+    return tuple(sorted(result, key=lambda item: item.value))
+
+
+def _atomic_evaluation(
+    license_expression: str,
+    license_id: str,
+    relationship: Relationship,
+    component: Component,
+    config: PolicyConfig,
+) -> ComponentEvaluation:
+    license_class = _classify(license_id, config)
+    rule = next(
+        (
+            item
+            for item in config.rules
+            if _rule_matches(
+                item,
+                license_expression=license_expression,
+                license_id=license_id,
+                license_class=license_class,
+                relationship=relationship,
+                component=component,
+            )
+        ),
+        None,
+    )
+    return ComponentEvaluation(
+        decision=rule.decision if rule else Decision.REVIEW,
+        license_expression=license_expression,
+        rule_ids=(rule.id,) if rule else ("POLICY-NO-MATCH",),
+        obligations=_obligations(license_id, config),
+    )
+
+
+def _combine(
+    left: ComponentEvaluation,
+    right: ComponentEvaluation,
+    *,
+    operator: str,
+    expression: str,
+) -> ComponentEvaluation:
+    if operator == "OR":
+        selected = min((left, right), key=lambda item: _DECISION_RANK[item.decision])
+        obligations = selected.obligations
+    else:
+        selected = max((left, right), key=lambda item: _DECISION_RANK[item.decision])
+        obligations = tuple(
+            sorted(
+                set(left.obligations + right.obligations), key=lambda item: item.value
+            )
+        )
+    return ComponentEvaluation(
+        decision=selected.decision,
+        license_expression=expression,
+        rule_ids=tuple(sorted(set(left.rule_ids + right.rule_ids))),
+        obligations=obligations,
+    )
+
+
+def _evaluate_expression(
+    expression: Expression,
+    relationship: Relationship,
+    component: Component,
+    config: PolicyConfig,
+) -> ComponentEvaluation:
+    rendered = expression.render()
+    exact = [
+        rule for rule in config.rules if rule.licenses and rendered in rule.licenses
+    ]
+    for rule in exact:
+        if _rule_matches(
+            rule,
+            license_expression=rendered,
+            license_id=rendered,
+            license_class=_classify(rendered, config),
+            relationship=relationship,
+            component=component,
+        ):
+            return ComponentEvaluation(
+                rule.decision,
+                rendered,
+                (rule.id,),
+                _obligations(rendered, config),
+            )
+    if expression.operator == "LICENSE":
+        assert expression.value is not None
+        return _atomic_evaluation(
+            rendered, expression.value, relationship, component, config
+        )
+    assert expression.left is not None and expression.right is not None
+    if expression.operator == "WITH":
+        return _atomic_evaluation(
+            rendered,
+            rendered,
+            relationship,
+            component,
+            config,
+        )
+    left = _evaluate_expression(expression.left, relationship, component, config)
+    right = _evaluate_expression(expression.right, relationship, component, config)
+    return _combine(left, right, operator=expression.operator, expression=rendered)
+
+
+def _component_license(component: Component) -> str:
+    if component.declared_license:
+        return component.declared_license
+    if component.detected_licenses:
+        return " AND ".join(component.detected_licenses)
+    return "NOASSERTION"
+
+
+def _matching_exception(
+    component: Component,
+    config: PolicyConfig,
+    today: dt.date,
+) -> tuple[ExceptionRule | None, ExceptionRule | None]:
+    exact = [item for item in config.exceptions if item.component == component.id]
+    for item in exact:
+        if item.expires < today:
+            return None, item
+        if item.module != (component.module or "repository"):
+            continue
+        if component.distribution not in item.distributions:
+            continue
+        if not set(component.relationships).issubset(item.relationships):
+            continue
+        return item, None
+    return None, None
+
+
+def _evaluate_component(
+    component: Component,
+    config: PolicyConfig,
+    today: dt.date,
+) -> tuple[Component, Finding, str | None]:
+    raw_expression = _component_license(component)
+    try:
+        expression = parse_expression(raw_expression)
+        normalized = expression.render()
+    except ExpressionError as error:
+        finding = Finding.create(
+            code="POLICY_INVALID_LICENSE_EXPRESSION",
+            severity=Severity.ERROR,
+            decision=Decision.REVIEW,
+            component_id=component.id,
+            message=f"Invalid SPDX license expression {raw_expression!r}: {error}",
+            evidence=component.evidence,
+            remediation=("Replace the value with a valid SPDX license expression.",),
+            fingerprint_values=(
+                raw_expression,
+                *component.relationships,
+                component.distribution,
+                component.module or "",
+            ),
+        )
+        return component, finding, None
+
+    evaluations = [
+        _evaluate_expression(expression, relationship, component, config)
+        for relationship in component.relationships
+    ]
+    evaluation = max(evaluations, key=lambda item: _DECISION_RANK[item.decision])
+    obligations = tuple(
+        sorted(
+            {obligation for item in evaluations for obligation in item.obligations},
+            key=lambda item: item.value,
+        )
+    )
+    updated = replace(component, declared_license=normalized, obligations=obligations)
+    exception, expired = _matching_exception(updated, config, today)
+    if expired:
+        finding = Finding.create(
+            code="POLICY_EXCEPTION_EXPIRED",
+            severity=Severity.ERROR,
+            decision=Decision.FAIL,
+            component_id=component.id,
+            message=f"Policy exception {expired.id} expired on {expired.expires.isoformat()}.",
+            evidence=component.evidence,
+            remediation=(
+                "Renew the approved exception or resolve the underlying finding.",
+            ),
+            fingerprint_values=(expired.id, expired.expires.isoformat()),
+        )
+        return updated, finding, None
+    if exception:
+        evaluation = replace(
+            evaluation,
+            decision=exception.decision,
+            rule_ids=(f"exception:{exception.id}",),
+            exception_id=exception.id,
+        )
+
+    code = {
+        Decision.PASS: "POLICY_COMPONENT_PASS",
+        Decision.REVIEW: "POLICY_COMPONENT_REVIEW",
+        Decision.FAIL: "POLICY_COMPONENT_FAIL",
+    }[evaluation.decision]
+    severity = {
+        Decision.PASS: Severity.INFO,
+        Decision.REVIEW: Severity.WARNING,
+        Decision.FAIL: Severity.ERROR,
+    }[evaluation.decision]
+    rules = ", ".join(evaluation.rule_ids)
+    finding = Finding.create(
+        code=code,
+        severity=severity,
+        decision=evaluation.decision,
+        component_id=component.id,
+        message=(
+            f"{component.name}: {normalized}; relationship="
+            f"{','.join(item.value for item in component.relationships)}; "
+            f"distribution={component.distribution.value}; rule={rules}."
+        ),
+        evidence=component.evidence,
+        remediation=(
+            "Add stronger license/distribution evidence or a narrowly approved exception."
+            if evaluation.decision is not Decision.PASS
+            else "No policy action required.",
+        ),
+        fingerprint_values=(
+            *evaluation.rule_ids,
+            normalized,
+            *(item.value for item in component.relationships),
+            component.distribution.value,
+            component.module or "repository",
+        ),
+    )
+    return updated, finding, exception.id if exception else None
+
+
+def evaluate_inventory(
+    inventory: Inventory,
+    config: PolicyConfig,
+    *,
+    today: dt.date | None = None,
+) -> EvaluationSummary:
+    today = today or dt.datetime.now(dt.timezone.utc).date()
+    components: list[Component] = []
+    findings = list(inventory.findings)
+    used_exceptions: set[str] = set()
+    for component in inventory.components:
+        updated, finding, exception_id = _evaluate_component(component, config, today)
+        components.append(updated)
+        findings.append(finding)
+        if exception_id:
+            used_exceptions.add(exception_id)
+
+    if inventory.repository.base_ref is None:
+        for exception in config.exceptions:
+            if exception.id in used_exceptions:
+                continue
+            findings.append(
+                Finding.create(
+                    code="POLICY_EXCEPTION_UNUSED",
+                    severity=Severity.WARNING,
+                    decision=Decision.REVIEW,
+                    component_id=exception.component,
+                    message=f"Policy exception {exception.id} did not match any component.",
+                    remediation=(
+                        "Remove the stale exception or correct its exact scope.",
+                    ),
+                    fingerprint_values=(exception.id, exception.component),
+                )
+            )
+
+    baseline = config.baseline_by_id
+    evaluated_findings = tuple(
+        sorted(
+            (
+                finding.suppress(baseline[finding.id].reason)
+                if finding.id in baseline
+                else finding
+                for finding in findings
+            ),
+            key=Finding.sort_key,
+        )
+    )
+    evaluated = replace(
+        inventory,
+        components=tuple(sorted(components, key=lambda item: item.id)),
+        findings=evaluated_findings,
+    )
+    active = [item for item in evaluated_findings if not item.suppressed]
+    return EvaluationSummary(
+        inventory=evaluated,
+        pass_count=sum(item.decision is Decision.PASS for item in active),
+        review_count=sum(item.decision is Decision.REVIEW for item in active),
+        fail_count=sum(item.decision is Decision.FAIL for item in active),
+        suppressed_count=sum(item.suppressed for item in evaluated_findings),
+    )
+
+
+def apply_baseline(inventory: Inventory, config: PolicyConfig) -> Inventory:
+    baseline = config.baseline_by_id
+    return replace(
+        inventory,
+        findings=tuple(
+            sorted(
+                (
+                    item.suppress(baseline[item.id].reason)
+                    if item.id in baseline and not item.suppressed
+                    else item
+                    for item in inventory.findings
+                ),
+                key=Finding.sort_key,
+            )
+        ),
+    )

--- a/tools/license_compliance/src/ov_contrib_license/policy/engine.py
+++ b/tools/license_compliance/src/ov_contrib_license/policy/engine.py
@@ -134,6 +134,7 @@ def _combine(
     if operator == "OR":
         selected = min((left, right), key=lambda item: _DECISION_RANK[item.decision])
         obligations = selected.obligations
+        rule_ids = selected.rule_ids
     else:
         selected = max((left, right), key=lambda item: _DECISION_RANK[item.decision])
         obligations = tuple(
@@ -141,10 +142,11 @@ def _combine(
                 set(left.obligations + right.obligations), key=lambda item: item.value
             )
         )
+        rule_ids = tuple(sorted(set(left.rule_ids + right.rule_ids)))
     return ComponentEvaluation(
         decision=selected.decision,
         license_expression=expression,
-        rule_ids=tuple(sorted(set(left.rule_ids + right.rule_ids))),
+        rule_ids=rule_ids,
         obligations=obligations,
     )
 
@@ -205,19 +207,37 @@ def _matching_exception(
     component: Component,
     config: PolicyConfig,
     today: dt.date,
-) -> tuple[ExceptionRule | None, ExceptionRule | None]:
+) -> tuple[ExceptionRule | None, ExceptionRule | None, str | None]:
     exact = [item for item in config.exceptions if item.component == component.id]
+    mismatch: tuple[ExceptionRule, str] | None = None
     for item in exact:
         if item.expires < today:
-            return None, item
+            mismatch = mismatch or (item, "POLICY_EXCEPTION_EXPIRED")
+            continue
         if item.module != (component.module or "repository"):
+            mismatch = mismatch or (item, "POLICY_EXCEPTION_MODULE_MISMATCH")
             continue
         if component.distribution not in item.distributions:
+            mismatch = mismatch or (item, "POLICY_EXCEPTION_DISTRIBUTION_MISMATCH")
             continue
         if not set(component.relationships).issubset(item.relationships):
+            mismatch = mismatch or (item, "POLICY_EXCEPTION_RELATIONSHIP_MISMATCH")
             continue
-        return item, None
-    return None, None
+        return item, None, None
+    if mismatch:
+        return None, mismatch[0], mismatch[1]
+    identity = component.id.rsplit("@", 1)[0]
+    version_mismatch = next(
+        (
+            item
+            for item in config.exceptions
+            if item.component.rsplit("@", 1)[0] == identity
+        ),
+        None,
+    )
+    if version_mismatch:
+        return None, version_mismatch, "POLICY_EXCEPTION_VERSION_MISMATCH"
+    return None, None, None
 
 
 def _evaluate_component(
@@ -259,21 +279,45 @@ def _evaluate_component(
         )
     )
     updated = replace(component, declared_license=normalized, obligations=obligations)
-    exception, expired = _matching_exception(updated, config, today)
-    if expired:
+    exception, exception_issue, issue_code = _matching_exception(updated, config, today)
+    if exception_issue:
+        issue_decision = (
+            Decision.FAIL
+            if issue_code == "POLICY_EXCEPTION_EXPIRED"
+            else max(
+                (evaluation.decision, Decision.REVIEW),
+                key=lambda item: _DECISION_RANK[item],
+            )
+        )
+        issue_description = (
+            issue_code.removeprefix("POLICY_EXCEPTION_").replace("_", " ").lower()
+        )
+        if issue_code == "POLICY_EXCEPTION_EXPIRED":
+            issue_description += f" on {exception_issue.expires.isoformat()}"
         finding = Finding.create(
-            code="POLICY_EXCEPTION_EXPIRED",
+            code=issue_code or "POLICY_EXCEPTION_MISMATCH",
             severity=Severity.ERROR,
-            decision=Decision.FAIL,
+            decision=issue_decision,
             component_id=component.id,
-            message=f"Policy exception {expired.id} expired on {expired.expires.isoformat()}.",
+            message=(
+                f"Policy exception {exception_issue.id} has {issue_description} for "
+                f"component {component.id}."
+            ),
             evidence=component.evidence,
             remediation=(
-                "Renew the approved exception or resolve the underlying finding.",
+                "Update the narrowly approved exception or resolve the underlying finding.",
             ),
-            fingerprint_values=(expired.id, expired.expires.isoformat()),
+            fingerprint_values=(
+                exception_issue.id,
+                exception_issue.component,
+                exception_issue.expires.isoformat(),
+                component.id,
+                *(item.value for item in component.relationships),
+                component.distribution.value,
+                component.module or "repository",
+            ),
         )
-        return updated, finding, None
+        return updated, finding, exception_issue.id
     if exception:
         evaluation = replace(
             evaluation,

--- a/tools/license_compliance/src/ov_contrib_license/policy/expressions.py
+++ b/tools/license_compliance/src/ov_contrib_license/policy/expressions.py
@@ -1,0 +1,123 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+class ExpressionError(ValueError):
+    pass
+
+
+TOKEN = re.compile(
+    r"\s*(\(|\)|AND\b|OR\b|WITH\b|[A-Za-z0-9][A-Za-z0-9.+:-]*)", re.IGNORECASE
+)
+
+
+@dataclass(frozen=True)
+class Expression:
+    operator: str
+    value: str | None = None
+    left: Expression | None = None
+    right: Expression | None = None
+
+    def render(self, parent_precedence: int = 0) -> str:
+        if self.operator == "LICENSE":
+            assert self.value is not None
+            return self.value
+        precedence = {"OR": 1, "AND": 2, "WITH": 3}[self.operator]
+        assert self.left is not None and self.right is not None
+        rendered = f"{self.left.render(precedence)} {self.operator} {self.right.render(precedence + 1)}"
+        return f"({rendered})" if precedence < parent_precedence else rendered
+
+    def identifiers(self) -> tuple[str, ...]:
+        if self.operator == "LICENSE":
+            assert self.value is not None
+            return (self.value,)
+        assert self.left is not None and self.right is not None
+        return self.left.identifiers() + self.right.identifiers()
+
+
+def _tokens(value: str) -> tuple[str, ...]:
+    result: list[str] = []
+    position = 0
+    while position < len(value):
+        match = TOKEN.match(value, position)
+        if not match:
+            raise ExpressionError(f"Invalid SPDX expression near {value[position:]!r}")
+        result.append(match.group(1))
+        position = match.end()
+    return tuple(result)
+
+
+class _Parser:
+    def __init__(self, tokens: tuple[str, ...]) -> None:
+        self.tokens = tokens
+        self.position = 0
+
+    def parse(self) -> Expression:
+        if not self.tokens:
+            raise ExpressionError("SPDX expression must not be empty")
+        result = self._or()
+        if self.position != len(self.tokens):
+            raise ExpressionError(f"Unexpected token {self.tokens[self.position]!r}")
+        return result
+
+    def _or(self) -> Expression:
+        result = self._and()
+        while self._peek("OR"):
+            self.position += 1
+            result = Expression("OR", left=result, right=self._and())
+        return result
+
+    def _and(self) -> Expression:
+        result = self._with()
+        while self._peek("AND"):
+            self.position += 1
+            result = Expression("AND", left=result, right=self._with())
+        return result
+
+    def _with(self) -> Expression:
+        result = self._primary()
+        if self._peek("WITH"):
+            self.position += 1
+            exception = self._primary()
+            if result.operator != "LICENSE" or exception.operator != "LICENSE":
+                raise ExpressionError(
+                    "WITH requires a license and an exception identifier"
+                )
+            result = Expression("WITH", left=result, right=exception)
+        return result
+
+    def _primary(self) -> Expression:
+        if self.position >= len(self.tokens):
+            raise ExpressionError("Unexpected end of SPDX expression")
+        token = self.tokens[self.position]
+        if token == "(":
+            self.position += 1
+            result = self._or()
+            if self.position >= len(self.tokens) or self.tokens[self.position] != ")":
+                raise ExpressionError("Missing closing parenthesis in SPDX expression")
+            self.position += 1
+            return result
+        if token.upper() in {"AND", "OR", "WITH"} or token == ")":
+            raise ExpressionError(f"Unexpected token {token!r}")
+        self.position += 1
+        value = "NOASSERTION" if token.upper() == "NOASSERTION" else token
+        return Expression("LICENSE", value=value)
+
+    def _peek(self, value: str) -> bool:
+        return (
+            self.position < len(self.tokens)
+            and self.tokens[self.position].upper() == value
+        )
+
+
+def parse_expression(value: str | None) -> Expression:
+    return _Parser(_tokens(value or "NOASSERTION")).parse()
+
+
+def normalize_expression(value: str | None) -> str:
+    return parse_expression(value).render()

--- a/tools/license_compliance/src/ov_contrib_license/reconciliation/__init__.py
+++ b/tools/license_compliance/src/ov_contrib_license/reconciliation/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from .artifacts import reconcile_artifact
+from .tpp import generate_tpp_preview, parse_tpp, reconcile_tpp
+
+__all__ = ["generate_tpp_preview", "parse_tpp", "reconcile_artifact", "reconcile_tpp"]

--- a/tools/license_compliance/src/ov_contrib_license/reconciliation/artifacts.py
+++ b/tools/license_compliance/src/ov_contrib_license/reconciliation/artifacts.py
@@ -1,0 +1,137 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from ov_contrib_license.model import (
+    Component,
+    Decision,
+    DistributionStatus,
+    Finding,
+    Inventory,
+    Relationship,
+    Severity,
+)
+
+_NON_RUNTIME = frozenset(
+    {
+        Relationship.BUILD_TOOL,
+        Relationship.CODE_GENERATOR,
+        Relationship.TEST_ONLY,
+        Relationship.DEV_ONLY,
+        Relationship.DOCUMENTATION_ASSET,
+    }
+)
+
+
+def _identity(component: Component) -> tuple[str, str]:
+    return component.name.casefold(), component.version or ""
+
+
+def _expected(component: Component) -> bool:
+    return component.distribution is DistributionStatus.DISTRIBUTED and not set(
+        component.relationships
+    ).issubset(_NON_RUNTIME)
+
+
+def reconcile_artifact(source: Inventory, artifact: Inventory) -> Inventory:
+    by_id = {component.id: component for component in source.components}
+    by_identity = {_identity(component): component for component in source.components}
+    matched_source: set[str] = set()
+    components = dict(by_id)
+    findings = list(source.findings)
+
+    for actual in artifact.components:
+        expected = by_id.get(actual.id) or by_identity.get(_identity(actual))
+        if expected is None:
+            components[actual.id] = actual
+            findings.append(
+                Finding.create(
+                    code="ARTIFACT_UNDECLARED_COMPONENT",
+                    severity=Severity.ERROR,
+                    decision=Decision.FAIL,
+                    component_id=actual.id,
+                    message=f"Artifact contains undeclared component {actual.name!r}.",
+                    evidence=actual.evidence,
+                    remediation=(
+                        "Declare the source dependency and classify its distributed use.",
+                    ),
+                    fingerprint_values=(
+                        actual.version or "",
+                        Relationship.BUNDLED_BINARY.value,
+                        DistributionStatus.DISTRIBUTED.value,
+                    ),
+                )
+            )
+            continue
+        matched_source.add(expected.id)
+        components[expected.id] = replace(
+            expected,
+            distribution=DistributionStatus.DISTRIBUTED,
+            relationships=tuple(
+                sorted(
+                    set(expected.relationships + (Relationship.BUNDLED_BINARY,)),
+                    key=lambda item: item.value,
+                )
+            ),
+            evidence=tuple(
+                sorted(
+                    set(expected.evidence + actual.evidence),
+                    key=lambda item: item.sort_key(),
+                )
+            ),
+            details=tuple(sorted(set(expected.details + actual.details))),
+        )
+        source_license = expected.declared_license
+        artifact_license = actual.declared_license
+        if source_license and artifact_license and source_license != artifact_license:
+            findings.append(
+                Finding.create(
+                    code="ARTIFACT_LICENSE_MISMATCH",
+                    severity=Severity.ERROR,
+                    decision=Decision.REVIEW,
+                    component_id=expected.id,
+                    message=(
+                        f"Artifact license {artifact_license!r} differs from source license "
+                        f"{source_license!r} for {expected.name}."
+                    ),
+                    evidence=expected.evidence + actual.evidence,
+                    remediation=(
+                        "Resolve the source/artifact license evidence mismatch.",
+                    ),
+                    fingerprint_values=(source_license, artifact_license),
+                )
+            )
+
+    for expected in source.components:
+        if _expected(expected) and expected.id not in matched_source:
+            findings.append(
+                Finding.create(
+                    code="ARTIFACT_MISSING_EXPECTED_COMPONENT",
+                    severity=Severity.WARNING,
+                    decision=Decision.REVIEW,
+                    component_id=expected.id,
+                    message=f"Expected distributed component {expected.name!r} was not found in the artifact.",
+                    evidence=expected.evidence,
+                    remediation=(
+                        "Confirm the artifact scope or correct the distribution classification.",
+                    ),
+                    fingerprint_values=(
+                        expected.version or "",
+                        *[item.value for item in expected.relationships],
+                    ),
+                )
+            )
+
+    providers = {item.name: item for item in source.providers}
+    providers.update({item.name: item for item in artifact.providers})
+    return replace(
+        source,
+        components=tuple(sorted(components.values(), key=lambda item: item.id)),
+        findings=tuple(
+            sorted({item.id: item for item in findings}.values(), key=Finding.sort_key)
+        ),
+        providers=tuple(sorted(providers.values(), key=lambda item: item.name)),
+    )

--- a/tools/license_compliance/src/ov_contrib_license/reconciliation/tpp.py
+++ b/tools/license_compliance/src/ov_contrib_license/reconciliation/tpp.py
@@ -1,0 +1,219 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+from ov_contrib_license.model import (
+    Decision,
+    DistributionStatus,
+    Finding,
+    Inventory,
+    Obligation,
+    Severity,
+)
+
+_SEPARATOR = re.compile(r"(?m)^-{20,}\s*$")
+_NAME_NORMALIZER = re.compile(r"[^a-z0-9]+")
+_NOTICE_OBLIGATIONS = frozenset(
+    {
+        Obligation.RETAIN_COPYRIGHT,
+        Obligation.RETAIN_LICENSE_TEXT,
+        Obligation.RETAIN_NOTICE,
+        Obligation.SEPARATE_LICENSE_TERMS,
+    }
+)
+
+
+@dataclass(frozen=True)
+class TppEntry:
+    name: str
+    text: str
+    license_expression: str | None
+
+
+def _normalized_name(value: str) -> str:
+    return _NAME_NORMALIZER.sub("", value.casefold())
+
+
+def _detected_license(text: str) -> str | None:
+    lowered = text.casefold()
+    if "apache license" in lowered and "version 2.0" in lowered:
+        return "Apache-2.0"
+    if (
+        "mit license" in lowered
+        or "permission is hereby granted, free of charge" in lowered
+    ):
+        return "MIT"
+    if "bsd 3-clause" in lowered:
+        return "BSD-3-Clause"
+    if "bsd 2-clause" in lowered:
+        return "BSD-2-Clause"
+    return None
+
+
+def parse_tpp(path: Path) -> tuple[str, tuple[TppEntry, ...]]:
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError as error:
+        raise ValueError(
+            f"Unable to read third-party programs file {path}: {error}"
+        ) from error
+    sections = _SEPARATOR.split(text)
+    header = sections[0].rstrip()
+    entries: list[TppEntry] = []
+    for section in sections[1:]:
+        stripped = section.strip()
+        if not stripped:
+            continue
+        lines = stripped.splitlines()
+        name = lines[0].strip()
+        body = "\n".join(lines[1:]).strip()
+        if name:
+            entries.append(TppEntry(name, body, _detected_license(body)))
+    return header, tuple(entries)
+
+
+def _component_names(component_id: str, name: str) -> set[str]:
+    result = {_normalized_name(name)}
+    identity = component_id.rsplit("/", 1)[-1].split("@", 1)[0]
+    result.add(_normalized_name(identity))
+    return result
+
+
+def reconcile_tpp(inventory: Inventory, tpp_path: Path) -> Inventory:
+    _, entries = parse_tpp(tpp_path)
+    entry_by_name = {_normalized_name(entry.name): entry for entry in entries}
+    matched: set[str] = set()
+    findings = list(inventory.findings)
+    for component in inventory.components:
+        candidates = _component_names(component.id, component.name)
+        entry = next(
+            (entry_by_name[value] for value in candidates if value in entry_by_name),
+            None,
+        )
+        if entry:
+            matched.add(_normalized_name(entry.name))
+        required = component.distribution is DistributionStatus.DISTRIBUTED and bool(
+            set(component.obligations) & _NOTICE_OBLIGATIONS
+        )
+        if required and entry is None:
+            findings.append(
+                Finding.create(
+                    code="TPP_MISSING_COMPONENT",
+                    severity=Severity.ERROR,
+                    decision=Decision.FAIL,
+                    component_id=component.id,
+                    message=f"Distributed component {component.name!r} requires a TPP entry.",
+                    evidence=component.evidence,
+                    remediation=(
+                        "Add the reviewed attribution and applicable license/NOTICE text.",
+                    ),
+                    fingerprint_values=(
+                        component.declared_license or "NOASSERTION",
+                        *component.obligations,
+                    ),
+                )
+            )
+        if (
+            entry
+            and entry.license_expression
+            and component.declared_license
+            and entry.license_expression != component.declared_license
+        ):
+            findings.append(
+                Finding.create(
+                    code="TPP_LICENSE_MISMATCH",
+                    severity=Severity.ERROR,
+                    decision=Decision.REVIEW,
+                    component_id=component.id,
+                    message=(
+                        f"TPP entry for {component.name!r} contains {entry.license_expression}, "
+                        f"but inventory declares {component.declared_license}."
+                    ),
+                    evidence=component.evidence,
+                    remediation=(
+                        "Reconcile the component license evidence with the reviewed TPP text.",
+                    ),
+                    fingerprint_values=(
+                        entry.license_expression,
+                        component.declared_license,
+                    ),
+                )
+            )
+    for entry in entries:
+        normalized = _normalized_name(entry.name)
+        if normalized not in matched:
+            findings.append(
+                Finding.create(
+                    code="TPP_UNRESOLVED_ENTRY",
+                    severity=Severity.WARNING,
+                    decision=Decision.REVIEW,
+                    component_id=None,
+                    message=f"TPP entry {entry.name!r} could not be mapped to discovered evidence.",
+                    remediation=(
+                        "Add canonical component mapping evidence or remove a confirmed stale entry.",
+                    ),
+                    fingerprint_values=(
+                        normalized,
+                        entry.license_expression or "NOASSERTION",
+                    ),
+                )
+            )
+    return replace(
+        inventory,
+        findings=tuple(
+            sorted({item.id: item for item in findings}.values(), key=Finding.sort_key)
+        ),
+    )
+
+
+def generate_tpp_preview(
+    inventory: Inventory, existing_path: Path | None = None
+) -> str:
+    existing: dict[str, TppEntry] = {}
+    if existing_path and existing_path.is_file():
+        _, entries = parse_tpp(existing_path)
+        existing = {_normalized_name(item.name): item for item in entries}
+    lines = [
+        "OpenVINO Contrib Third Party Programs File (PREVIEW)",
+        "",
+        "Generated output is a review aid and is not authoritative.",
+    ]
+    components = [
+        item
+        for item in inventory.components
+        if item.distribution is DistributionStatus.DISTRIBUTED
+        and bool(set(item.obligations) & _NOTICE_OBLIGATIONS)
+    ]
+    for component in sorted(
+        components, key=lambda item: (item.name.casefold(), item.id)
+    ):
+        entry = next(
+            (
+                existing[name]
+                for name in _component_names(component.id, component.name)
+                if name in existing
+            ),
+            None,
+        )
+        lines.extend(
+            (
+                "",
+                "-------------------------------------------------------------",
+                "",
+                component.name,
+                "",
+            )
+        )
+        if entry and entry.text:
+            lines.append(entry.text)
+        else:
+            lines.append(
+                f"SPDX license expression: {component.declared_license or 'NOASSERTION'}"
+            )
+            lines.append("TODO: insert reviewed copyright, license, and NOTICE text.")
+    return "\n".join(lines).rstrip() + "\n"

--- a/tools/license_compliance/src/ov_contrib_license/reporters/__init__.py
+++ b/tools/license_compliance/src/ov_contrib_license/reporters/__init__.py
@@ -2,5 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .inventory import render_inventory, write_inventory
+from .markdown import render_markdown
+from .spdx import render_spdx
 
-__all__ = ["render_inventory", "write_inventory"]
+__all__ = ["render_inventory", "render_markdown", "render_spdx", "write_inventory"]

--- a/tools/license_compliance/src/ov_contrib_license/reporters/__init__.py
+++ b/tools/license_compliance/src/ov_contrib_license/reporters/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from .inventory import render_inventory, write_inventory
+
+__all__ = ["render_inventory", "write_inventory"]

--- a/tools/license_compliance/src/ov_contrib_license/reporters/inventory.py
+++ b/tools/license_compliance/src/ov_contrib_license/reporters/inventory.py
@@ -61,7 +61,9 @@ def render_inventory(inventory: Inventory, output_format: str = "json") -> str:
     raise ValueError(f"Unsupported inventory format: {output_format}")
 
 
-def write_inventory(inventory: Inventory, output: Path | None, output_format: str = "json") -> None:
+def write_inventory(
+    inventory: Inventory, output: Path | None, output_format: str = "json"
+) -> None:
     rendered = render_inventory(inventory, output_format)
     if output is None:
         print(rendered, end="")

--- a/tools/license_compliance/src/ov_contrib_license/reporters/inventory.py
+++ b/tools/license_compliance/src/ov_contrib_license/reporters/inventory.py
@@ -1,0 +1,69 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ov_contrib_license.model import Inventory
+
+
+def _yaml_scalar(value: object) -> str:
+    if value is None:
+        return "null"
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    return json.dumps(str(value), ensure_ascii=False)
+
+
+def _yaml_lines(value: object, indentation: int = 0) -> list[str]:
+    prefix = " " * indentation
+    if isinstance(value, dict):
+        if not value:
+            return [f"{prefix}{{}}"]
+        lines: list[str] = []
+        for key, child in value.items():
+            if isinstance(child, (dict, list)) and child:
+                lines.append(f"{prefix}{key}:")
+                lines.extend(_yaml_lines(child, indentation + 2))
+            elif isinstance(child, dict):
+                lines.append(f"{prefix}{key}: {{}}")
+            elif isinstance(child, list):
+                lines.append(f"{prefix}{key}: []")
+            else:
+                lines.append(f"{prefix}{key}: {_yaml_scalar(child)}")
+        return lines
+    if isinstance(value, list):
+        if not value:
+            return [f"{prefix}[]"]
+        lines = []
+        for child in value:
+            if isinstance(child, (dict, list)):
+                lines.append(f"{prefix}-")
+                lines.extend(_yaml_lines(child, indentation + 2))
+            else:
+                lines.append(f"{prefix}- {_yaml_scalar(child)}")
+        return lines
+    return [f"{prefix}{_yaml_scalar(value)}"]
+
+
+def render_inventory(inventory: Inventory, output_format: str = "json") -> str:
+    data = inventory.to_dict()
+    if output_format == "json":
+        return json.dumps(data, ensure_ascii=False, indent=2) + "\n"
+    if output_format == "yaml":
+        return "\n".join(_yaml_lines(data)) + "\n"
+    raise ValueError(f"Unsupported inventory format: {output_format}")
+
+
+def write_inventory(inventory: Inventory, output: Path | None, output_format: str = "json") -> None:
+    rendered = render_inventory(inventory, output_format)
+    if output is None:
+        print(rendered, end="")
+    else:
+        output.write_text(rendered, encoding="utf-8")

--- a/tools/license_compliance/src/ov_contrib_license/reporters/markdown.py
+++ b/tools/license_compliance/src/ov_contrib_license/reporters/markdown.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from ov_contrib_license.model import Decision, Inventory
+
+MAX_FINDINGS_PER_DECISION = 20
+
+
+def render_markdown(inventory: Inventory, title: str = "License Compliance") -> str:
+    active = [item for item in inventory.findings if not item.suppressed]
+    counts = {
+        decision: sum(item.decision is decision for item in active)
+        for decision in Decision
+    }
+    scopes = ", ".join(inventory.repository.impacted_scopes) or "full repository"
+    lines = [
+        f"# {title}",
+        "",
+        f"Impacted scopes: {scopes}",
+        f"Components: {len(inventory.components)}",
+        f"PASS: {counts[Decision.PASS]}",
+        f"REVIEW: {counts[Decision.REVIEW]}",
+        f"FAIL: {counts[Decision.FAIL]}",
+        f"Suppressed by exact baseline: {sum(item.suppressed for item in inventory.findings)}",
+    ]
+    for decision in (Decision.FAIL, Decision.REVIEW):
+        selected = [item for item in active if item.decision is decision]
+        if not selected:
+            continue
+        lines.extend(("", f"## {decision.value}"))
+        for finding in selected[:MAX_FINDINGS_PER_DECISION]:
+            component = f" — `{finding.component_id}`" if finding.component_id else ""
+            lines.extend(("", f"### {finding.code}{component}", "", finding.message))
+            for remediation in finding.remediation:
+                lines.append(f"- {remediation}")
+        omitted = len(selected) - MAX_FINDINGS_PER_DECISION
+        if omitted > 0:
+            lines.extend(
+                (
+                    "",
+                    f"_Omitted {omitted} additional {decision.value} findings; see the JSON inventory._",
+                )
+            )
+    return "\n".join(lines).rstrip() + "\n"

--- a/tools/license_compliance/src/ov_contrib_license/reporters/spdx.py
+++ b/tools/license_compliance/src/ov_contrib_license/reporters/spdx.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from ov_contrib_license.model import Inventory
+
+
+def _spdx_id(component_id: str) -> str:
+    digest = hashlib.sha256(component_id.encode("utf-8")).hexdigest()[:20]
+    return f"SPDXRef-Package-{digest}"
+
+
+def render_spdx(inventory: Inventory) -> str:
+    canonical = json.dumps(inventory.to_dict(), sort_keys=True, separators=(",", ":"))
+    namespace_hash = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    packages: list[dict[str, object]] = []
+    relationships: list[dict[str, str]] = []
+    for component in inventory.components:
+        spdx_id = _spdx_id(component.id)
+        package: dict[str, object] = {
+            "SPDXID": spdx_id,
+            "name": component.name,
+            "downloadLocation": dict(component.details).get(
+                "source_url", "NOASSERTION"
+            ),
+            "filesAnalyzed": False,
+            "licenseConcluded": (
+                " AND ".join(component.detected_licenses)
+                if component.detected_licenses
+                else "NOASSERTION"
+            ),
+            "licenseDeclared": component.declared_license or "NOASSERTION",
+            "copyrightText": "NOASSERTION",
+        }
+        if component.version:
+            package["versionInfo"] = component.version
+        if component.id.startswith("pkg:"):
+            package["externalRefs"] = [
+                {
+                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceType": "purl",
+                    "referenceLocator": component.id,
+                }
+            ]
+        packages.append(package)
+        relationships.append(
+            {
+                "spdxElementId": "SPDXRef-DOCUMENT",
+                "relationshipType": "DESCRIBES",
+                "relatedSpdxElement": spdx_id,
+            }
+        )
+    data = {
+        "spdxVersion": "SPDX-2.3",
+        "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT",
+        "name": "openvino-contrib-license-inventory",
+        "documentNamespace": f"https://openvinotoolkit.org/spdx/openvino-contrib/{namespace_hash}",
+        "creationInfo": {
+            "created": "1970-01-01T00:00:00Z",
+            "creators": ["Tool: ov-contrib-license"],
+        },
+        "packages": packages,
+        "relationships": relationships,
+    }
+    return json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True) + "\n"

--- a/tools/license_compliance/src/ov_contrib_license/toolchain.py
+++ b/tools/license_compliance/src/ov_contrib_license/toolchain.py
@@ -1,0 +1,225 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, replace
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10
+    import tomli as tomllib
+
+from ov_contrib_license.model import (
+    Decision,
+    Evidence,
+    EvidenceKind,
+    Finding,
+    Inventory,
+    Severity,
+)
+from ov_contrib_license.policy import PolicyConfig
+
+_DEPENDENCY_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*")
+
+
+@dataclass(frozen=True)
+class ToolchainSummary:
+    inventory: Inventory
+    review_count: int
+    fail_count: int
+    suppressed_count: int
+
+
+def _license_allowed(license_id: str, config: PolicyConfig) -> bool:
+    if license_id in config.toolchain.allowed_explicit_licenses:
+        return True
+    return any(
+        class_name in config.toolchain.allowed_license_classes
+        and license_id in licenses
+        for class_name, licenses in config.license_classes.items()
+    )
+
+
+def _action_name(value: str) -> str:
+    reference = value.split("@", 1)[0]
+    return "/".join(reference.split("/")[:2]).casefold()
+
+
+def _dependencies(root: Path) -> tuple[str, ...]:
+    pyproject = root / "tools" / "license_compliance" / "pyproject.toml"
+    if not pyproject.is_file():
+        return ()
+    try:
+        data = tomllib.loads(pyproject.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise ValueError(
+            f"Unable to parse compliance tool pyproject.toml: {error}"
+        ) from error
+    values = list(data.get("project", {}).get("dependencies", ()))
+    values.extend(data.get("build-system", {}).get("requires", ()))
+    names = []
+    for value in values:
+        match = _DEPENDENCY_NAME.match(str(value))
+        if match:
+            names.append(match.group(0).casefold())
+    return tuple(sorted(set(names)))
+
+
+def audit_toolchain(
+    root: Path, inventory: Inventory, config: PolicyConfig
+) -> ToolchainSummary:
+    findings = list(inventory.findings)
+    registry = config.toolchain.actions
+    for component in inventory.components:
+        action_evidence = [
+            item
+            for item in component.evidence
+            if item.kind is EvidenceKind.GITHUB_ACTION
+        ]
+        if not action_evidence:
+            continue
+        evidence = action_evidence[0]
+        reference = evidence.value or component.name
+        if reference.startswith("docker://"):
+            pinned = "@sha256:" in reference
+            action_name = reference.split("@", 1)[0].casefold()
+        else:
+            ref = reference.rpartition("@")[2]
+            pinned = bool(re.fullmatch(r"[0-9a-fA-F]{40}", ref))
+            action_name = _action_name(reference)
+        if config.toolchain.require_full_sha_for_github_actions and not pinned:
+            findings.append(
+                Finding.create(
+                    code="TOOL_ACTION_UNPINNED",
+                    severity=Severity.ERROR,
+                    decision=Decision.FAIL,
+                    component_id=component.id,
+                    message=f"Toolchain action {reference!r} is not pinned immutably.",
+                    evidence=action_evidence,
+                    remediation=(
+                        "Pin GitHub Actions to a full commit SHA or containers to sha256.",
+                    ),
+                    fingerprint_values=(reference,),
+                )
+            )
+        license_id = registry.get(action_name)
+        if license_id is None:
+            findings.append(
+                Finding.create(
+                    code="TOOL_ACTION_UNKNOWN_LICENSE",
+                    severity=Severity.WARNING,
+                    decision=Decision.REVIEW,
+                    component_id=component.id,
+                    message=f"No reviewed toolchain license is registered for {action_name!r}.",
+                    evidence=action_evidence,
+                    remediation=(
+                        "Review the public action source and add its license to toolchain.yml.",
+                    ),
+                    fingerprint_values=(action_name,),
+                )
+            )
+        elif not _license_allowed(license_id, config):
+            findings.append(
+                Finding.create(
+                    code="TOOL_ACTION_DISALLOWED_LICENSE",
+                    severity=Severity.ERROR,
+                    decision=Decision.FAIL,
+                    component_id=component.id,
+                    message=f"Toolchain action {action_name!r} has disallowed license {license_id}.",
+                    evidence=action_evidence,
+                    remediation=(
+                        "Replace the action or approve a narrowly reviewed toolchain policy change.",
+                    ),
+                    fingerprint_values=(action_name, license_id),
+                )
+            )
+
+    dependency_registry = config.toolchain.dependencies
+    for dependency in _dependencies(root):
+        license_id = dependency_registry.get(dependency)
+        evidence = Evidence(
+            EvidenceKind.PACKAGE_METADATA,
+            "toolchain-policy",
+            "tools/license_compliance/pyproject.toml",
+            dependency,
+        )
+        if license_id is None:
+            findings.append(
+                Finding.create(
+                    code="TOOL_DEPENDENCY_UNKNOWN_LICENSE",
+                    severity=Severity.WARNING,
+                    decision=Decision.REVIEW,
+                    component_id=f"pkg:pypi/{dependency}",
+                    message=f"Direct tool dependency {dependency!r} has no reviewed license entry.",
+                    evidence=(evidence,),
+                    remediation=(
+                        "Review and register the dependency license in toolchain.yml.",
+                    ),
+                    fingerprint_values=(dependency,),
+                )
+            )
+        elif not _license_allowed(license_id, config):
+            findings.append(
+                Finding.create(
+                    code="TOOL_DEPENDENCY_DISALLOWED_LICENSE",
+                    severity=Severity.ERROR,
+                    decision=Decision.FAIL,
+                    component_id=f"pkg:pypi/{dependency}",
+                    message=f"Direct tool dependency {dependency!r} has disallowed license {license_id}.",
+                    evidence=(evidence,),
+                    remediation=(
+                        "Remove the dependency or approve an explicit toolchain policy change.",
+                    ),
+                    fingerprint_values=(dependency, license_id),
+                )
+            )
+
+    workflow_paths = sorted(
+        {item.path for item in inventory.discoveries if item.kind == "github-action"}
+    )
+    for service_id, reason in config.toolchain.forbidden_services:
+        for path in workflow_paths:
+            try:
+                text = (root / path).read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            if service_id.casefold() not in text.casefold():
+                continue
+            evidence = Evidence(
+                EvidenceKind.GITHUB_ACTION, "toolchain-policy", path, service_id
+            )
+            findings.append(
+                Finding.create(
+                    code="TOOL_PROPRIETARY_BACKEND_REQUIRED",
+                    severity=Severity.ERROR,
+                    decision=Decision.FAIL,
+                    component_id=None,
+                    message=f"Workflow references forbidden service {service_id!r}: {reason}",
+                    evidence=(evidence,),
+                    remediation=("Remove the mandatory proprietary decision backend.",),
+                    fingerprint_values=(service_id, path),
+                )
+            )
+
+    unique = {item.id: item for item in findings}
+    baseline = config.baseline_by_id
+    evaluated = tuple(
+        sorted(
+            (
+                item.suppress(baseline[item.id].reason) if item.id in baseline else item
+                for item in unique.values()
+            ),
+            key=Finding.sort_key,
+        )
+    )
+    result = replace(inventory, findings=evaluated)
+    active = [item for item in evaluated if not item.suppressed]
+    return ToolchainSummary(
+        inventory=result,
+        review_count=sum(item.decision is Decision.REVIEW for item in active),
+        fail_count=sum(item.decision is Decision.FAIL for item in active),
+        suppressed_count=sum(item.suppressed for item in evaluated),
+    )

--- a/tools/license_compliance/tests/fixtures/license-eye-result.json
+++ b/tools/license_compliance/tests/fixtures/license-eye-result.json
@@ -1,0 +1,8 @@
+{
+  "version": "0.6.0",
+  "header": {
+    "valid": ["src/good.py"],
+    "invalid": ["src/missing.py"],
+    "ignored": ["vendor/imported.c"]
+  }
+}

--- a/tools/license_compliance/tests/fixtures/ort-result.json
+++ b/tools/license_compliance/tests/fixtures/ort-result.json
@@ -1,0 +1,21 @@
+{
+  "ort_version": "50.0.0",
+  "analyzer": {
+    "result": {
+      "packages": [
+        {
+          "id": {
+            "type": "PyPI",
+            "namespace": "",
+            "name": "example-runtime",
+            "version": "1.2.3"
+          },
+          "purl": "pkg:pypi/example-runtime@1.2.3",
+          "declared_licenses_processed": {
+            "spdx_expression": "MIT OR Apache-2.0"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tools/license_compliance/tests/fixtures/repository/.github/workflows/test.yml
+++ b/tools/license_compliance/tests/fixtures/repository/.github/workflows/test.yml
@@ -1,0 +1,10 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+name: Fixture
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4

--- a/tools/license_compliance/tests/fixtures/repository/modules/a/CMakeLists.txt
+++ b/tools/license_compliance/tests/fixtures/repository/modules/a/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+FetchContent_Declare(
+    permissive
+    GIT_REPOSITORY https://github.com/example/permissive.git
+    GIT_TAG 1.0.0
+)

--- a/tools/license_compliance/tests/fixtures/repository/modules/b/vendor/gpl_component/source.c
+++ b/tools/license_compliance/tests/fixtures/repository/modules/b/vendor/gpl_component/source.c
@@ -1,0 +1,6 @@
+// Copyright (C) 2018-2026 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+
+int imported_source(void) {
+    return 0;
+}

--- a/tools/license_compliance/tests/fixtures/repository/ort-result.json
+++ b/tools/license_compliance/tests/fixtures/repository/ort-result.json
@@ -1,0 +1,21 @@
+{
+  "ort_version": "50.0.0",
+  "analyzer": {
+    "result": {
+      "packages": [
+        {
+          "id": {
+            "type": "Generic",
+            "namespace": "example",
+            "name": "permissive",
+            "version": "1.0.0"
+          },
+          "purl": "pkg:github/example/permissive@1.0.0",
+          "declared_licenses_processed": {
+            "spdx_expression": "MIT"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tools/license_compliance/tests/fixtures/repository/syft-result.json
+++ b/tools/license_compliance/tests/fixtures/repository/syft-result.json
@@ -1,0 +1,17 @@
+{
+  "descriptor": {
+    "name": "syft",
+    "version": "1.30.0"
+  },
+  "artifacts": [
+    {
+      "id": "permissive-id",
+      "name": "permissive",
+      "version": "1.0.0",
+      "type": "generic",
+      "purl": "pkg:github/example/permissive@1.0.0",
+      "licenses": [{"value": "MIT", "spdxExpression": "MIT"}],
+      "locations": [{"path": "/lib/permissive.so"}]
+    }
+  ]
+}

--- a/tools/license_compliance/tests/fixtures/repository/third-party-programs.txt
+++ b/tools/license_compliance/tests/fixtures/repository/third-party-programs.txt
@@ -1,0 +1,3 @@
+OpenVINO Contrib Third Party Programs File
+
+No reviewed entries in this synthetic fixture.

--- a/tools/license_compliance/tests/fixtures/syft-result.json
+++ b/tools/license_compliance/tests/fixtures/syft-result.json
@@ -1,0 +1,26 @@
+{
+  "descriptor": {
+    "name": "syft",
+    "version": "1.30.0"
+  },
+  "artifacts": [
+    {
+      "id": "expected-id",
+      "name": "expected-runtime",
+      "version": "1.0.0",
+      "type": "python",
+      "purl": "pkg:pypi/expected-runtime@1.0.0",
+      "licenses": [{"value": "MIT", "spdxExpression": "MIT"}],
+      "locations": [{"path": "/site-packages/expected_runtime.py"}]
+    },
+    {
+      "id": "unknown-id",
+      "name": "artifact-only",
+      "version": "2.0.0",
+      "type": "python",
+      "purl": "pkg:pypi/artifact-only@2.0.0",
+      "licenses": [{"value": "Apache-2.0", "spdxExpression": "Apache-2.0"}],
+      "locations": [{"path": "/site-packages/artifact_only.py"}]
+    }
+  ]
+}

--- a/tools/license_compliance/tests/test_adapters_and_reconciliation.py
+++ b/tools/license_compliance/tests/test_adapters_and_reconciliation.py
@@ -1,0 +1,119 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from ov_contrib_license.adapters import import_license_eye, import_ort, import_syft
+from ov_contrib_license.model import (
+    Component,
+    DistributionStatus,
+    InventoryBuilder,
+    Obligation,
+    Relationship,
+    RepositoryInfo,
+)
+from ov_contrib_license.reconciliation import reconcile_artifact, reconcile_tpp
+from ov_contrib_license.reporters import render_spdx
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+class AdapterTests(unittest.TestCase):
+    def test_ort_maps_package_and_license_to_canonical_model(self) -> None:
+        source = InventoryBuilder(RepositoryInfo(".", "revision")).build()
+        inventory = import_ort(source, FIXTURES / "ort-result.json")
+
+        self.assertEqual(inventory.components[0].id, "pkg:pypi/example-runtime@1.2.3")
+        self.assertEqual(inventory.components[0].declared_license, "MIT OR Apache-2.0")
+        self.assertIn("ort", {item.name for item in inventory.providers})
+
+    def test_license_eye_failure_and_ignore_are_not_silent_passes(self) -> None:
+        source = InventoryBuilder(RepositoryInfo(".", "revision")).build()
+        inventory = import_license_eye(source, FIXTURES / "license-eye-result.json")
+
+        self.assertEqual(
+            {item.code for item in inventory.findings},
+            {"HEADER_IGNORED_PATHS", "HEADER_INVALID"},
+        )
+
+    def test_syft_maps_artifact_packages_as_distributed(self) -> None:
+        inventory = import_syft(FIXTURES / "syft-result.json")
+
+        self.assertEqual(len(inventory.components), 2)
+        self.assertTrue(
+            all(
+                item.distribution is DistributionStatus.DISTRIBUTED
+                for item in inventory.components
+            )
+        )
+
+
+class ReconciliationTests(unittest.TestCase):
+    def test_artifact_only_component_fails_but_absent_build_tool_does_not(self) -> None:
+        builder = InventoryBuilder(RepositoryInfo(".", "revision"))
+        builder.add_component(
+            Component(
+                id="pkg:pypi/expected-runtime@1.0.0",
+                name="expected-runtime",
+                version="1.0.0",
+                declared_license="MIT",
+                relationships=(Relationship.RUNTIME_DEPENDENCY,),
+                distribution=DistributionStatus.DISTRIBUTED,
+            )
+        )
+        builder.add_component(
+            Component(
+                id="pkg:generic/build-helper@1",
+                name="build-helper",
+                version="1",
+                declared_license="MIT",
+                relationships=(Relationship.BUILD_TOOL,),
+                distribution=DistributionStatus.NOT_DISTRIBUTED,
+            )
+        )
+        result = reconcile_artifact(
+            builder.build(), import_syft(FIXTURES / "syft-result.json")
+        )
+        codes = [item.code for item in result.findings]
+
+        self.assertEqual(codes.count("ARTIFACT_UNDECLARED_COMPONENT"), 1)
+        self.assertNotIn("ARTIFACT_MISSING_EXPECTED_COMPONENT", codes)
+
+    def test_tpp_missing_distributed_attribution_is_a_failure(self) -> None:
+        builder = InventoryBuilder(RepositoryInfo(".", "revision"))
+        builder.add_component(
+            Component(
+                id="pkg:generic/new-component@1",
+                name="new-component",
+                version="1",
+                declared_license="MIT",
+                relationships=(Relationship.BUNDLED_BINARY,),
+                distribution=DistributionStatus.DISTRIBUTED,
+                obligations=(Obligation.RETAIN_LICENSE_TEXT,),
+            )
+        )
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            tpp = Path(temporary_directory) / "third-party-programs.txt"
+            tpp.write_text("Third Party Programs\n", encoding="utf-8")
+            result = reconcile_tpp(builder.build(), tpp)
+
+        self.assertIn("TPP_MISSING_COMPONENT", {item.code for item in result.findings})
+
+    def test_spdx_output_is_deterministic_and_contains_purl(self) -> None:
+        inventory = import_syft(FIXTURES / "syft-result.json")
+        first = render_spdx(inventory)
+        second = render_spdx(inventory)
+        data = json.loads(first)
+
+        self.assertEqual(first, second)
+        self.assertEqual(data["spdxVersion"], "SPDX-2.3")
+        self.assertEqual(
+            data["packages"][0]["externalRefs"][0]["referenceType"], "purl"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/license_compliance/tests/test_cli.py
+++ b/tools/license_compliance/tests/test_cli.py
@@ -1,0 +1,33 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from ov_contrib_license.cli import EXIT_CONFIGURATION_ERROR, EXIT_SUCCESS, main
+
+
+class CliTests(unittest.TestCase):
+    def test_inventory_writes_canonical_json(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            (root / "requirements.txt").write_text("example==1\n", encoding="utf-8")
+            output = root / "result.json"
+
+            exit_code = main(["inventory", str(root), "--offline", "--output", str(output)])
+            data = json.loads(output.read_text(encoding="utf-8"))
+
+        self.assertEqual(exit_code, EXIT_SUCCESS)
+        self.assertEqual(data["schema_version"], 1)
+        self.assertEqual(data["discoveries"][0]["path"], "requirements.txt")
+
+    def test_partial_incremental_configuration_has_distinct_exit_code(self) -> None:
+        exit_code = main(["inventory", ".", "--base-ref", "HEAD~1"])
+
+        self.assertEqual(exit_code, EXIT_CONFIGURATION_ERROR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/license_compliance/tests/test_cli.py
+++ b/tools/license_compliance/tests/test_cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 from ov_contrib_license.cli import (
     EXIT_CONFIGURATION_ERROR,
+    EXIT_DISCOVERY_ERROR,
     EXIT_POLICY_FAIL,
     EXIT_REVIEW_BLOCKING,
     EXIT_SUCCESS,
@@ -46,6 +47,27 @@ class CliTests(unittest.TestCase):
         exit_code = main(["inventory", ".", "--base-ref", "HEAD~1"])
 
         self.assertEqual(exit_code, EXIT_CONFIGURATION_ERROR)
+
+    def test_malformed_provider_result_has_distinct_exit_code(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            result = root / "ort-result.json"
+            result.write_text("not JSON", encoding="utf-8")
+
+            exit_code = main(
+                [
+                    "check",
+                    str(root),
+                    "--policy-dir",
+                    str(POLICY),
+                    "--ort-result",
+                    str(result),
+                    "--report",
+                    str(root / "report.md"),
+                ]
+            )
+
+        self.assertEqual(exit_code, EXIT_DISCOVERY_ERROR)
 
     def test_new_unknown_vendored_component_is_blocking(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:

--- a/tools/license_compliance/tests/test_cli.py
+++ b/tools/license_compliance/tests/test_cli.py
@@ -6,7 +6,24 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from ov_contrib_license.cli import EXIT_CONFIGURATION_ERROR, EXIT_SUCCESS, main
+from ov_contrib_license.cli import (
+    EXIT_CONFIGURATION_ERROR,
+    EXIT_POLICY_FAIL,
+    EXIT_REVIEW_BLOCKING,
+    EXIT_SUCCESS,
+    main,
+)
+from ov_contrib_license.model import (
+    Component,
+    DistributionStatus,
+    InventoryBuilder,
+    Relationship,
+    RepositoryInfo,
+)
+from ov_contrib_license.reporters import write_inventory
+
+FIXTURES = Path(__file__).parent / "fixtures"
+POLICY = Path(__file__).parents[1] / "policy"
 
 
 class CliTests(unittest.TestCase):
@@ -16,7 +33,9 @@ class CliTests(unittest.TestCase):
             (root / "requirements.txt").write_text("example==1\n", encoding="utf-8")
             output = root / "result.json"
 
-            exit_code = main(["inventory", str(root), "--offline", "--output", str(output)])
+            exit_code = main(
+                ["inventory", str(root), "--offline", "--output", str(output)]
+            )
             data = json.loads(output.read_text(encoding="utf-8"))
 
         self.assertEqual(exit_code, EXIT_SUCCESS)
@@ -27,6 +46,117 @@ class CliTests(unittest.TestCase):
         exit_code = main(["inventory", ".", "--base-ref", "HEAD~1"])
 
         self.assertEqual(exit_code, EXIT_CONFIGURATION_ERROR)
+
+    def test_new_unknown_vendored_component_is_blocking(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source = root / "modules" / "sample" / "vendor" / "lib" / "source.cpp"
+            source.parent.mkdir(parents=True)
+            source.write_text("// imported source\n", encoding="utf-8")
+            report = root / "report.md"
+
+            exit_code = main(
+                [
+                    "check",
+                    str(root),
+                    "--policy-dir",
+                    str(POLICY),
+                    "--fail-on",
+                    "FAIL",
+                    "--report",
+                    str(report),
+                ]
+            )
+
+        self.assertEqual(exit_code, EXIT_POLICY_FAIL)
+
+    def test_review_has_a_distinct_blocking_exit_code(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            cmake = root / "modules" / "sample" / "CMakeLists.txt"
+            cmake.parent.mkdir(parents=True)
+            cmake.write_text(
+                "FetchContent_Declare(example URL https://example.org/example.tar.gz VERSION 1)\n",
+                encoding="utf-8",
+            )
+
+            exit_code = main(
+                [
+                    "check",
+                    str(root),
+                    "--policy-dir",
+                    str(POLICY),
+                    "--fail-on",
+                    "REVIEW",
+                    "--report",
+                    str(root / "report.md"),
+                ]
+            )
+
+        self.assertEqual(exit_code, EXIT_REVIEW_BLOCKING)
+
+    def test_artifact_command_returns_policy_fail_for_artifact_only_package(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source_path = root / "source.json"
+            report = root / "artifact.md"
+            builder = InventoryBuilder(RepositoryInfo(".", "revision"))
+            builder.add_component(
+                Component(
+                    id="pkg:pypi/expected-runtime@1.0.0",
+                    name="expected-runtime",
+                    version="1.0.0",
+                    declared_license="MIT",
+                    relationships=(Relationship.RUNTIME_DEPENDENCY,),
+                    distribution=DistributionStatus.DISTRIBUTED,
+                )
+            )
+            write_inventory(builder.build(), source_path)
+
+            exit_code = main(
+                [
+                    "artifact",
+                    "check",
+                    str(root),
+                    "--source-inventory",
+                    str(source_path),
+                    "--syft-result",
+                    str(FIXTURES / "syft-result.json"),
+                    "--policy-dir",
+                    str(POLICY),
+                    "--report",
+                    str(report),
+                ]
+            )
+            rendered = report.read_text(encoding="utf-8")
+
+        self.assertEqual(exit_code, EXIT_POLICY_FAIL)
+        self.assertIn("ARTIFACT_UNDECLARED_COMPONENT", rendered)
+
+    def test_toolchain_command_rejects_unpinned_action(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            workflow = root / ".github" / "workflows" / "test.yml"
+            workflow.parent.mkdir(parents=True)
+            workflow.write_text(
+                "steps:\n  - uses: actions/checkout@v4\n", encoding="utf-8"
+            )
+
+            exit_code = main(
+                [
+                    "toolchain",
+                    "check",
+                    str(root),
+                    "--policy-dir",
+                    str(POLICY),
+                    "--report",
+                    str(root / "toolchain.md"),
+                ]
+            )
+
+        self.assertEqual(exit_code, EXIT_POLICY_FAIL)
 
 
 if __name__ == "__main__":

--- a/tools/license_compliance/tests/test_cmake.py
+++ b/tools/license_compliance/tests/test_cmake.py
@@ -1,0 +1,78 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from ov_contrib_license.discovery.cmake import parse_cmake
+from ov_contrib_license.discovery.repository import DiscoveryOptions, RepositoryDiscovery
+
+
+class CMakeParserTests(unittest.TestCase):
+    def test_multiline_command_and_comments(self) -> None:
+        commands = parse_cmake(
+            """
+            # FetchContent_Declare(ignored GIT_REPOSITORY https://example.invalid/ignored)
+            FetchContent_Declare(
+                fmt
+                GIT_REPOSITORY "https://github.com/fmtlib/fmt.git"
+                GIT_TAG 10.2.1 # exact upstream tag
+            )
+            """
+        )
+
+        self.assertEqual(len(commands), 1)
+        self.assertEqual(commands[0].name, "fetchcontent_declare")
+        self.assertIn("https://github.com/fmtlib/fmt.git", commands[0].arguments)
+        self.assertIn("10.2.1", commands[0].arguments)
+
+    def test_balanced_nested_syntax(self) -> None:
+        commands = parse_cmake(
+            "FetchContent_Declare(foo URL $<IF:$<BOOL:${FLAG}>,https://example/a,https://example/b>)"
+        )
+
+        self.assertEqual(len(commands), 1)
+        self.assertEqual(commands[0].arguments[0], "foo")
+
+    def test_bracket_comment_is_ignored(self) -> None:
+        commands = parse_cmake(
+            """
+            #[=[
+            ExternalProject_Add(ignored URL https://example.invalid/archive)
+            ]=]
+            find_package(OpenVINO REQUIRED)
+            """
+        )
+
+        self.assertEqual([command.name for command in commands], ["find_package"])
+
+    def test_unresolved_revision_is_preserved_as_review(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            cmake = root / "modules" / "sample" / "CMakeLists.txt"
+            cmake.parent.mkdir(parents=True)
+            cmake.write_text(
+                """
+                FetchContent_Declare(
+                    example
+                    GIT_REPOSITORY https://github.com/example/project.git
+                    GIT_TAG ${EXAMPLE_REVISION}
+                )
+                """,
+                encoding="utf-8",
+            )
+
+            inventory = RepositoryDiscovery(root, DiscoveryOptions()).run()
+
+        self.assertEqual(len(inventory.components), 1)
+        component = inventory.components[0]
+        self.assertIsNone(component.version)
+        self.assertEqual(component.relationships[0].value, "FETCHED_AT_BUILD")
+        self.assertEqual(inventory.findings[0].code, "DISCOVERY_CMAKE_UNRESOLVED_REVISION")
+        evidence_details = dict(component.evidence[0].details)
+        self.assertEqual(evidence_details["unresolved_revision_expression"], "${EXAMPLE_REVISION}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/license_compliance/tests/test_cmake.py
+++ b/tools/license_compliance/tests/test_cmake.py
@@ -6,7 +6,10 @@ import unittest
 from pathlib import Path
 
 from ov_contrib_license.discovery.cmake import parse_cmake
-from ov_contrib_license.discovery.repository import DiscoveryOptions, RepositoryDiscovery
+from ov_contrib_license.discovery.repository import (
+    DiscoveryOptions,
+    RepositoryDiscovery,
+)
 
 
 class CMakeParserTests(unittest.TestCase):
@@ -69,9 +72,13 @@ class CMakeParserTests(unittest.TestCase):
         component = inventory.components[0]
         self.assertIsNone(component.version)
         self.assertEqual(component.relationships[0].value, "FETCHED_AT_BUILD")
-        self.assertEqual(inventory.findings[0].code, "DISCOVERY_CMAKE_UNRESOLVED_REVISION")
+        self.assertEqual(
+            inventory.findings[0].code, "DISCOVERY_CMAKE_UNRESOLVED_REVISION"
+        )
         evidence_details = dict(component.evidence[0].details)
-        self.assertEqual(evidence_details["unresolved_revision_expression"], "${EXAMPLE_REVISION}")
+        self.assertEqual(
+            evidence_details["unresolved_revision_expression"], "${EXAMPLE_REVISION}"
+        )
 
 
 if __name__ == "__main__":

--- a/tools/license_compliance/tests/test_discovery.py
+++ b/tools/license_compliance/tests/test_discovery.py
@@ -9,7 +9,10 @@ from unittest.mock import patch
 
 from ov_contrib_license.discovery.downloads import extract_downloads
 from ov_contrib_license.discovery.github_actions import extract_action_references
-from ov_contrib_license.discovery.repository import DiscoveryOptions, RepositoryDiscovery
+from ov_contrib_license.discovery.repository import (
+    DiscoveryOptions,
+    RepositoryDiscovery,
+)
 
 
 class DiscoveryTests(unittest.TestCase):
@@ -17,7 +20,9 @@ class DiscoveryTests(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
             manifest = root / "modules" / "sample" / "requirements-test.txt"
-            vendored = root / "modules" / "sample" / "third_party" / "lib" / "source.cpp"
+            vendored = (
+                root / "modules" / "sample" / "third_party" / "lib" / "source.cpp"
+            )
             manifest.parent.mkdir(parents=True)
             vendored.parent.mkdir(parents=True)
             manifest.write_text("example==1.0\n", encoding="utf-8")
@@ -28,7 +33,10 @@ class DiscoveryTests(unittest.TestCase):
         manifests = [item for item in inventory.discoveries if item.kind == "manifest"]
         self.assertEqual(manifests[0].ecosystem, "python")
         self.assertEqual(manifests[0].module, "sample")
-        self.assertIn("local:modules/sample/third_party", {item.id for item in inventory.components})
+        self.assertIn(
+            "local:modules/sample/third_party",
+            {item.id for item in inventory.components},
+        )
 
     def test_foreign_copyright_cluster_is_a_vendored_candidate(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
@@ -43,9 +51,16 @@ class DiscoveryTests(unittest.TestCase):
 
             inventory = RepositoryDiscovery(root).run()
 
-        candidate = next(item for item in inventory.components if item.id == "local:modules/sample/imported")
+        candidate = next(
+            item
+            for item in inventory.components
+            if item.id == "local:modules/sample/imported"
+        )
         self.assertEqual(candidate.relationships[0].value, "VENDORED_SOURCE")
-        self.assertEqual(dict(candidate.evidence[0].details)["heuristic"], "foreign-copyright-cluster")
+        self.assertEqual(
+            dict(candidate.evidence[0].details)["heuristic"],
+            "foreign-copyright-cluster",
+        )
 
     def test_downloads_ignore_comments_and_plain_python_strings(self) -> None:
         shell = """
@@ -85,7 +100,12 @@ class DiscoveryTests(unittest.TestCase):
             path.write_text(workflow, encoding="utf-8")
             inventory = RepositoryDiscovery(root).run()
 
-        self.assertEqual(len([item for item in inventory.discoveries if item.kind == "github-action"]), 4)
+        self.assertEqual(
+            len(
+                [item for item in inventory.discoveries if item.kind == "github-action"]
+            ),
+            4,
+        )
         self.assertEqual(len(inventory.findings), 1)
         self.assertIn("setup-python@v5", inventory.findings[0].message)
 
@@ -102,7 +122,9 @@ class DiscoveryTests(unittest.TestCase):
             ):
                 inventory = RepositoryDiscovery(root).run()
 
-        submodule = next(item for item in inventory.discoveries if item.kind == "git-submodule")
+        submodule = next(
+            item for item in inventory.discoveries if item.kind == "git-submodule"
+        )
         self.assertEqual(submodule.module, "sample")
         self.assertEqual(inventory.components[0].version, "c" * 40)
         self.assertFalse(inventory.findings)
@@ -120,7 +142,9 @@ class DiscoveryTests(unittest.TestCase):
             self._git(root, "add", ".")
             self._git(root, "commit", "-m", "initial")
             base = self._git(root, "rev-parse", "HEAD").strip()
-            (root / "modules" / "a" / "README.md").write_text("change\n", encoding="utf-8")
+            (root / "modules" / "a" / "README.md").write_text(
+                "change\n", encoding="utf-8"
+            )
             self._git(root, "add", ".")
             self._git(root, "commit", "-m", "change a")
             head = self._git(root, "rev-parse", "HEAD").strip()
@@ -151,6 +175,36 @@ class DiscoveryTests(unittest.TestCase):
 
         self.assertFalse(inventory.discoveries)
         self.assertFalse(inventory.components)
+
+    def test_policy_change_triggers_full_repository_discovery(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            manifest = root / "modules" / "a" / "requirements.txt"
+            policy = root / "tools" / "license_compliance" / "policy" / "rules.yml"
+            manifest.parent.mkdir(parents=True)
+            policy.parent.mkdir(parents=True)
+            manifest.write_text("example==1\n", encoding="utf-8")
+            policy.write_text("rules: []\n", encoding="utf-8")
+            self._git(root, "init")
+            self._git(root, "config", "user.email", "tests@example.org")
+            self._git(root, "config", "user.name", "Tests")
+            self._git(root, "add", ".")
+            self._git(root, "commit", "-m", "initial")
+            base = self._git(root, "rev-parse", "HEAD").strip()
+            policy.write_text("rules:\n  - id: changed\n", encoding="utf-8")
+            self._git(root, "add", ".")
+            self._git(root, "commit", "-m", "change policy")
+            head = self._git(root, "rev-parse", "HEAD").strip()
+
+            inventory = RepositoryDiscovery(
+                root,
+                DiscoveryOptions(base_ref=base, head_ref=head),
+            ).run()
+
+        self.assertIn("repository-tooling", inventory.repository.impacted_scopes)
+        self.assertIn(
+            "modules/a/requirements.txt", {item.path for item in inventory.discoveries}
+        )
 
     @staticmethod
     def _git(root: Path, *arguments: str) -> str:

--- a/tools/license_compliance/tests/test_discovery.py
+++ b/tools/license_compliance/tests/test_discovery.py
@@ -38,6 +38,18 @@ class DiscoveryTests(unittest.TestCase):
             {item.id for item in inventory.components},
         )
 
+    def test_virtual_environment_contents_are_ignored(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            vendored = root / "venv" / "lib" / "package" / "vendor" / "source.py"
+            vendored.parent.mkdir(parents=True)
+            vendored.write_text("# installed package\n", encoding="utf-8")
+
+            inventory = RepositoryDiscovery(root).run()
+
+        self.assertFalse(inventory.components)
+        self.assertFalse(inventory.discoveries)
+
     def test_foreign_copyright_cluster_is_a_vendored_candidate(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)

--- a/tools/license_compliance/tests/test_discovery.py
+++ b/tools/license_compliance/tests/test_discovery.py
@@ -1,0 +1,168 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from ov_contrib_license.discovery.downloads import extract_downloads
+from ov_contrib_license.discovery.github_actions import extract_action_references
+from ov_contrib_license.discovery.repository import DiscoveryOptions, RepositoryDiscovery
+
+
+class DiscoveryTests(unittest.TestCase):
+    def test_manifest_ownership_and_vendored_tree(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            manifest = root / "modules" / "sample" / "requirements-test.txt"
+            vendored = root / "modules" / "sample" / "third_party" / "lib" / "source.cpp"
+            manifest.parent.mkdir(parents=True)
+            vendored.parent.mkdir(parents=True)
+            manifest.write_text("example==1.0\n", encoding="utf-8")
+            vendored.write_text("// source\n", encoding="utf-8")
+
+            inventory = RepositoryDiscovery(root).run()
+
+        manifests = [item for item in inventory.discoveries if item.kind == "manifest"]
+        self.assertEqual(manifests[0].ecosystem, "python")
+        self.assertEqual(manifests[0].module, "sample")
+        self.assertIn("local:modules/sample/third_party", {item.id for item in inventory.components})
+
+    def test_foreign_copyright_cluster_is_a_vendored_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            imported = root / "modules" / "sample" / "imported"
+            imported.mkdir(parents=True)
+            for index in range(3):
+                (imported / f"source_{index}.cpp").write_text(
+                    "// Copyright (C) Example Authors\n",
+                    encoding="utf-8",
+                )
+
+            inventory = RepositoryDiscovery(root).run()
+
+        candidate = next(item for item in inventory.components if item.id == "local:modules/sample/imported")
+        self.assertEqual(candidate.relationships[0].value, "VENDORED_SOURCE")
+        self.assertEqual(dict(candidate.evidence[0].details)["heuristic"], "foreign-copyright-cluster")
+
+    def test_downloads_ignore_comments_and_plain_python_strings(self) -> None:
+        shell = """
+        # git clone https://example.invalid/commented
+        git clone https://github.com/example/real.git
+        curl -L https://example.org/archive.tar.gz
+        """
+        python = """
+        import subprocess
+        documentation = "wget https://example.invalid/not-executed"
+        subprocess.run(["pip", "install", "git+https://github.com/example/package.git@abc123"])
+        """
+
+        shell_candidates = extract_downloads(shell)
+        python_candidates = extract_downloads(python, python=True)
+
+        self.assertEqual(len(shell_candidates), 2)
+        self.assertNotIn("commented", " ".join(item.url for item in shell_candidates))
+        self.assertEqual(len(python_candidates), 1)
+        self.assertEqual(python_candidates[0].mechanism, "pip-install")
+
+    def test_action_references_and_pinning_findings(self) -> None:
+        full_sha = "a" * 40
+        workflow = f"""
+        steps:
+          - uses: actions/checkout@{full_sha} # pinned
+          - uses: actions/setup-python@v5
+          - uses: ./local-action
+          - uses: docker://alpine@sha256:{"b" * 64}
+        """
+        self.assertEqual(len(extract_action_references(workflow)), 4)
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            path = root / ".github" / "workflows" / "test.yml"
+            path.parent.mkdir(parents=True)
+            path.write_text(workflow, encoding="utf-8")
+            inventory = RepositoryDiscovery(root).run()
+
+        self.assertEqual(len([item for item in inventory.discoveries if item.kind == "github-action"]), 4)
+        self.assertEqual(len(inventory.findings), 1)
+        self.assertIn("setup-python@v5", inventory.findings[0].message)
+
+    def test_git_submodule_metadata_and_index_revision(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            (root / ".gitmodules").write_text(
+                '[submodule "library"]\npath = modules/sample/vendor/library\nurl = https://example.org/library.git\n',
+                encoding="utf-8",
+            )
+            with patch(
+                "ov_contrib_license.discovery.submodules._index_revision",
+                return_value="c" * 40,
+            ):
+                inventory = RepositoryDiscovery(root).run()
+
+        submodule = next(item for item in inventory.discoveries if item.kind == "git-submodule")
+        self.assertEqual(submodule.module, "sample")
+        self.assertEqual(inventory.components[0].version, "c" * 40)
+        self.assertFalse(inventory.findings)
+
+    def test_incremental_mode_expands_to_module_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            for module in ("a", "b"):
+                path = root / "modules" / module / "requirements.txt"
+                path.parent.mkdir(parents=True)
+                path.write_text("example==1\n", encoding="utf-8")
+            self._git(root, "init")
+            self._git(root, "config", "user.email", "tests@example.org")
+            self._git(root, "config", "user.name", "Tests")
+            self._git(root, "add", ".")
+            self._git(root, "commit", "-m", "initial")
+            base = self._git(root, "rev-parse", "HEAD").strip()
+            (root / "modules" / "a" / "README.md").write_text("change\n", encoding="utf-8")
+            self._git(root, "add", ".")
+            self._git(root, "commit", "-m", "change a")
+            head = self._git(root, "rev-parse", "HEAD").strip()
+
+            inventory = RepositoryDiscovery(
+                root,
+                DiscoveryOptions(base_ref=base, head_ref=head),
+            ).run()
+
+        self.assertEqual(inventory.repository.impacted_scopes, ("module:a",))
+        self.assertEqual({item.module for item in inventory.discoveries}, {"a"})
+
+    def test_incremental_mode_with_no_changes_is_empty(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            (root / "requirements.txt").write_text("example==1\n", encoding="utf-8")
+            self._git(root, "init")
+            self._git(root, "config", "user.email", "tests@example.org")
+            self._git(root, "config", "user.name", "Tests")
+            self._git(root, "add", ".")
+            self._git(root, "commit", "-m", "initial")
+            revision = self._git(root, "rev-parse", "HEAD").strip()
+
+            inventory = RepositoryDiscovery(
+                root,
+                DiscoveryOptions(base_ref=revision, head_ref=revision),
+            ).run()
+
+        self.assertFalse(inventory.discoveries)
+        self.assertFalse(inventory.components)
+
+    @staticmethod
+    def _git(root: Path, *arguments: str) -> str:
+        result = subprocess.run(
+            ["git", "-C", str(root), *arguments],
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+        )
+        return result.stdout
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/license_compliance/tests/test_end_to_end.py
+++ b/tools/license_compliance/tests/test_end_to_end.py
@@ -1,0 +1,115 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from ov_contrib_license.cli import EXIT_POLICY_FAIL, EXIT_SUCCESS, main
+
+FIXTURES = Path(__file__).parent / "fixtures"
+REPOSITORY = FIXTURES / "repository"
+POLICY = Path(__file__).parents[1] / "policy"
+
+
+class EndToEndTests(unittest.TestCase):
+    def test_repository_to_policy_artifact_tpp_and_spdx(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            output = Path(temporary_directory)
+            source_inventory = output / "source.json"
+            source_report = output / "source.md"
+            artifact_inventory = output / "artifact.json"
+            artifact_report = output / "artifact.md"
+            tpp_report = output / "tpp.md"
+            spdx = output / "sbom.spdx.json"
+
+            source_exit = main(
+                [
+                    "check",
+                    str(REPOSITORY),
+                    "--policy-dir",
+                    str(POLICY),
+                    "--ort-result",
+                    str(REPOSITORY / "ort-result.json"),
+                    "--inventory-output",
+                    str(source_inventory),
+                    "--report",
+                    str(source_report),
+                ]
+            )
+            source = json.loads(source_inventory.read_text(encoding="utf-8"))
+            decisions = {
+                item["component_id"]: item["decision"]
+                for item in source["findings"]
+                if item["code"].startswith("POLICY_COMPONENT_")
+            }
+
+            toolchain_exit = main(
+                [
+                    "toolchain",
+                    "check",
+                    str(REPOSITORY),
+                    "--policy-dir",
+                    str(POLICY),
+                    "--report",
+                    str(output / "toolchain.md"),
+                ]
+            )
+            artifact_exit = main(
+                [
+                    "artifact",
+                    "check",
+                    str(output),
+                    "--source-inventory",
+                    str(source_inventory),
+                    "--syft-result",
+                    str(REPOSITORY / "syft-result.json"),
+                    "--policy-dir",
+                    str(POLICY),
+                    "--inventory-output",
+                    str(artifact_inventory),
+                    "--report",
+                    str(artifact_report),
+                ]
+            )
+            tpp_exit = main(
+                [
+                    "tpp",
+                    "check",
+                    str(REPOSITORY),
+                    "--source-inventory",
+                    str(artifact_inventory),
+                    "--policy-dir",
+                    str(POLICY),
+                    "--report",
+                    str(tpp_report),
+                ]
+            )
+            sbom_exit = main(
+                [
+                    "sbom",
+                    str(REPOSITORY),
+                    "--source-inventory",
+                    str(artifact_inventory),
+                    "--output",
+                    str(spdx),
+                ]
+            )
+
+            tpp_text = tpp_report.read_text(encoding="utf-8")
+            spdx_data = json.loads(spdx.read_text(encoding="utf-8"))
+
+        self.assertEqual(source_exit, EXIT_POLICY_FAIL)
+        self.assertEqual(decisions["pkg:github/example/permissive@1.0.0"], "PASS")
+        self.assertEqual(decisions["local:modules/b/vendor"], "FAIL")
+        self.assertEqual(toolchain_exit, EXIT_POLICY_FAIL)
+        self.assertEqual(artifact_exit, EXIT_POLICY_FAIL)
+        self.assertEqual(tpp_exit, EXIT_POLICY_FAIL)
+        self.assertIn("TPP_MISSING_COMPONENT", tpp_text)
+        self.assertEqual(sbom_exit, EXIT_SUCCESS)
+        self.assertEqual(spdx_data["spdxVersion"], "SPDX-2.3")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/license_compliance/tests/test_model_and_reporters.py
+++ b/tools/license_compliance/tests/test_model_and_reporters.py
@@ -23,7 +23,13 @@ class ModelAndReporterTests(unittest.TestCase):
     def test_component_evidence_is_merged_deterministically(self) -> None:
         builder = InventoryBuilder(RepositoryInfo(".", "revision"))
         for path in ("modules/z/CMakeLists.txt", "modules/a/CMakeLists.txt"):
-            evidence = Evidence(EvidenceKind.CMAKE_FIND_PACKAGE, "test", path, "Example", Confidence.MEDIUM)
+            evidence = Evidence(
+                EvidenceKind.CMAKE_FIND_PACKAGE,
+                "test",
+                path,
+                "Example",
+                Confidence.MEDIUM,
+            )
             builder.add_component(
                 Component(
                     id="pkg:generic/example",
@@ -38,7 +44,9 @@ class ModelAndReporterTests(unittest.TestCase):
         component = builder.build().components[0]
 
         self.assertIsNone(component.module)
-        self.assertEqual(component.paths, ("modules/a/CMakeLists.txt", "modules/z/CMakeLists.txt"))
+        self.assertEqual(
+            component.paths, ("modules/a/CMakeLists.txt", "modules/z/CMakeLists.txt")
+        )
         self.assertEqual(dict(component.details)["modules"], "a,z")
 
     def test_fingerprint_ignores_line_metadata_but_not_component(self) -> None:

--- a/tools/license_compliance/tests/test_model_and_reporters.py
+++ b/tools/license_compliance/tests/test_model_and_reporters.py
@@ -1,0 +1,101 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import unittest
+
+from ov_contrib_license.model import (
+    Component,
+    Confidence,
+    Decision,
+    Evidence,
+    EvidenceKind,
+    Finding,
+    InventoryBuilder,
+    Relationship,
+    RepositoryInfo,
+    Severity,
+)
+from ov_contrib_license.reporters import render_inventory
+
+
+class ModelAndReporterTests(unittest.TestCase):
+    def test_component_evidence_is_merged_deterministically(self) -> None:
+        builder = InventoryBuilder(RepositoryInfo(".", "revision"))
+        for path in ("modules/z/CMakeLists.txt", "modules/a/CMakeLists.txt"):
+            evidence = Evidence(EvidenceKind.CMAKE_FIND_PACKAGE, "test", path, "Example", Confidence.MEDIUM)
+            builder.add_component(
+                Component(
+                    id="pkg:generic/example",
+                    name="Example",
+                    module=path.split("/")[1],
+                    paths=(path,),
+                    relationships=(Relationship.UNKNOWN,),
+                    evidence=(evidence,),
+                )
+            )
+
+        component = builder.build().components[0]
+
+        self.assertIsNone(component.module)
+        self.assertEqual(component.paths, ("modules/a/CMakeLists.txt", "modules/z/CMakeLists.txt"))
+        self.assertEqual(dict(component.details)["modules"], "a,z")
+
+    def test_fingerprint_ignores_line_metadata_but_not_component(self) -> None:
+        first = Evidence(
+            EvidenceKind.CMAKE_FETCHCONTENT,
+            "test",
+            "CMakeLists.txt",
+            "example",
+            details=(("line", "10"),),
+        )
+        second = Evidence(
+            EvidenceKind.CMAKE_FETCHCONTENT,
+            "test",
+            "CMakeLists.txt",
+            "example",
+            details=(("line", "20"),),
+        )
+        finding_one = Finding.create(
+            code="TEST",
+            severity=Severity.WARNING,
+            decision=Decision.REVIEW,
+            component_id="pkg:generic/a@1",
+            message="one",
+            evidence=(first,),
+        )
+        finding_two = Finding.create(
+            code="TEST",
+            severity=Severity.WARNING,
+            decision=Decision.REVIEW,
+            component_id="pkg:generic/a@1",
+            message="two",
+            evidence=(second,),
+        )
+        changed_component = Finding.create(
+            code="TEST",
+            severity=Severity.WARNING,
+            decision=Decision.REVIEW,
+            component_id="pkg:generic/a@2",
+            message="one",
+            evidence=(first,),
+        )
+
+        self.assertEqual(finding_one.id, finding_two.id)
+        self.assertNotEqual(finding_one.id, changed_component.id)
+
+    def test_json_and_yaml_are_deterministic(self) -> None:
+        inventory = InventoryBuilder(RepositoryInfo(".", "revision")).build()
+
+        first_json = render_inventory(inventory)
+        second_json = render_inventory(inventory)
+        yaml = render_inventory(inventory, "yaml")
+
+        self.assertEqual(first_json, second_json)
+        self.assertEqual(json.loads(first_json)["schema_version"], 1)
+        self.assertIn("schema_version: 1", yaml)
+        self.assertNotIn("timestamp", first_json)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/license_compliance/tests/test_policy.py
+++ b/tools/license_compliance/tests/test_policy.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime as dt
+import shutil
+import tempfile
 import unittest
 from dataclasses import replace
 from pathlib import Path
@@ -114,17 +116,34 @@ class PolicyTests(unittest.TestCase):
                 )
 
     def test_or_selects_an_allowed_branch_and_and_combines_obligations(self) -> None:
-        permissive_or = self._decision(
-            "MIT OR GPL-3.0-only",
-            Relationship.BUNDLED_BINARY,
-            DistributionStatus.DISTRIBUTED,
-        )[0]
+        builder = InventoryBuilder(RepositoryInfo(".", "revision"))
+        builder.add_component(
+            Component(
+                id="pkg:generic/example@1",
+                name="example",
+                version="1",
+                module="sample",
+                declared_license="MIT OR GPL-3.0-only",
+                relationships=(Relationship.BUNDLED_BINARY,),
+                distribution=DistributionStatus.DISTRIBUTED,
+            )
+        )
+        permissive_summary = evaluate_inventory(builder.build(), self.config)
+        permissive_finding = next(
+            item
+            for item in permissive_summary.inventory.findings
+            if item.code == "POLICY_COMPONENT_PASS"
+        )
         combined_and = self._decision(
             "MIT AND GPL-3.0-only",
             Relationship.BUNDLED_BINARY,
             DistributionStatus.DISTRIBUTED,
         )[0]
-        self.assertEqual(permissive_or, Decision.PASS)
+        self.assertEqual(permissive_finding.decision, Decision.PASS)
+        self.assertIn("rule=LIC-PERMISSIVE-001", permissive_finding.message)
+        self.assertNotIn(
+            "LIC-STRONG-COPYLEFT-DISTRIBUTED-001", permissive_finding.message
+        )
         self.assertEqual(combined_and, Decision.FAIL)
 
     def test_expired_exception_is_a_failure(self) -> None:
@@ -158,6 +177,114 @@ class PolicyTests(unittest.TestCase):
         )
         self.assertEqual(summary.fail_count, 1)
 
+    def test_exact_exception_applies_but_relationship_mismatch_does_not(self) -> None:
+        exception = ExceptionRule(
+            id="TEST-EXCEPTION",
+            component="pkg:generic/example@1",
+            module="sample",
+            relationships=(Relationship.BUILD_TOOL,),
+            distributions=(DistributionStatus.DISTRIBUTED,),
+            rationale="fixture",
+            approved_by=("legal",),
+            expires=dt.date(2027, 1, 1),
+        )
+        self.config = replace(self.config, exceptions=(exception,))
+        allowed = self._decision(
+            "GPL-3.0-only",
+            Relationship.BUILD_TOOL,
+            DistributionStatus.DISTRIBUTED,
+        )[0]
+
+        builder = InventoryBuilder(RepositoryInfo(".", "revision"))
+        builder.add_component(
+            Component(
+                id=exception.component,
+                name="example",
+                version="1",
+                module="sample",
+                declared_license="GPL-3.0-only",
+                relationships=(Relationship.STATIC_LINK,),
+                distribution=DistributionStatus.DISTRIBUTED,
+            )
+        )
+        mismatch = evaluate_inventory(
+            builder.build(), self.config, today=dt.date(2026, 1, 1)
+        )
+
+        self.assertEqual(allowed, Decision.PASS)
+        self.assertIn(
+            "POLICY_EXCEPTION_RELATIONSHIP_MISMATCH",
+            {item.code for item in mismatch.inventory.findings},
+        )
+        self.assertEqual(mismatch.fail_count, 1)
+
+    def test_exception_version_mismatch_is_explicit(self) -> None:
+        exception = ExceptionRule(
+            id="TEST-EXCEPTION",
+            component="pkg:generic/example@1",
+            module="sample",
+            relationships=(Relationship.HEADER_ONLY,),
+            distributions=(DistributionStatus.DISTRIBUTED,),
+            rationale="fixture",
+            approved_by=("legal",),
+            expires=dt.date(2027, 1, 1),
+        )
+        config = replace(self.config, exceptions=(exception,))
+        builder = InventoryBuilder(RepositoryInfo(".", "revision"))
+        builder.add_component(
+            Component(
+                id="pkg:generic/example@2",
+                name="example",
+                version="2",
+                module="sample",
+                declared_license="MIT",
+                relationships=(Relationship.HEADER_ONLY,),
+                distribution=DistributionStatus.DISTRIBUTED,
+            )
+        )
+        summary = evaluate_inventory(builder.build(), config, today=dt.date(2026, 1, 1))
+
+        self.assertIn(
+            "POLICY_EXCEPTION_VERSION_MISMATCH",
+            {item.code for item in summary.inventory.findings},
+        )
+        self.assertEqual(summary.review_count, 1)
+
+    def test_exception_module_mismatch_and_unused_exception_are_explicit(self) -> None:
+        mismatch = ExceptionRule(
+            id="MODULE-EXCEPTION",
+            component="pkg:generic/example@1",
+            module="different-module",
+            relationships=(Relationship.HEADER_ONLY,),
+            distributions=(DistributionStatus.DISTRIBUTED,),
+            rationale="fixture",
+            approved_by=("legal",),
+            expires=dt.date(2027, 1, 1),
+        )
+        unused = replace(
+            mismatch,
+            id="UNUSED-EXCEPTION",
+            component="pkg:generic/not-present@1",
+        )
+        config = replace(self.config, exceptions=(mismatch, unused))
+        builder = InventoryBuilder(RepositoryInfo(".", "revision"))
+        builder.add_component(
+            Component(
+                id="pkg:generic/example@1",
+                name="example",
+                version="1",
+                module="sample",
+                declared_license="MIT",
+                relationships=(Relationship.HEADER_ONLY,),
+                distribution=DistributionStatus.DISTRIBUTED,
+            )
+        )
+        summary = evaluate_inventory(builder.build(), config, today=dt.date(2026, 1, 1))
+        codes = {item.code for item in summary.inventory.findings}
+
+        self.assertIn("POLICY_EXCEPTION_MODULE_MISMATCH", codes)
+        self.assertIn("POLICY_EXCEPTION_UNUSED", codes)
+
     def test_exact_baseline_does_not_suppress_changed_version(self) -> None:
         _, fingerprint, _ = self._decision(
             None,
@@ -182,6 +309,57 @@ class PolicyTests(unittest.TestCase):
                 component_id="pkg:generic/example@2",
             )[2]
         )
+
+    def test_exact_baseline_does_not_suppress_changed_relationship(self) -> None:
+        _, fingerprint, _ = self._decision(
+            None,
+            Relationship.BUNDLED_BINARY,
+            DistributionStatus.DISTRIBUTED,
+        )
+        self.config = replace(
+            self.config,
+            baseline=(BaselineEntry(fingerprint, "existing-before-enforcement"),),
+        )
+
+        self.assertFalse(
+            self._decision(
+                None,
+                Relationship.VENDORED_SOURCE,
+                DistributionStatus.DISTRIBUTED,
+            )[2]
+        )
+
+    def test_invalid_exception_configuration_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            policy = Path(temporary_directory) / "policy"
+            shutil.copytree(POLICY, policy)
+            (policy / "exceptions.yml").write_text(
+                "exceptions:\n  - id: BROAD\n    component: pkg:generic/example\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(ValueError):
+                load_policy(policy)
+
+    def test_invalid_baseline_and_toolchain_configuration_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            policy = Path(temporary_directory) / "policy"
+            shutil.copytree(POLICY, policy)
+            (policy / "baseline.yml").write_text(
+                "baseline:\n  - finding_fingerprint: sha256:not-a-digest\n"
+                "    reason: fixture\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(ValueError):
+                load_policy(policy)
+
+            shutil.copy(POLICY / "baseline.yml", policy / "baseline.yml")
+            (policy / "toolchain.yml").write_text(
+                "require_full_sha_for_github_actions: 'false'\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(ValueError):
+                load_policy(policy)
 
 
 if __name__ == "__main__":

--- a/tools/license_compliance/tests/test_policy.py
+++ b/tools/license_compliance/tests/test_policy.py
@@ -1,0 +1,188 @@
+# Copyright (C) 2018-2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import datetime as dt
+import unittest
+from dataclasses import replace
+from pathlib import Path
+
+from ov_contrib_license.model import (
+    Component,
+    Decision,
+    DistributionStatus,
+    InventoryBuilder,
+    Relationship,
+    RepositoryInfo,
+)
+from ov_contrib_license.policy import (
+    BaselineEntry,
+    ExceptionRule,
+    evaluate_inventory,
+    load_policy,
+)
+from ov_contrib_license.policy.expressions import ExpressionError, normalize_expression
+
+POLICY = Path(__file__).parents[1] / "policy"
+
+
+class ExpressionTests(unittest.TestCase):
+    def test_normalizes_nested_spdx_without_flattening_or(self) -> None:
+        self.assertEqual(
+            normalize_expression("MIT OR (Apache-2.0 AND BSD-3-Clause)"),
+            "MIT OR Apache-2.0 AND BSD-3-Clause",
+        )
+        self.assertEqual(
+            normalize_expression("GPL-2.0-only WITH Classpath-exception-2.0"),
+            "GPL-2.0-only WITH Classpath-exception-2.0",
+        )
+
+    def test_invalid_expression_is_rejected(self) -> None:
+        with self.assertRaises(ExpressionError):
+            normalize_expression("MIT OR")
+
+
+class PolicyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.config = load_policy(POLICY)
+
+    def _decision(
+        self,
+        license_expression: str | None,
+        relationship: Relationship,
+        distribution: DistributionStatus,
+        *,
+        component_id: str = "pkg:generic/example@1",
+    ) -> tuple[Decision, str, bool]:
+        builder = InventoryBuilder(RepositoryInfo(".", "revision"))
+        builder.add_component(
+            Component(
+                id=component_id,
+                name="example",
+                version="1",
+                module="sample",
+                declared_license=license_expression,
+                relationships=(relationship,),
+                distribution=distribution,
+            )
+        )
+        summary = evaluate_inventory(builder.build(), self.config)
+        finding = next(
+            item
+            for item in summary.inventory.findings
+            if item.code.startswith("POLICY_")
+        )
+        return finding.decision, finding.id, finding.suppressed
+
+    def test_policy_table(self) -> None:
+        cases = (
+            (
+                "MIT",
+                Relationship.HEADER_ONLY,
+                DistributionStatus.DISTRIBUTED,
+                Decision.PASS,
+            ),
+            (
+                "GPL-3.0-only",
+                Relationship.STATIC_LINK,
+                DistributionStatus.DISTRIBUTED,
+                Decision.FAIL,
+            ),
+            (
+                "GPL-3.0-only",
+                Relationship.BUILD_TOOL,
+                DistributionStatus.NOT_DISTRIBUTED,
+                Decision.PASS,
+            ),
+            (
+                "LGPL-3.0-only",
+                Relationship.DYNAMIC_LINK,
+                DistributionStatus.DISTRIBUTED,
+                Decision.REVIEW,
+            ),
+            (
+                None,
+                Relationship.BUNDLED_BINARY,
+                DistributionStatus.DISTRIBUTED,
+                Decision.FAIL,
+            ),
+        )
+        for license_expression, relationship, distribution, expected in cases:
+            with self.subTest(license=license_expression, relationship=relationship):
+                self.assertEqual(
+                    self._decision(license_expression, relationship, distribution)[0],
+                    expected,
+                )
+
+    def test_or_selects_an_allowed_branch_and_and_combines_obligations(self) -> None:
+        permissive_or = self._decision(
+            "MIT OR GPL-3.0-only",
+            Relationship.BUNDLED_BINARY,
+            DistributionStatus.DISTRIBUTED,
+        )[0]
+        combined_and = self._decision(
+            "MIT AND GPL-3.0-only",
+            Relationship.BUNDLED_BINARY,
+            DistributionStatus.DISTRIBUTED,
+        )[0]
+        self.assertEqual(permissive_or, Decision.PASS)
+        self.assertEqual(combined_and, Decision.FAIL)
+
+    def test_expired_exception_is_a_failure(self) -> None:
+        exception = ExceptionRule(
+            id="TEST-EXCEPTION",
+            component="pkg:generic/example@1",
+            module="sample",
+            relationships=(Relationship.STATIC_LINK,),
+            distributions=(DistributionStatus.DISTRIBUTED,),
+            rationale="fixture",
+            approved_by=("legal",),
+            expires=dt.date(2024, 1, 1),
+        )
+        config = replace(self.config, exceptions=(exception,))
+        builder = InventoryBuilder(RepositoryInfo(".", "revision"))
+        builder.add_component(
+            Component(
+                id=exception.component,
+                name="example",
+                version="1",
+                module="sample",
+                declared_license="GPL-3.0-only",
+                relationships=(Relationship.STATIC_LINK,),
+                distribution=DistributionStatus.DISTRIBUTED,
+            )
+        )
+        summary = evaluate_inventory(builder.build(), config, today=dt.date(2026, 1, 1))
+        self.assertIn(
+            "POLICY_EXCEPTION_EXPIRED",
+            {item.code for item in summary.inventory.findings},
+        )
+        self.assertEqual(summary.fail_count, 1)
+
+    def test_exact_baseline_does_not_suppress_changed_version(self) -> None:
+        _, fingerprint, _ = self._decision(
+            None,
+            Relationship.BUNDLED_BINARY,
+            DistributionStatus.DISTRIBUTED,
+        )
+        config = replace(
+            self.config,
+            baseline=(BaselineEntry(fingerprint, "existing-before-enforcement"),),
+        )
+        self.config = config
+        self.assertTrue(
+            self._decision(
+                None, Relationship.BUNDLED_BINARY, DistributionStatus.DISTRIBUTED
+            )[2]
+        )
+        self.assertFalse(
+            self._decision(
+                None,
+                Relationship.BUNDLED_BINARY,
+                DistributionStatus.DISTRIBUTED,
+                component_id="pkg:generic/example@2",
+            )[2]
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add an autonomous `tools/license_compliance` control plane for repository discovery and canonical inventory
- import FOSS evidence from ORT and License Eye result contracts, and scan explicit artifacts with Syft
- evaluate SPDX expressions against version-controlled, relationship/distribution-aware policy
- support exact expiring exceptions, exact-fingerprint baseline suppression, obligations, and `PASS` / `REVIEW` / `FAIL`
- reconcile `third-party-programs.txt`, generate deterministic SPDX 2.3 JSON, and compare source inventory with built artifacts
- provide `inventory`, `check`, `explain`, `tpp`, `sbom`, `artifact`, and `toolchain` commands
- add a thin GitHub workflow that runs in an isolated venv, publishes step summaries, and uploads evidence artifacts

## Rollout behavior

The workflow starts in Stage B: unsuppressed `FAIL` findings block the PR, while insufficient evidence remains visible as `REVIEW`. Six existing vendored-source candidates are suppressed by exact fingerprints only. A new component, version, relationship, distribution state, module, or rule does not inherit that baseline.

Policy or TPP changes trigger a full reevaluation. Ordinary PR changes expand to the affected module/repository ownership boundary.

## Boundaries

- no proprietary scanner, SaaS decision backend, or OpenVINO licensing infrastructure
- no OpenVINO build/runtime dependency and no implicit OpenVINO build
- ORT and License Eye consume saved results; optional provider binaries are not downloaded by the package
- Syft runs only for an explicitly supplied artifact/install tree, or consumes saved Syft JSON
- `tpp generate` is preview-only and never edits the authoritative notice file
- policy configuration is project input, not a universal legal conclusion

## Validation

- 42 offline unit/contract/end-to-end tests passed
- clean wheel install and all commands passed in isolated Python 3.10 and Python 3.12 venvs
- Ruff lint and formatting passed
- License Eye checked 2068 files with 0 invalid headers
- actionlint passed for the new workflow
- exact `openvinotoolkit/openvino_contrib:master` (`bc7c53c5`) audit passed: 75 components, 199 discovery records, 0 active FAIL, 69 REVIEW, 6 exact baseline suppressions
- full PR-tree audit passed with 75 components and 202 discovery records
- JSON inventory validated against the committed schema
- toolchain audit: 0 FAIL and 2 REVIEW requiring maintainer follow-up
